### PR TITLE
Update portfile to use 2.1.0 release

### DIFF
--- a/ports/vanillapdf/portfile.cmake
+++ b/ports/vanillapdf/portfile.cmake
@@ -10,7 +10,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO vanillapdf/vanillapdf
-    HEAD_REF main
+    REF v${VERSION}
+    SHA512 f15d9a290de0eebac9073503ac555cbf389484aa3ff6385697ba879c336ed9cd4277af180f9d842b5bd8cca69bf6ef4dcfbedba07a6a76014e3974fe09fc6190
 )
 
 vcpkg_cmake_configure(

--- a/ports/vanillapdf/vcpkg.json
+++ b/ports/vanillapdf/vcpkg.json
@@ -1,6 +1,6 @@
 {
     "name": "vanillapdf",
-    "version-string": "2.0.0",
+    "version-string": "2.1.0",
     "description": "Vanilla.PDF is a cross-platform SDK for creating and modifying PDF documents.",
     "homepage": "https://github.com/vanillapdf/vanillapdf",
     "documentation": "https://vanillapdf.github.io/vanillapdf",

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,6 +1,6 @@
 {
     "name": "vanillapdf",
-    "version": "2.0.0",
+    "version": "2.1.0",
     "description": "PDF rendering engine using vcpkg-managed dependencies",
     "dependencies": [
         "openssl",


### PR DESCRIPTION
## Summary
- bump port version to `2.1.0` in `vcpkg.json` and `ports/vanillapdf/vcpkg.json`
- update `portfile.cmake` to fetch sources from `v${VERSION}`
- fix the SHA512 hash for the v2.1.0 source archive

## Testing
- `cmake -B build -S .` *(fails: Could not bootstrap vcpkg)*


------
https://chatgpt.com/codex/tasks/task_e_68642b67cedc832ba32e9a39d68b91c9