### PR TITLE
Fix runtime nuspec path search

### DIFF
--- a/.github/workflows/build-nuget.yml
+++ b/.github/workflows/build-nuget.yml
@@ -7,6 +7,13 @@ on:
         required: false
         type: string
         default: ""
+  # Allow triggering manually from the Actions tab
+  workflow_dispatch:
+    inputs:
+      build_suffix:
+        description: "Optional build suffix for version"
+        required: false
+        default: ""
 
 permissions:
   contents: read  # Needed for future GitHub release or content access

--- a/nuget/vanillapdf.runtime.nuspec.in
+++ b/nuget/vanillapdf.runtime.nuspec.in
@@ -27,10 +27,10 @@
     <file src="vanillapdf_net.targets" target="build\netstandard2.0\vanillapdf.runtime.@PLATFORM_IDENTIFIER@.targets" />
 
     <!-- Binary files -->
-    <file src="..\src\vanillapdf\*\libvanillapdf.dll" target="runtimes\@PLATFORM_IDENTIFIER@\native" />
-    <file src="..\src\vanillapdf\**\libvanillapdf.so" target="runtimes\@PLATFORM_IDENTIFIER@\native" />
-    <file src="..\src\vanillapdf\**\libvanillapdf.dylib" target="runtimes\@PLATFORM_IDENTIFIER@\native" />
-    <file src="..\src\vanillapdf\*\vanillapdf.lib" target="lib\native\@PLATFORM_IDENTIFIER@" />
+    <file src="../build/**/libvanillapdf.dll" target="runtimes\@PLATFORM_IDENTIFIER@\native" />
+    <file src="../build/**/libvanillapdf.so" target="runtimes\@PLATFORM_IDENTIFIER@\native" />
+    <file src="../build/**/libvanillapdf.dylib" target="runtimes\@PLATFORM_IDENTIFIER@\native" />
+    <file src="../build/**/vanillapdf.lib" target="lib\native\@PLATFORM_IDENTIFIER@" />
 
     <!-- This is a placeholder file, so we can target netstandard without a warning -->
     <file src="_._" target="lib\native" />


### PR DESCRIPTION
## Summary
- search for native libraries in `build/**` instead of `src/vanillapdf`
- regenerate `vanillapdf.runtime.nuspec`
- allow manual execution of build-nuget workflow from the Actions tab

## Testing
- `cmake --preset default` *(fails: Could not bootstrap vcpkg)*
- `ctest` *(fails: No test configuration file found)*

------
https://chatgpt.com/codex/tasks/task_e_684dcd701fa0832ba768a7fe0f724f38