### PR TITLE
Test homebrew dependencies linking on mac

### DIFF
--- a/.github/workflows/build-brew-package.yml
+++ b/.github/workflows/build-brew-package.yml
@@ -1,0 +1,58 @@
+name: Build Homebrew package
+
+on:
+  workflow_dispatch:
+
+  push:
+    branches:
+      - main
+    paths:
+      - .github/workflows/build-brew-package.yml
+
+  pull_request:
+    branches:
+      - main
+    paths:
+      - .github/workflows/build-brew-package.yml
+
+  schedule:
+    - cron: '0 3 * * 1'
+
+permissions:
+  contents: read
+
+jobs:
+  build-package:
+    name: Build package
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install system dependencies
+        run: |
+          brew update
+          brew install openssl@3 jpeg-turbo zlib
+
+      - name: Configure
+        run: |
+          cmake --preset macos-arm64 -DCMAKE_BUILD_TYPE=Release \
+            -DVANILLAPDF_STANDALONE=ON \
+            -DVANILLAPDF_EXTERNAL_OPENSSL=ON \
+            -DVANILLAPDF_EXTERNAL_JPEG=ON \
+            -DVANILLAPDF_EXTERNAL_OPENJPEG=OFF \
+            -DVANILLAPDF_EXTERNAL_ZLIB=ON \
+            -DVANILLAPDF_EXTERNAL_SPDLOG=OFF \
+            -DVANILLAPDF_EXTERNAL_NLOHMANN_JSON=OFF \
+            -DVANILLAPDF_ENABLE_TESTS=ON -DVANILLAPDF_EXTERNAL_GTEST=OFF \
+            -DVANILLAPDF_ENABLE_BENCHMARK=ON -DVANILLAPDF_EXTERNAL_BENCHMARK=OFF
+
+      - name: Build
+        run: cmake --build --preset macos-arm64
+
+      - name: Test
+        run: ctest --preset macos-arm64
+
+      - name: Package
+        run: cmake --build --preset macos-arm64 --target package

--- a/README.md
+++ b/README.md
@@ -107,6 +107,28 @@ cmake --preset linux-x64-gcc -DCMAKE_BUILD_TYPE=Release \
 cmake --build --preset linux-x64-gcc --target package
 ```
 
+### Building Homebrew Packages
+
+On macOS systems you can use Homebrew to install the required
+dependencies and generate a package:
+
+```bash
+brew install openssl@3 jpeg-turbo zlib
+
+cmake --preset macos-arm64 -DCMAKE_BUILD_TYPE=Release \
+  -DVANILLAPDF_STANDALONE=ON \
+  -DVANILLAPDF_EXTERNAL_OPENSSL=ON \
+  -DVANILLAPDF_EXTERNAL_JPEG=ON \
+  -DVANILLAPDF_EXTERNAL_OPENJPEG=OFF \
+  -DVANILLAPDF_EXTERNAL_ZLIB=ON \
+  -DVANILLAPDF_EXTERNAL_SPDLOG=OFF \
+  -DVANILLAPDF_EXTERNAL_NLOHMANN_JSON=OFF \
+  -DVANILLAPDF_ENABLE_TESTS=ON -DVANILLAPDF_EXTERNAL_GTEST=OFF \
+  -DVANILLAPDF_ENABLE_BENCHMARK=ON -DVANILLAPDF_EXTERNAL_BENCHMARK=OFF
+
+cmake --build --preset macos-arm64 --target package
+```
+
 ---
 
 ## 🔗 CMake Integration (Modern Target-Based)


### PR DESCRIPTION
## Summary
- update Homebrew workflow to run on `macos-latest` arm64
- use the `macos-arm64` CMake preset in workflow and docs

## Testing
- `ctest -N`


------
https://chatgpt.com/codex/tasks/task_e_68693b662eb8832bb2e9a1b0215a6fb7