### PR TITLE
Limit doxygen build to latest tag

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -2,9 +2,10 @@
 name: Generate doxygen
 
 on:
-  # Runs on pushes targeting the default branch
+  # Runs when a version tag is pushed
   push:
-    branches: ["main"]
+    tags:
+      - 'v*.*.*'
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -22,9 +23,36 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  # Determine if the pushed tag is the latest
+  check-tag:
+    runs-on: ubuntu-latest
+    outputs:
+      is_latest: ${{ steps.check.outputs.is_latest }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Extract tag name
+        id: tag
+        run: echo "tag=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
+
+      - name: Determine latest tag
+        id: check
+        run: |
+          latest=$(git tag -l 'v*.*.*' --sort=-v:refname | head -n 1)
+          if [ "$latest" = "${{ steps.tag.outputs.tag }}" ]; then
+            echo "is_latest=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_latest=false" >> "$GITHUB_OUTPUT"
+          fi
+
   # Build job
   build:
+    if: needs.check-tag.outputs.is_latest == 'true'
     runs-on: ubuntu-latest
+    needs: check-tag
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -47,12 +75,13 @@ jobs:
 
   # Deployment job
   deploy:
+    if: needs.check-tag.outputs.is_latest == 'true'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
 
     runs-on: ubuntu-latest
-    needs: build
+    needs: [check-tag, build]
     steps:
       - name: Deploy to GitHub Pages
         id: deployment


### PR DESCRIPTION
## Summary
- run GitHub Pages build only on tag pushes
- skip doxygen generation unless the pushed tag is the most recent
- move latest-tag check to separate job so build/deploy are skipped with one condition each

## Testing
- `python3 scripts/run_test.py` *(fails: Incorrect number of arguments)*
- `yamllint -d relaxed .github/workflows/github-pages.yml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dd40f5a10832ba51c127f0844f86e