### PR TITLE
Fix release scripts (#56)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,11 +13,21 @@ name: "CodeQL Advanced"
 
 on:
   push:
-    branches: [ "main" ]
+    branches:
+      - main
+      - 'release/*'
+
   pull_request:
-    branches: [ "main" ]
+    branches:
+      - main
+      - 'release/*'
+
   schedule:
     - cron: '15 22 * * 6'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   analyze:

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -14,6 +14,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
       - name: Extract tag name and suffix
         id: vars
         run: |
@@ -35,6 +40,7 @@ jobs:
           TAG: ${{ steps.vars.outputs.tag }}
           PRERELEASE: ${{ steps.vars.outputs.prerelease }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
         run: |
           echo "Creating draft release for tag: $TAG"
           if gh release view "$TAG" &>/dev/null; then

--- a/.github/workflows/publish-nuget-packages.yml
+++ b/.github/workflows/publish-nuget-packages.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Push to GitHub Packages
         run: |
-          dotnet nuget push nupkgs/*.nupkg \
+          dotnet nuget push nupkgs/**/*.nupkg \
             --source "${{ vars.NUGET_SOURCE }}" \
             --api-key "${{ secrets.GITHUB_TOKEN }}" \
             --skip-duplicate


### PR DESCRIPTION
* FIX: GitHub release

Include code checkout, so that we can tag the current commit. Without this there is no .git folder.

* FIX: nupkg location

In the publish nuget packages we have not updated the nupkg location.

* FIX: Cannot merge PR

PR cannot be merges into release branch if the CodeQL was not run.

Let's include this in the conditions,
that it runs on PR agains main as well as release/* branches.

* FIX: yml syntax error

* FIX: yml syntax error

* FIX: yml syntax error

* TWEAK: Codeql concurrency

When doing rapid changes on a branch the CodeQL is ran multiple times. Let's cancel the older runs if they are still active and keep just the latest.