### PR TITLE
Switch to version field in port manifest

### DIFF
--- a/ports/vanillapdf/vcpkg.json
+++ b/ports/vanillapdf/vcpkg.json
@@ -1,6 +1,6 @@
 {
     "name": "vanillapdf",
-    "version-string": "2.1.0",
+    "version": "2.1.0",
     "description": "Vanilla.PDF is a cross-platform SDK for creating and modifying PDF documents.",
     "homepage": "https://github.com/vanillapdf/vanillapdf",
     "documentation": "https://vanillapdf.github.io/vanillapdf",


### PR DESCRIPTION
## Summary
- follow vcpkg recommendation and use the `version` field instead of `version-string` in the port manifest

## Testing
- `cmake --preset linux-x64-gcc` *(fails: Could not bootstrap vcpkg)*

------
https://chatgpt.com/codex/tasks/task_e_686436ec29b0832ba2605aa13a2aed79