### PR TITLE
Fix GitHub Pages release tag detection

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -6,6 +6,8 @@ on:
   push:
     tags:
       - 'v*.*.*'
+    tags-ignore:
+      - 'v*.*.*-*'
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -41,11 +43,16 @@ jobs:
       - name: Determine latest tag
         id: check
         run: |
-          latest=$(git tag -l 'v*.*.*' --sort=-v:refname | head -n 1)
-          if [ "$latest" = "${{ steps.tag.outputs.tag }}" ]; then
-            echo "is_latest=true" >> "$GITHUB_OUTPUT"
-          else
+          tag="${{ steps.tag.outputs.tag }}"
+          if [[ "$tag" == *-* ]]; then
             echo "is_latest=false" >> "$GITHUB_OUTPUT"
+          else
+            latest=$(git tag -l 'v*.*.*' --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -n 1)
+            if [ "$latest" = "$tag" ]; then
+              echo "is_latest=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "is_latest=false" >> "$GITHUB_OUTPUT"
+            fi
           fi
 
   # Build job


### PR DESCRIPTION
## Summary
- ignore prerelease tags when triggering the GitHub Pages workflow

## Testing
- `cmake --preset linux-x64-clang` *(fails: Could not bootstrap vcpkg)*
- `ctest --preset linux-x64-clang` *(fails: No tests were found)*

------
https://chatgpt.com/codex/tasks/task_e_6861477d4d38832b9f5adb4c2d559d1b