### PR TITLE
Add vcpkg_copy_pdbs

### DIFF
--- a/ports/vanillapdf/portfile.cmake
+++ b/ports/vanillapdf/portfile.cmake
@@ -23,6 +23,9 @@ vcpkg_cmake_configure(
 
 vcpkg_cmake_install()
 
+# Ensure debug symbols are copied for proper installation
+vcpkg_copy_pdbs()
+
 vcpkg_cmake_config_fixup(
     PACKAGE_NAME "vanillapdf"
     CONFIG_PATH "lib/cmake/vanillapdf"


### PR DESCRIPTION
## Summary
- ensure `vcpkg_copy_pdbs()` runs after installation so debug symbols are packaged

## Testing
- `cmake -B build` *(fails: Could not bootstrap vcpkg)*

------
https://chatgpt.com/codex/tasks/task_e_68642b71b448832b898076b6dd071304