### PR TITLE
Remove skia vcpkg feature

### DIFF
--- a/ports/vanillapdf/portfile.cmake
+++ b/ports/vanillapdf/portfile.cmake
@@ -13,12 +13,19 @@ vcpkg_from_github(
     HEAD_REF main
 )
 
+vcpkg_check_features(
+    OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    tests        -DVANILLAPDF_ENABLE_TESTS=ON
+    benchmarks   -DVANILLAPDF_ENABLE_BENCHMARK=ON
+)
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
       -DVANILLAPDF_STANDALONE=OFF
       -DVANILLAPDF_ENABLE_TESTS=OFF
       -DVANILLAPDF_ENABLE_BENCHMARK=OFF
+      ${FEATURE_OPTIONS}
 )
 
 vcpkg_cmake_install()

--- a/ports/vanillapdf/usage
+++ b/ports/vanillapdf/usage
@@ -19,7 +19,6 @@ Features:
 
 Optional features (must be enabled manually):
 
-- Skia rendering: `--feature=skia-support`
 - Benchmarks: `--feature=benchmarks`
 - Tests: `--feature=tests`
 

--- a/ports/vanillapdf/vcpkg.json
+++ b/ports/vanillapdf/vcpkg.json
@@ -23,12 +23,6 @@
     ],
     "default-features": [],
     "features": {
-        "skia-support": {
-            "description": "Enable Skia graphics engine integration for rendering",
-            "dependencies": [
-                "skia"
-            ]
-        },
         "tests": {
             "description": "Enable unit and integration tests",
             "dependencies": [

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -11,12 +11,6 @@
         "nlohmann-json"
     ],
     "features": {
-        "skia-support": {
-            "description": "Enable Skia support",
-            "dependencies": [
-                "skia"
-            ]
-        },
         "tests": {
             "description": "Enable unit and integration tests",
             "dependencies": [


### PR DESCRIPTION
## Summary
- stop advertising the unfinished Skia support in the port
- update portfile and manifests accordingly

## Testing
- `cmake --version`
- `ctest -N`


------
https://chatgpt.com/codex/tasks/task_e_68642b702470832b85740a40c39e7944