### PR TITLE
Run CI only on source changes

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -14,16 +14,26 @@ name: "CodeQL Advanced"
 on:
   push:
     branches: [ "main" ]
-    paths-ignore:
-      - 'doc/**'
-      - 'nuget/**'
-      - '**/*.md'
+    paths:
+      - '.github/workflows/codeql.yml'
+      - 'src/**'
+      - 'include/**'
+      - 'cmake/**'
+      - 'scripts/**'
+      - 'CMakeLists.txt'
+      - 'CMakePresets.json'
+      - 'test/**'
   pull_request:
     branches: [ "main" ]
-    paths-ignore:
-      - 'doc/**'
-      - 'nuget/**'
-      - '**/*.md'
+    paths:
+      - '.github/workflows/codeql.yml'
+      - 'src/**'
+      - 'include/**'
+      - 'cmake/**'
+      - 'scripts/**'
+      - 'CMakeLists.txt'
+      - 'CMakePresets.json'
+      - 'test/**'
   schedule:
     - cron: '15 22 * * 6'
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -3,16 +3,28 @@ name: Coverage
 on:
   push:
     branches: [main]
-    paths-ignore:
-      - 'doc/**'
-      - 'nuget/**'
-      - '**/*.md'
+    paths:
+      - '.github/workflows/coverage.yml'
+      - '.codecov.yml'
+      - 'src/**'
+      - 'include/**'
+      - 'cmake/**'
+      - 'scripts/**'
+      - 'CMakeLists.txt'
+      - 'CMakePresets.json'
+      - 'test/**'
 
   pull_request:
-    paths-ignore:
-      - 'doc/**'
-      - 'nuget/**'
-      - '**/*.md'
+    paths:
+      - '.github/workflows/coverage.yml'
+      - '.codecov.yml'
+      - 'src/**'
+      - 'include/**'
+      - 'cmake/**'
+      - 'scripts/**'
+      - 'CMakeLists.txt'
+      - 'CMakePresets.json'
+      - 'test/**'
 
 permissions:
   contents: read  # Download the repository source code

--- a/.github/workflows/sanity-check.yml
+++ b/.github/workflows/sanity-check.yml
@@ -10,18 +10,28 @@ on:
   # Run workflow on any push into main branch
   push:
     branches: [ "main" ]
-    paths-ignore:
-      - 'doc/**'
-      - 'nuget/**'
-      - '**/*.md'
+    paths:
+      - '.github/workflows/sanity-check.yml'
+      - 'src/**'
+      - 'include/**'
+      - 'cmake/**'
+      - 'scripts/**'
+      - 'CMakeLists.txt'
+      - 'CMakePresets.json'
+      - 'test/**'
 
   # Run workflow when there is a pull request towards main branch
   pull_request:
     branches: [ "main" ]
-    paths-ignore:
-      - 'doc/**'
-      - 'nuget/**'
-      - '**/*.md'
+    paths:
+      - '.github/workflows/sanity-check.yml'
+      - 'src/**'
+      - 'include/**'
+      - 'cmake/**'
+      - 'scripts/**'
+      - 'CMakeLists.txt'
+      - 'CMakePresets.json'
+      - 'test/**'
 
 permissions:
   contents: read    # Download the repository source code


### PR DESCRIPTION
## Summary
- trigger CodeQL when code or its own workflow file changes
- run coverage only if code, tests, `.codecov.yml`, or its workflow file change
- run sanity check on source or its workflow updates

## Testing
- `python3 -m py_compile scripts/run_test.py`
- `cmake --version`
- `ctest` *(fails: No test configuration file found)*

------
https://chatgpt.com/codex/tasks/task_e_684dd826e73c832b91b74e57e4155d2f