### PR TITLE
FIX: CodeQL rules

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,13 +1,13 @@
 name: "Vanilla.PDF CodeQL Config"
 
-excludes:
+query-filters:
 
   # We are using RC4 function for PDF level encryption required by the standard
   # CodeQL does issue a warning for this usage, however we have to support this.
   # There is a project, that can delete the warnings in the post-process it's not very clean.
   # https://github.com/advanced-security/dismiss-alerts
   # I prefer to disable this rule for the time being.
-  - rules:
-      - cpp/weak-cryptographic-algorithm
+  - exclude:
+      id: cpp/weak-cryptographic-algorithm
     paths:
       - src/vanillapdf/syntax/utils/encryption.cpp

--- a/.github/codeql/codeql.yml
+++ b/.github/codeql/codeql.yml
@@ -1,0 +1,13 @@
+name: "Vanilla.PDF CodeQL Config"
+
+excludes:
+
+  # We are using RC4 function for PDF level encryption required by the standard
+  # CodeQL does issue a warning for this usage, however we have to support this.
+  # There is a project, that can delete the warnings in the post-process it's not very clean.
+  # https://github.com/advanced-security/dismiss-alerts
+  # I prefer to disable this rule for the time being.
+  - rules:
+      - cpp/weak-cryptographic-algorithm
+    paths:
+      - src/vanillapdf/syntax/utils/encryption.cpp

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -75,6 +75,8 @@ jobs:
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
+        config-file: ./.github/codeql/codeql-config.yml
+
         # If you wish to specify custom queries, you can do so here or in a config file.
         # By default, queries listed here will override any specified in a config file.
         # Prefix the list here with "+" to use these queries and those in the config file.

--- a/src/vanillapdf/syntax/utils/encryption.cpp
+++ b/src/vanillapdf/syntax/utils/encryption.cpp
@@ -26,8 +26,6 @@
 
 #endif
 
-// codeql[cpp/weak-cryptographic-algorithm] reason: RC4 use is confined to a well-audited legacy compatibility function
-
 namespace vanillapdf {
 namespace syntax {
 


### PR DESCRIPTION
We do have a warning about weak-cryptographic-algorithm, which we need to suppress.
RC4 algorithm has to be supported, even though it's considered weak.