### PR TITLE
FIX: codeql rc4

### DIFF
--- a/src/vanillapdf/syntax/utils/encryption.cpp
+++ b/src/vanillapdf/syntax/utils/encryption.cpp
@@ -26,6 +26,8 @@
 
 #endif
 
+// codeql[cpp/weak-cryptographic-algorithm] reason: RC4 use is confined to a well-audited legacy compatibility function
+
 namespace vanillapdf {
 namespace syntax {
 


### PR DESCRIPTION
The project is using RC4 as this is required by the PDF specification, however it is a weak cipher and we need to disable the checks in specific places.