### PR TITLE
Run vanillapdf core packaging on Ubuntu

### DIFF
--- a/.github/workflows/build-nuget.yml
+++ b/.github/workflows/build-nuget.yml
@@ -271,7 +271,7 @@ jobs:
 
       matrix:
         config:
-          - { name: "win.2025-x64", os: windows-2025, preset: "windows-x64-msvc-17", build_type: Release }
+          - { name: "ubuntu.24.04-x64", os: ubuntu-24.04, preset: "linux-x64-gcc", build_type: Release }
 
     steps:
       - uses: actions/checkout@v4
@@ -294,9 +294,10 @@ jobs:
             vcpkg-${{ runner.os }}-${{ matrix.config.preset }}-
             vcpkg-${{ runner.os }}-
 
-      # Bootstrap vcpkg on Windows
-      - name: Bootstrap vcpkg (Windows)
-        run: ${{ github.workspace }}\\external\\vcpkg\\bootstrap-vcpkg.bat
+      # Bootstrap vcpkg on Linux
+      - name: Bootstrap vcpkg (Linux)
+        run: ./external/vcpkg/bootstrap-vcpkg.sh
+        shell: bash
 
       - name: Configure
         run: cmake --preset ${{ matrix.config.preset }} -DCMAKE_BUILD_TYPE=${{ matrix.config.build_type }} -DVANILLAPDF_VERSION_BUILD_SUFFIX="${{ inputs.build_suffix }}"


### PR DESCRIPTION
## Summary
- switch the `build-vanillapdf-core` job in the NuGet workflow to run on Ubuntu
- bootstrap vcpkg with the Linux script for this job

## Testing
- `cmake --preset linux-x64-gcc` *(fails: Could not bootstrap vcpkg)*

------
https://chatgpt.com/codex/tasks/task_e_6865996e21b0832bb562554cbb03495b