### PR TITLE
CMake 4.0 update

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Require minimum CMAKE version
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.10)
 
 # Minimum version is 2.8.4 due to Cygwin warning:
 


### PR DESCRIPTION
Latest CMake is issuing an error on minimum version 3.5. The minimum supported with latest CMake is 3.10