### PR TITLE
Fix build suffix handling in NuGet workflows

### DIFF
--- a/.github/workflows/build-nuget.yml
+++ b/.github/workflows/build-nuget.yml
@@ -190,20 +190,11 @@ jobs:
             vcpkg-${{ runner.os }}-${{ matrix.config.preset }}-
             vcpkg-${{ runner.os }}-
 
-      - name: Install Mono & NuGet
-        run: |
-          # Try installing mono, but continue even if linking fails
-          if ! brew install mono; then
-            echo "Mono installed, but link failed. Forcing overwrite..."
-            brew link --overwrite mono
-          fi
-          
-          # Download and prepare NuGet
-          curl -L https://dist.nuget.org/win-x86-commandline/latest/nuget.exe -o nuget.exe
-          chmod +x nuget.exe
+      - name: Install NuGet
+        run: brew install nuget
 
       - name: Verify NuGet installation
-        run: mono ./nuget.exe help
+        run: nuget help
 
       # Bootstrap vcpkg on macOS
       - name: Bootstrap vcpkg (macOS)
@@ -223,7 +214,7 @@ jobs:
         run: cmake --build build/${{ matrix.config.preset }} --target package
 
       - name: Execute nuget packaging
-        run: mono ./nuget.exe pack nuget/vanillapdf.runtime.nuspec
+        run: nuget pack nuget/vanillapdf.runtime.nuspec
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-nuget.yml
+++ b/.github/workflows/build-nuget.yml
@@ -75,7 +75,7 @@ jobs:
         shell: bash
 
       - name: Configure ${{ matrix.config.name }}
-        run: cmake --preset ${{ matrix.config.preset }} -DCMAKE_BUILD_TYPE=${{ matrix.config.build_type }} -DVANILLAPDF_VERSION_BUILD_SUFFIX="-${{ inputs.build_suffix }}"
+        run: cmake --preset ${{ matrix.config.preset }} -DCMAKE_BUILD_TYPE=${{ matrix.config.build_type }} -DVANILLAPDF_VERSION_BUILD_SUFFIX="${{ inputs.build_suffix }}"
 
       - name: Build ${{ matrix.config.name }}
         run: cmake --build --preset ${{ matrix.config.preset }}
@@ -134,7 +134,7 @@ jobs:
         run: ${{ github.workspace }}\\external\\vcpkg\\bootstrap-vcpkg.bat
 
       - name: Configure ${{ matrix.config.name }}
-        run: cmake --preset ${{ matrix.config.preset }} -DCMAKE_BUILD_TYPE=${{ matrix.config.build_type }} -DVANILLAPDF_VERSION_BUILD_SUFFIX="-${{ inputs.build_suffix }}"
+        run: cmake --preset ${{ matrix.config.preset }} -DCMAKE_BUILD_TYPE=${{ matrix.config.build_type }} -DVANILLAPDF_VERSION_BUILD_SUFFIX="${{ inputs.build_suffix }}"
 
       - name: Build ${{ matrix.config.name }}
         run: cmake --build --preset ${{ matrix.config.preset }} --config ${{ matrix.config.build_type }}
@@ -211,7 +211,7 @@ jobs:
         shell: bash
 
       - name: Configure ${{ matrix.config.name }}
-        run: cmake --preset ${{ matrix.config.preset }} -DCMAKE_BUILD_TYPE=${{ matrix.config.build_type }} -DVANILLAPDF_VERSION_BUILD_SUFFIX="-${{ inputs.build_suffix }}"
+        run: cmake --preset ${{ matrix.config.preset }} -DCMAKE_BUILD_TYPE=${{ matrix.config.build_type }} -DVANILLAPDF_VERSION_BUILD_SUFFIX="${{ inputs.build_suffix }}"
 
       - name: Build ${{ matrix.config.name }}
         run: cmake --build --preset ${{ matrix.config.preset }}
@@ -265,7 +265,7 @@ jobs:
         run: ${{ github.workspace }}\\external\\vcpkg\\bootstrap-vcpkg.bat
 
       - name: Configure
