### PR TITLE
Fix JPEG dev dependency and cleanup comment

### DIFF
--- a/.github/workflows/build-deb-package.yml
+++ b/.github/workflows/build-deb-package.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install system dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libssl-dev libjpeg-turbo8 zlib1g-dev libopenjp2-7-dev \
+          sudo apt-get install -y libssl-dev libjpeg-turbo8 libjpeg-turbo8-dev zlib1g-dev libopenjp2-7-dev \
             libspdlog-dev nlohmann-json3-dev libgtest-dev libbenchmark-dev
 
       - name: Configure

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,8 +19,8 @@ option(VANILLAPDF_STANDALONE "Enable internal vcpkg setup for standalone builds"
 option(VANILLAPDF_ENABLE_TESTS "Perform test scenarios to ensure stable releases" ON)
 option(VANILLAPDF_ENABLE_BENCHMARK "Include benchmarking project to measure performance" ON)
 
-# Allow linking selected dependencies from the system instead of vcpkg
-# Allow linking selected dependencies provided outside of vcpkg
+# Allow linking selected dependencies from the system instead of vcpkg,
+# or provided externally
 option(VANILLAPDF_EXTERNAL_OPENSSL "Use OpenSSL from the system or a package manager" OFF)
 option(VANILLAPDF_EXTERNAL_JPEG "Use libjpeg from the system or a package manager" OFF)
 option(VANILLAPDF_EXTERNAL_OPENJPEG "Use openjpeg from the system or a package manager" OFF)

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ produce a `.deb` package directly:
 
 ```bash
 sudo apt-get update
-sudo apt-get install libssl-dev libjpeg-turbo8 zlib1g-dev libopenjp2-7-dev \
+sudo apt-get install libssl-dev libjpeg-turbo8 libjpeg-turbo8-dev zlib1g-dev libopenjp2-7-dev \
   libspdlog-dev nlohmann-json3-dev libgtest-dev libbenchmark-dev
 
 cmake -S . -B build/deb -DCMAKE_BUILD_TYPE=Release \


### PR DESCRIPTION
## Summary
- add libjpeg-turbo8-dev to Debian packaging instructions
- fix duplicated comment in main `CMakeLists.txt`

## Testing
- `cmake -S . -B build/test` *(fails: Could not bootstrap vcpkg)*

------
https://chatgpt.com/codex/tasks/task_e_6868f9cc4ad4832b9e0b057af5c9001f