### PR TITLE
Document supported build targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,15 @@
 
 ---
 
+## 🖥️ Supported Platforms & Compilers
+
+- **Windows:** Visual Studio 2019 (MSVC 16.11) or 2022 (MSVC 17.x)
+- **Linux:** GCC 8.1+ or Clang 10+ (x64, ARM64, ARM)
+- **macOS:** AppleClang 15+ (Xcode 15)
+- **Android:** NDK toolchain (arm64-v8a, armeabi-v7a, x86, x86_64)
+
+---
+
 ## 📦 Installation Options
 
 ### 🛠 Build from Source

--- a/doc/src/input/architecture.dox
+++ b/doc/src/input/architecture.dox
@@ -2,8 +2,10 @@
 \page page_architecture Architecture
 \tableofcontents
 
-The library is writted in standard C++ (currently 14) and can be compiled using
-Visual studio (2015 and 2017) and GCC (tested on Ubuntu 16.04) as well.
+The library is written in standard C++17 and can be compiled using Microsoft
+Visual Studio 2019 (MSVC 16.11) or 2022 (MSVC 17.x), GCC 8.1+, or Clang 10+
+(including AppleClang 15 on macOS 13). Official CMake presets cover Windows,
+Linux, macOS and Android targets.
 
 Build is executed using cross-platform make tool CMake (<https://cmake.org/>).
 CMake also integrates packaging system to provide one-click installable packages for each platform.

--- a/nuget/vanillapdf.readme.md
+++ b/nuget/vanillapdf.readme.md
@@ -10,6 +10,13 @@
 - Access low-level PDF objects and structure directly
 - Fast and lightweight native runtime for each platform
 
+## Supported Platforms & Compilers
+
+- **Windows:** Visual Studio 2019 (MSVC 16.11) or 2022 (MSVC 17.x)
+- **Linux:** GCC 8.1+ or Clang 10+ (x64, ARM64, ARM)
+- **macOS:** AppleClang 15+ (Xcode 15)
+- **Android:** NDK toolchain (arm64-v8a, armeabi-v7a, x86, x86_64)
+
 ## Getting Started
 
 1. Install the NuGet package:


### PR DESCRIPTION
## Summary
- document supported platforms & compilers in README
- mention the same in nuget package README
- refresh compiler info in doxygen architecture page
- clarify specific compiler versions

## Testing
- `cmake --preset linux-x64-gcc` *(fails: Could not bootstrap vcpkg)*

------
https://chatgpt.com/codex/tasks/task_e_6865690f663c832b9cd9f925bfe1ef65