### PR TITLE
TWEAK: Update compiler flag config

### DIFF
--- a/cmake/compiler_checks.cmake
+++ b/cmake/compiler_checks.cmake
@@ -2,7 +2,7 @@
 
 include(CheckCXXSourceCompiles)
 
-macro(vanillapdf_check_standard_features TARGET)
+function(vanillapdf_check_standard_features TARGET)
     # Check std::from_chars for float/double
     set(_check_from_chars_float "
         #include <charconv>
@@ -19,4 +19,4 @@ macro(vanillapdf_check_standard_features TARGET)
     endif()
 
     # Add more checks here as needed...
-endmacro()
+endfunction()

--- a/cmake/compiler_flags.cmake
+++ b/cmake/compiler_flags.cmake
@@ -1,59 +1,23 @@
-# Set additional compiler flags
-
-# Local compilation definitions
-set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -DDEBUG")
-set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -DDEBUG")
-
-set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -DRELEASE")
-set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -DRELEASE")
-
-set(CMAKE_C_FLAGS_MINSIZEREL "${CMAKE_C_FLAGS_MINSIZEREL} -DRELEASE")
-set(CMAKE_CXX_FLAGS_MINSIZEREL "${CMAKE_CXX_FLAGS_MINSIZEREL} -DRELEASE")
-
-set(CMAKE_C_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS_RELWITHDEBINFO} -DRELEASE")
-set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} -DRELEASE")
-
-if(CMAKE_COMPILER_IS_GNUCXX)
-
-    # Enable maximum warning level
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra")
-    
-    # GCC warns on pragma region directive, which is only IDE feature
-    # It could be solved with #ifdef only for MSVC
-    # All other pragmas are only for suppressing specific warnings on MSVC
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-unknown-pragmas")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unknown-pragmas")
-    
-    # Variables in constructors should be initialized in order
-    # they were declared. I prefer initializing variables
-    # in order they make sense and are declared as constructor parameters.
-    # This should be harmless unless you take at least a little care.
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-reorder")
-
-    # On Linux arm GCC the entire log is filled with notes:
-
-    # parameter passing for argument of type 'std::_Rb_tree<vanillapdf::syntax::IndirectReferenceObject,
-    # std::pair<const vanillapdf::syntax::IndirectReferenceObject, bool>,
-    # std::_Select1st<std::pair<const vanillapdf::syntax::IndirectReferenceObject, bool> >,
-    # std::less<vanillapdf::syntax::IndirectReferenceObject>,
-    # std::allocator<std::pair<const vanillapdf::syntax::IndirectReferenceObject, bool> > >::const_iterator' changed in GCC 7.1
-
-    # That warning is telling you that there was a subtle ABI change
-    # (actually a conformance fix) between 6 and 7.1,
-    # such that libraries built with 6.x or earlier may not work properly when called
-    # from code built with 7.x (and vice-versa).
-    # As long as all your C++ code is built with GCC 7.1 or later, you can safely ignore this warning.
-    # To disable it, pass -Wno-psabi to the compiler.
-    # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=77728
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-psabi")
-
-    # There are quite some parameters defined in functions, however they are not used.
-    # I do not really consider this an issue, as even having the name of the parameter gives you some insights.
-    # Having just the type even if it is currently not used is not a bug for me.
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-parameter")
-
-endif(CMAKE_COMPILER_IS_GNUCXX)
+# =====================================================================================
+# \file compiler_flags.cmake
+# \brief Compiler configuration defaults for Vanilla.PDF
+#
+# This file configures optimal compilation behavior for Vanilla.PDF across supported
+# platforms and compilers. It avoids global flag pollution by applying settings
+# per-target through `vanillapdf_target_compile_defaults()`.
+#
+# Features:
+# - Applies DEBUG/RELEASE macros based on build configuration.
+# - Enables `/WX` or `-Werror` to treat warnings as errors (except in Release).
+# - Enables strict warning levels for GCC/Clang.
+# - Disables known noisy or non-critical warnings for improved developer ergonomics.
+# - Configures MSVC CRT linkage via `CMAKE_MSVC_RUNTIME_LIBRARY`.
+#
+# To apply these defaults:
+#   vanillapdf_target_compile_defaults(<target>)
+#
+# This module should be included after target creation.
+# =====================================================================================
 
 if(MSVC)
 