-        run: cmake --preset ${{ matrix.config.preset }} -DCMAKE_BUILD_TYPE=${{ matrix.config.build_type }} -DVANILLAPDF_VERSION_BUILD_SUFFIX="-${{ inputs.build_suffix }}"
+        run: cmake --preset ${{ matrix.config.preset }} -DCMAKE_BUILD_TYPE=${{ matrix.config.build_type }} -DVANILLAPDF_VERSION_BUILD_SUFFIX="${{ inputs.build_suffix }}"
 
       - name: Execute nuget packaging
         run: nuget pack nuget/vanillapdf.nuspec

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -14,22 +14,42 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Extract tag name
+      - name: Extract tag name and suffix
         id: vars
-        run: echo "tag=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          VERSION="${TAG#v}"
+          EXTRA=""
+          if [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(.*)$ ]]; then
+            EXTRA="${BASH_REMATCH[1]}"
+          fi
+          if [[ -n "$EXTRA" ]]; then
+            echo "prerelease=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "prerelease=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Create release from tag
+        env:
+          TAG: ${{ steps.vars.outputs.tag }}
+          PRERELEASE: ${{ steps.vars.outputs.prerelease }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           echo "Creating draft release for tag: $TAG"
           if gh release view "$TAG" &>/dev/null; then
             echo "Release $TAG already exists. Skipping."
             exit 0
           fi
-          gh release create "$TAG" \
-            --title "vanillapdf $TAG" \
-            --generate-notes \
-            --draft
-
-        env:
-          TAG: ${{ steps.vars.outputs.tag }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          if [ "$PRERELEASE" = "true" ]; then
+            gh release create "$TAG" \
+              --title "vanillapdf $TAG" \
+              --generate-notes \
+              --draft \
+              --prerelease
+          else
+            gh release create "$TAG" \
+              --title "vanillapdf $TAG" \
+              --generate-notes \
+              --draft
+          fi

--- a/.github/workflows/nightly-nuget.yml
+++ b/.github/workflows/nightly-nuget.yml
@@ -42,7 +42,7 @@ jobs:
           # Clean it up for suffix use (remove slashes, lowercase)
           CLEAN_NAME=$(echo "$BRANCH_NAME" | tr '/' '-' | tr '[:upper:]' '[:lower:]')
           DATE=$(date +'%Y%m%d')
-          echo "nightly_suffix=nightly-${CLEAN_NAME}-${DATE}" >> "$GITHUB_OUTPUT"
+          echo "nightly_suffix=-nightly-${CLEAN_NAME}-${DATE}" >> "$GITHUB_OUTPUT"
 
   build-nuget:
     needs: prepare-suffix

--- a/.github/workflows/publish-nuget-packages.yml
+++ b/.github/workflows/publish-nuget-packages.yml
@@ -10,8 +10,32 @@ permissions:
   packages: write  # Required for pushing to GitHub Packages
 
 jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      build_suffix: ${{ steps.parse.outputs.build_suffix }}
+    steps:
+      - name: Derive build suffix from tag
+        id: parse
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          VERSION="${TAG#v}"
+          EXTRA=""
+          if [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(.*)$ ]]; then
+            EXTRA="${BASH_REMATCH[1]}"
+          fi
+          if [[ -n "$EXTRA" ]]; then
+            EXTRA="${EXTRA#-}"
+            echo "build_suffix=-$EXTRA" >> "$GITHUB_OUTPUT"
+          else
+            echo "build_suffix=" >> "$GITHUB_OUTPUT"
+          fi
+
   build-nuget:
+    needs: prepare
     uses: ./.github/workflows/build-nuget.yml
+    with:
+      build_suffix: ${{ needs.prepare.outputs.build_suffix }}
 
   publish-nuget-github:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- avoid dangling hyphen by passing build suffix directly to cmake
- generate nightly suffix with leading `-`
- parse prerelease suffix from tag before building packages
- mark GitHub releases as prerelease when appropriate

## Testing
- `ctest --version`

------
https://chatgpt.com/codex/tasks/task_e_684dea23aeb4832b8951a99a81253767