### PR TITLE
Enable workflows on release branches

### DIFF
--- a/.github/workflows/build-brew-package.yml
+++ b/.github/workflows/build-brew-package.yml
@@ -6,12 +6,14 @@ on:
   push:
     branches:
       - main
+      - 'release/*'
     paths:
       - .github/workflows/build-brew-package.yml
 
   pull_request:
     branches:
       - main
+      - 'release/*'
     paths:
       - .github/workflows/build-brew-package.yml
 

--- a/.github/workflows/build-deb-package.yml
+++ b/.github/workflows/build-deb-package.yml
@@ -6,12 +6,14 @@ on:
   push:
     branches:
       - main
+      - 'release/*'
     paths:
       - .github/workflows/build-deb-package.yml
 
   pull_request:
     branches:
       - main
+      - 'release/*'
     paths:
       - .github/workflows/build-deb-package.yml
 

--- a/.github/workflows/build-nuget.yml
+++ b/.github/workflows/build-nuget.yml
@@ -18,7 +18,7 @@ on:
 
   # Run package build on code changes
   push:
-    branches: [ "main" ]
+    branches: [ "main", "release/*" ]
     paths:
       - '.github/workflows/build-nuget.yml'
       - 'nuget/**'
@@ -26,7 +26,7 @@ on:
       - 'vcpkg.json'
 
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "release/*" ]
     paths:
       - '.github/workflows/build-nuget.yml'
       - 'nuget/**'

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -2,7 +2,9 @@ name: Coverage
 
 on:
   push:
-    branches: [main]
+    branches:
+      - main
+      - 'release/*'
     paths:
       - '.github/workflows/coverage.yml'
       - '.codecov.yml'
@@ -15,6 +17,9 @@ on:
       - 'test/**'
 
   pull_request:
+    branches:
+      - main
+      - 'release/*'
     paths:
       - '.github/workflows/coverage.yml'
       - '.codecov.yml'

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -7,13 +7,14 @@ on:
       - 'v*.*.*'
     branches:
       - "main"
+      - "release/*"
     paths:
       - '.github/workflows/github-pages.yml'
       - 'doc/doxyfile.in'
       - 'cmake/**'
       - 'CMakeLists.txt'
   pull_request:
-    branches: ["main"]
+    branches: ["main", "release/*"]
     paths:
       - '.github/workflows/github-pages.yml'
       - 'doc/doxyfile.in'

--- a/.github/workflows/nightly-check.yml
+++ b/.github/workflows/nightly-check.yml
@@ -10,7 +10,7 @@ on:
   # Run workflow on any push into main branch
   # only there was a change in the workflow file
   push:
-    branches: [ "main" ]
+    branches: [ "main", "release/*" ]
     paths:
       - '.github/workflows/nightly-check.yml'
       - 'vcpkg.json'
@@ -18,7 +18,7 @@ on:
   # Run workflow when there is a pull request towards main branch
   # only there was a change in the workflow file
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "release/*" ]
     paths:
       - '.github/workflows/nightly-check.yml'
       - 'vcpkg.json'

--- a/.github/workflows/nightly-nuget.yml
+++ b/.github/workflows/nightly-nuget.yml
@@ -8,7 +8,7 @@ on:
   # Run workflow on any push into main branch
   # only there was a change in the workflow file
   push:
-    branches: [ "main" ]
+    branches: [ "main", "release/*" ]
     paths:
       - '.github/workflows/nightly-nuget.yml'
       - 'vcpkg.json'
@@ -16,7 +16,7 @@ on:
   # Run workflow when there is a pull request towards main branch
   # only there was a change in the workflow file
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "release/*" ]
     paths:
       - '.github/workflows/nightly-nuget.yml'
       - 'vcpkg.json'

--- a/.github/workflows/sanity-check.yml
+++ b/.github/workflows/sanity-check.yml
@@ -9,7 +9,7 @@ on:
 
   # Run workflow on any push into main branch
   push:
-    branches: [ "main" ]
+    branches: [ "main", "release/*" ]
     paths:
       - '.github/workflows/sanity-check.yml'
       - 'src/**'
@@ -23,7 +23,7 @@ on:
 
   # Run workflow when there is a pull request towards main branch
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "release/*" ]
     paths:
       - '.github/workflows/sanity-check.yml'
       - 'src/**'


### PR DESCRIPTION
## Summary
- run CI workflows when pushing to or opening PRs against `release/*`

## Testing
- `ctest --version`


------
https://chatgpt.com/codex/tasks/task_e_686951b0b9a8832ba3461c536a2ac4ee