@@ -68,3 +32,72 @@ if(MSVC)
         endif()
     endif()
 endif()
+
+# Utility functions that change the options on per-targer basis
+
+function(vanillapdf_target_compile_defaults TARGET)
+
+    # Define config-specific macros
+    target_compile_definitions(${TARGET} PRIVATE
+        $<$<CONFIG:Debug>:DEBUG>
+        $<$<OR:$<CONFIG:Release>,$<CONFIG:RelWithDebInfo>,$<CONFIG:MinSizeRel>>:RELEASE>
+    )
+
+    # Enable warning as errors, so we catch whatever possible before public release
+    target_compile_options(${TARGET} PRIVATE
+        # MSVC: apply /WX for Debug and RelWithDebInfo
+        $<$<AND:$<CXX_COMPILER_ID:MSVC>,$<CONFIG:Debug>>:/WX>
+        $<$<AND:$<CXX_COMPILER_ID:MSVC>,$<CONFIG:RelWithDebInfo>>:/WX>
+        $<$<AND:$<C_COMPILER_ID:MSVC>,$<CONFIG:Debug>>:/WX>
+        $<$<AND:$<C_COMPILER_ID:MSVC>,$<CONFIG:RelWithDebInfo>>:/WX>
+
+        # GCC/Clang: apply -Werror for all non-Release builds
+        $<$<AND:$<CXX_COMPILER_ID:GNU>,$<NOT:$<CONFIG:Release>>>:-Werror>
+        $<$<AND:$<C_COMPILER_ID:GNU>,$<NOT:$<CONFIG:Release>>>:-Werror>
+        $<$<AND:$<CXX_COMPILER_ID:Clang>,$<NOT:$<CONFIG:Release>>>:-Werror>
+        $<$<AND:$<C_COMPILER_ID:Clang>,$<NOT:$<CONFIG:Release>>>:-Werror>
+    )
+
+    # GCC/Clang warnings
+    if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+        target_compile_options(${TARGET} PRIVATE
+
+            # Enable maximum warning level
+            -Wall
+            -Wextra
+
+            # GCC warns on pragma region directive, which is only IDE feature
+            # It could be solved with #ifdef only for MSVC
+            # All other pragmas are only for suppressing specific warnings on MSVC
+            -Wno-unknown-pragmas
+
+            # Variables in constructors should be initialized in order
+            # they were declared. I prefer initializing variables
+            # in order they make sense and are declared as constructor parameters.
+            # This should be harmless unless you take at least a little care.
+            -Wno-reorder
+
+            # On Linux arm GCC the entire log is filled with notes:
+
+            # parameter passing for argument of type 'std::_Rb_tree<vanillapdf::syntax::IndirectReferenceObject,
+            # std::pair<const vanillapdf::syntax::IndirectReferenceObject, bool>,
+            # std::_Select1st<std::pair<const vanillapdf::syntax::IndirectReferenceObject, bool> >,
+            # std::less<vanillapdf::syntax::IndirectReferenceObject>,
+            # std::allocator<std::pair<const vanillapdf::syntax::IndirectReferenceObject, bool> > >::const_iterator' changed in GCC 7.1
+
+            # That warning is telling you that there was a subtle ABI change
+            # (actually a conformance fix) between 6 and 7.1,
+            # such that libraries built with 6.x or earlier may not work properly when called
+            # from code built with 7.x (and vice-versa).
+            # As long as all your C++ code is built with GCC 7.1 or later, you can safely ignore this warning.
+            # To disable it, pass -Wno-psabi to the compiler.
+            # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=77728
+            -Wno-psabi
+
+            # There are quite some parameters defined in functions, however they are not used.
+            # I do not really consider this an issue, as even having the name of the parameter gives you some insights.
+            # Having just the type even if it is currently not used is not a bug for me.
+            -Wno-unused-parameter
+        )
+    endif()
+endfunction()

--- a/cmake/compiler_flags.cmake
+++ b/cmake/compiler_flags.cmake
@@ -43,23 +43,27 @@ function(vanillapdf_target_compile_defaults TARGET)
         $<$<OR:$<CONFIG:Release>,$<CONFIG:RelWithDebInfo>,$<CONFIG:MinSizeRel>>:RELEASE>
     )
 
-    # Enable warning as errors, so we catch whatever possible before public release
-    target_compile_options(${TARGET} PRIVATE
-        # MSVC: apply /WX for Debug and RelWithDebInfo
-        $<$<AND:$<CXX_COMPILER_ID:MSVC>,$<CONFIG:Debug>>:/WX>
-        $<$<AND:$<CXX_COMPILER_ID:MSVC>,$<CONFIG:RelWithDebInfo>>:/WX>
-        $<$<AND:$<C_COMPILER_ID:MSVC>,$<CONFIG:Debug>>:/WX>
-        $<$<AND:$<C_COMPILER_ID:MSVC>,$<CONFIG:RelWithDebInfo>>:/WX>
+    # Warnings as errors for MSVC
+    if(CMAKE_C_COMPILER_ID MATCHES "MSVC" OR CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
+        target_compile_options(${TARGET} PRIVATE
+            # MSVC: apply /WX for Debug and RelWithDebInfo
+            $<$<CONFIG:Debug>:/WX>
+            $<$<CONFIG:RelWithDebInfo>:/WX>
+        )
+    endif()
 
-        # GCC/Clang: apply -Werror for all non-Release builds
-        $<$<AND:$<CXX_COMPILER_ID:GNU>,$<NOT:$<CONFIG:Release>>>:-Werror>
-        $<$<AND:$<C_COMPILER_ID:GNU>,$<NOT:$<CONFIG:Release>>>:-Werror>
-        $<$<AND:$<CXX_COMPILER_ID:Clang>,$<NOT:$<CONFIG:Release>>>:-Werror>
-        $<$<AND:$<C_COMPILER_ID:Clang>,$<NOT:$<CONFIG:Release>>>:-Werror>
-    )
+    # Warnings as errors for GCC, Clang, AppleClang (C and C++)
+    if(CMAKE_C_COMPILER_ID MATCHES "GNU|Clang|AppleClang" OR CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang|AppleClang")
+        target_compile_options(${TARGET} PRIVATE
+            $<$<CONFIG:Debug>:-Werror>
+            $<$<CONFIG:RelWithDebInfo>:-Werror>
+        )
+    endif()
 
     # GCC/Clang warnings
     if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+
+        # Apply to both C and C++
         target_compile_options(${TARGET} PRIVATE
 
             # Enable maximum warning level
@@ -70,12 +74,6 @@ function(vanillapdf_target_compile_defaults TARGET)
             # It could be solved with #ifdef only for MSVC
             # All other pragmas are only for suppressing specific warnings on MSVC
             -Wno-unknown-pragmas
-
-            # Variables in constructors should be initialized in order
-            # they were declared. I prefer initializing variables
-            # in order they make sense and are declared as constructor parameters.
-            # This should be harmless unless you take at least a little care.
-            -Wno-reorder
 
             # On Linux arm GCC the entire log is filled with notes:
 
@@ -98,6 +96,16 @@ function(vanillapdf_target_compile_defaults TARGET)
             # I do not really consider this an issue, as even having the name of the parameter gives you some insights.
             # Having just the type even if it is currently not used is not a bug for me.
             -Wno-unused-parameter
+        )
+
+        # Apply only to C++
+        target_compile_options(${TARGET} PRIVATE
+
+            # Variables in constructors should be initialized in order
+            # they were declared. I prefer initializing variables
+            # in order they make sense and are declared as constructor parameters.
+            # This should be harmless unless you take at least a little care.
+            $<$<COMPILE_LANGUAGE:CXX>:-Wno-reorder>
         )
     endif()
 endfunction()

--- a/include/vanillapdf/utils/c_memory_buffer_output_stream.h
+++ b/include/vanillapdf/utils/c_memory_buffer_output_stream.h
@@ -62,6 +62,11 @@ extern "C"
     VANILLAPDF_API error_type CALLING_CONVENTION MemoryBufferOutputStream_WriteBuffer(MemoryBufferOutputStreamHandle* handle, BufferHandle* data);
 
     /**
+    * \brief Appends buffer data to current output stream instance up to length specified
+    */
+    VANILLAPDF_API error_type CALLING_CONVENTION MemoryBufferOutputStream_WriteBufferRange(MemoryBufferOutputStreamHandle* handle, BufferHandle* data, offset_type length);
+
+    /**
     * \brief Flushes all pending data from the stream to it's destination
     */
     VANILLAPDF_API error_type CALLING_CONVENTION MemoryBufferOutputStream_Flush(MemoryBufferOutputStreamHandle* handle);

--- a/src/vanillapdf.benchmark/CMakeLists.txt
+++ b/src/vanillapdf.benchmark/CMakeLists.txt
@@ -37,6 +37,9 @@ add_executable(vanillapdf.benchmark
     ${VANILLAPDF_BENCHMARK_RESOURCE_FILES}
 )
 
+# Configure default compilation parameters, strict warnings, config based definition for DEBUG/RELEASE, etc.
+vanillapdf_target_compile_defaults(vanillapdf.benchmark)
+
 if(WIN32)
     # Copy DLL dependencies on windows to our build directory
     add_custom_command(

--- a/src/vanillapdf.test/CMakeLists.txt
+++ b/src/vanillapdf.test/CMakeLists.txt
@@ -44,6 +44,9 @@ add_executable(vanillapdf.test
     ${VANILLAPDF_TEST_RESOURCE_FILES}
 )
 
+# Configure default compilation parameters, strict warnings, config based definition for DEBUG/RELEASE, etc.
+vanillapdf_target_compile_defaults(vanillapdf.test)
+
 if(WIN32)
     # Copy DLL dependencies on windows to our build directory
     add_custom_command(

--- a/src/vanillapdf.tools/CMakeLists.txt
+++ b/src/vanillapdf.tools/CMakeLists.txt
@@ -49,6 +49,9 @@ add_executable(vanillapdf.tools
     ${VANILLAPDF_TOOLS_RESOURCE_FILES}
 )
 
+# Configure default compilation parameters, strict warnings, config based definition for DEBUG/RELEASE, etc.
+vanillapdf_target_compile_defaults(vanillapdf.tools)
+
 if(WIN32)
 
     # Copy DLL dependencies on windows to our build directory

--- a/src/vanillapdf.unittest/CMakeLists.txt
+++ b/src/vanillapdf.unittest/CMakeLists.txt
@@ -42,6 +42,9 @@ add_executable(vanillapdf.unittest
     ${VANILLAPDF_UNITTEST_RESOURCE_FILES}
 )
 
+# Configure default compilation parameters, strict warnings, config based definition for DEBUG/RELEASE, etc.
+vanillapdf_target_compile_defaults(vanillapdf.unittest)
+
 if(WIN32)
     # Copy DLL dependencies on windows to our build directory
     add_custom_command(

--- a/src/vanillapdf.unittest/main.cpp
+++ b/src/vanillapdf.unittest/main.cpp
@@ -197,16 +197,49 @@ TEST(MemoryBufferOutputStream, WriteBuffer) {
 
     const char TEST_DATA[] = "TEST_DATA\x01\x02\xFF";
 
+    offset_type stream_position = 0;
     BufferHandle* buffer_ptr = nullptr;
     MemoryBufferOutputStreamHandle* stream_ptr = nullptr;
 
     ASSERT_EQ(MemoryBufferOutputStream_Create(&stream_ptr), VANILLAPDF_ERROR_SUCCESS);
     ASSERT_NE(stream_ptr, nullptr);
 
-    ASSERT_EQ(Buffer_CreateFromData(TEST_DATA, sizeof(TEST_DATA), &buffer_ptr), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Buffer_CreateFromData(TEST_DATA, strlen(TEST_DATA), &buffer_ptr), VANILLAPDF_ERROR_SUCCESS);
     ASSERT_NE(buffer_ptr, nullptr);
 
     EXPECT_EQ(MemoryBufferOutputStream_WriteBuffer(stream_ptr, buffer_ptr), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(MemoryBufferOutputStream_GetOutputPosition(stream_ptr, &stream_position), VANILLAPDF_ERROR_SUCCESS);
+    EXPECT_EQ(stream_position, strlen(TEST_DATA));
+
+    ASSERT_EQ(Buffer_Release(buffer_ptr), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(MemoryBufferOutputStream_Release(stream_ptr), VANILLAPDF_ERROR_SUCCESS);
+}
+
+TEST(MemoryBufferOutputStream, WriteBufferLength) {
+
+    const char TEST_DATA[] = "TEST_DATA\x01\x02\xFF";
+
+    offset_type stream_position = 0;
+    BufferHandle* buffer_ptr = nullptr;
+    MemoryBufferOutputStreamHandle* stream_ptr = nullptr;
+
+    ASSERT_EQ(MemoryBufferOutputStream_Create(&stream_ptr), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_NE(stream_ptr, nullptr);
+
+    ASSERT_EQ(Buffer_CreateFromData(TEST_DATA, strlen(TEST_DATA), &buffer_ptr), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_NE(buffer_ptr, nullptr);
+
+    EXPECT_EQ(MemoryBufferOutputStream_WriteBufferRange(stream_ptr, buffer_ptr, 0), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(MemoryBufferOutputStream_GetOutputPosition(stream_ptr, &stream_position), VANILLAPDF_ERROR_SUCCESS);
+    EXPECT_EQ(stream_position, 0);
+
+    EXPECT_EQ(MemoryBufferOutputStream_WriteBufferRange(stream_ptr, buffer_ptr, 2), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(MemoryBufferOutputStream_GetOutputPosition(stream_ptr, &stream_position), VANILLAPDF_ERROR_SUCCESS);
+    EXPECT_EQ(stream_position, 2);
+
+    EXPECT_EQ(MemoryBufferOutputStream_WriteBufferRange(stream_ptr, buffer_ptr, 1000), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(MemoryBufferOutputStream_GetOutputPosition(stream_ptr, &stream_position), VANILLAPDF_ERROR_SUCCESS);
+    EXPECT_EQ(stream_position, strlen(TEST_DATA) + 2);
 
     ASSERT_EQ(Buffer_Release(buffer_ptr), VANILLAPDF_ERROR_SUCCESS);
     ASSERT_EQ(MemoryBufferOutputStream_Release(stream_ptr), VANILLAPDF_ERROR_SUCCESS);
@@ -231,6 +264,9 @@ TEST(MemoryBufferOutputStream, GetOutputPosition) {
 
     ASSERT_EQ(MemoryBufferOutputStream_Create(&stream_ptr), VANILLAPDF_ERROR_SUCCESS);
     ASSERT_NE(stream_ptr, nullptr);
+
+    ASSERT_EQ(MemoryBufferOutputStream_GetOutputPosition(stream_ptr, &stream_position), VANILLAPDF_ERROR_SUCCESS);
+    EXPECT_EQ(stream_position, 0);
 
     ASSERT_EQ(MemoryBufferOutputStream_WriteString(stream_ptr, TEST_DATA), VANILLAPDF_ERROR_SUCCESS);
     ASSERT_EQ(MemoryBufferOutputStream_GetOutputPosition(stream_ptr, &stream_position), VANILLAPDF_ERROR_SUCCESS);

--- a/src/vanillapdf/CMakeLists.txt
+++ b/src/vanillapdf/CMakeLists.txt
@@ -535,6 +535,7 @@ if(MSVC)
 endif(MSVC)
 
 if(MSVC)
+
     # Add natvis file embedding
     target_link_options(vanillapdf PRIVATE "/NATVIS:${CMAKE_CURRENT_SOURCE_DIR}/public.natvis")
 
@@ -604,6 +605,9 @@ target_compile_definitions(vanillapdf PRIVATE -DVANILLAPDF_BUILD_YEAR=${VANILLAP
 
 # Check for compiler features and include compile definitions
 vanillapdf_check_standard_features(vanillapdf)
+
+# Configure default compilation parameters, strict warnings, config based definition for DEBUG/RELEASE, etc.
+vanillapdf_target_compile_defaults(vanillapdf)
 
 # In case we would like to extract code coverage report enable the flag
 if(VANILLAPDF_ENABLE_COVERAGE)

--- a/src/vanillapdf/CMakeLists.txt
+++ b/src/vanillapdf/CMakeLists.txt
@@ -521,18 +521,10 @@ set_target_properties(vanillapdf PROPERTIES
   PREFIX "lib"
 )
 
-# Add precompiled header optimization
-if(MSVC)
-    get_filename_component(PrecompiledBasename ${VANILLAPDF_PRECOMPILED_HEADER} NAME_WE)
-    set(PrecompiledBinary "${CMAKE_CURRENT_BINARY_DIR}/${PrecompiledBasename}.pch")
-
-    set_source_files_properties(${VANILLAPDF_PRECOMPILED_SOURCE}
-	                            PROPERTIES COMPILE_FLAGS "/Yc\"${VANILLAPDF_PRECOMPILED_HEADER}\" /Fp\"${PrecompiledBinary}\""
-			                               OBJECT_OUTPUTS "${PrecompiledBinary}")
-    set_source_files_properties(${VANILLAPDF_ALL_SOURCES}
-	                            PROPERTIES COMPILE_FLAGS "/Yu\"${VANILLAPDF_PRECOMPILED_HEADER}\" /FI\"${VANILLAPDF_PRECOMPILED_HEADER}\" /Fp\"${PrecompiledBinary}\""
-			                               OBJECT_DEPENDS "${PrecompiledBinary}")
-endif(MSVC)
+# Add precompiled header to speed up the compilation process
+if(VANILLAPDF_PRECOMPILED_HEADER)
+    target_precompile_headers(vanillapdf PRIVATE ${VANILLAPDF_PRECOMPILED_HEADER})
+endif()
 
 if(MSVC)
 

--- a/src/vanillapdf/implementation/utils/c_memory_buffer_output_stream.cpp
+++ b/src/vanillapdf/implementation/utils/c_memory_buffer_output_stream.cpp
@@ -66,6 +66,19 @@ VANILLAPDF_API error_type CALLING_CONVENTION MemoryBufferOutputStream_WriteBuffe
     } CATCH_VANILLAPDF_EXCEPTIONS
 }
 
+VANILLAPDF_API error_type CALLING_CONVENTION MemoryBufferOutputStream_WriteBufferRange(MemoryBufferOutputStreamHandle* handle, BufferHandle* data_handle, offset_type length) {
+    MemoryBufferOutputStream* stream = reinterpret_cast<MemoryBufferOutputStream*>(handle);
+    Buffer* data = reinterpret_cast<Buffer*>(data_handle);
+
+    RETURN_ERROR_PARAM_VALUE_IF_NULL(stream);
+    RETURN_ERROR_PARAM_VALUE_IF_NULL(data);
+
+    try {
+        stream->Write(*data, length);
+        return VANILLAPDF_ERROR_SUCCESS;
+    } CATCH_VANILLAPDF_EXCEPTIONS
+}
+
 VANILLAPDF_API error_type CALLING_CONVENTION MemoryBufferOutputStream_Flush(MemoryBufferOutputStreamHandle* handle) {
     MemoryBufferOutputStream* stream = reinterpret_cast<MemoryBufferOutputStream*>(handle);
     RETURN_ERROR_PARAM_VALUE_IF_NULL(stream);

--- a/src/vanillapdf/syntax/files/file_writer.cpp
+++ b/src/vanillapdf/syntax/files/file_writer.cpp
@@ -2124,6 +2124,8 @@ void FileWriter::RemoveUnreferencedObjects(XrefChainPtr xref) {
         }
     }
 
+    spdlog::debug("RemoveUnreferencedObjects used: {} / unused: {}", used_count, unused_count);
+
 #endif
 
     // ----- DEBUG END -----

--- a/src/vanillapdf/utils/streams/memory_buffer_output_stream.cpp
+++ b/src/vanillapdf/utils/streams/memory_buffer_output_stream.cpp
@@ -12,8 +12,10 @@ void MemoryBufferOutputStream::Write(const Buffer& data) {
 }
 
 void MemoryBufferOutputStream::Write(const Buffer& data, types::stream_size size) {
+    auto size_converted = ValueConvertUtils::SafeConvert<size_t>(size);
+
     auto str = data.ToStringView();
-    auto substring = str.substr(0, size);
+    auto substring = str.substr(0, size_converted);
 
     m_buffer.append(substring);
     m_position += size;

--- a/src/vanillapdf/utils/streams/memory_buffer_output_stream.cpp
+++ b/src/vanillapdf/utils/streams/memory_buffer_output_stream.cpp
@@ -18,7 +18,7 @@ void MemoryBufferOutputStream::Write(const Buffer& data, types::stream_size size
     auto substring = str.substr(0, size_converted);
 
     m_buffer.append(substring);
-    m_position += size;
+    m_position += substring.size();
 }
 
 void MemoryBufferOutputStream::Write(std::string_view data) {


### PR DESCRIPTION
Switch to target based definition instead of global to avoid parent project pollution. Add treat warnings as errors for DEBUG and RELWITHDEBINFO.