### PR TITLE
Switch core NuGet packaging job to Ubuntu

### DIFF
--- a/.github/workflows/build-nuget.yml
+++ b/.github/workflows/build-nuget.yml
@@ -260,8 +260,8 @@ jobs:
 
 
   build-vanillapdf-core:
-    name: vanillapdf core - ${{ matrix.config.name }}
-    runs-on: ${{ matrix.config.os }}
+    name: vanillapdf core
+    runs-on: ubuntu-latest
 
     needs:
       - build-linux
@@ -270,10 +270,6 @@ jobs:
 
     strategy:
       fail-fast: false
-
-      matrix:
-        config:
-          - { name: "win.2025-x64", os: windows-2025, preset: "windows-x64-msvc-17", build_type: Release }
 
     steps:
       - uses: actions/checkout@v4
@@ -284,24 +280,8 @@ jobs:
         with:
           dotnet-version: 8.0.x
 
-      - name: Cache vcpkg
-        uses: actions/cache@v4
-        with:
-          path: |
-            build/${{ matrix.config.preset }}/vcpkg_installed
-            external/vcpkg/downloads
-            external/vcpkg/bincache
-          key: vcpkg-${{ runner.os }}-${{ matrix.config.preset }}-${{ hashFiles('vcpkg.json', 'cmake/overlays/*.cmake') }}
-          restore-keys: |
-            vcpkg-${{ runner.os }}-${{ matrix.config.preset }}-
-            vcpkg-${{ runner.os }}-
-
-      # Bootstrap vcpkg on Windows
-      - name: Bootstrap vcpkg (Windows)
-        run: ${{ github.workspace }}\\external\\vcpkg\\bootstrap-vcpkg.bat
-
-      - name: Configure
-        run: cmake --preset ${{ matrix.config.preset }} -DCMAKE_BUILD_TYPE=${{ matrix.config.build_type }} -DVANILLAPDF_VERSION_BUILD_SUFFIX="${{ inputs.build_suffix }}"
+      - name: Generate NuGet project files
+        run: cmake -DVANILLAPDF_VERSION_BUILD_SUFFIX="${{ inputs.build_suffix }}" -P cmake/nuget.cmake
 
       - name: Download runtime packages
         uses: actions/download-artifact@v4

--- a/cmake/nuget.cmake
+++ b/cmake/nuget.cmake
@@ -1,0 +1,22 @@
+cmake_minimum_required(VERSION 3.15)
+
+# Configure NuGet project templates. This script can be included from a regular
+# build or executed directly via `cmake -P`. In both cases
+# `CMAKE_CURRENT_SOURCE_DIR` resolves to the project root.
+
+include(${CMAKE_CURRENT_LIST_DIR}/version.cmake)
+configure_file(
+    ${CMAKE_CURRENT_SOURCE_DIR}/nuget/vanillapdf.runtime.csproj.in
+    ${CMAKE_CURRENT_SOURCE_DIR}/nuget/vanillapdf.runtime.csproj
+    @ONLY
+)
+configure_file(
+    ${CMAKE_CURRENT_SOURCE_DIR}/nuget/vanillapdf_net.targets.in
+    ${CMAKE_CURRENT_SOURCE_DIR}/nuget/vanillapdf_net.targets
+    @ONLY
+)
+configure_file(
+    ${CMAKE_CURRENT_SOURCE_DIR}/nuget/vanillapdf.csproj.in
+    ${CMAKE_CURRENT_SOURCE_DIR}/nuget/vanillapdf.csproj
+    @ONLY
+)

--- a/cmake/packaging.cmake
+++ b/cmake/packaging.cmake
@@ -95,10 +95,9 @@ set(CPACK_WIX_CMAKE_PACKAGE_REGISTRY	"Vanilla.PDF")
 # I am not able to use NuGet generator since it bundles a lot of unnecessary
 # items and the controlling is not sufficient, so let's do it the old way
 
-# Initialize NuGet for current platform
-configure_file("${CMAKE_CURRENT_SOURCE_DIR}/nuget/vanillapdf.runtime.csproj.in" "${CMAKE_CURRENT_SOURCE_DIR}/nuget/vanillapdf.runtime.csproj")
-configure_file("${CMAKE_CURRENT_SOURCE_DIR}/nuget/vanillapdf_net.targets.in" "${CMAKE_CURRENT_SOURCE_DIR}/nuget/vanillapdf_net.targets")
-configure_file("${CMAKE_CURRENT_SOURCE_DIR}/nuget/vanillapdf.csproj.in" "${CMAKE_CURRENT_SOURCE_DIR}/nuget/vanillapdf.csproj")
+# Initialize NuGet project files for the current platform
+# This script simply configures *.in templates to actual files.
+include(${CMAKE_CURRENT_LIST_DIR}/nuget.cmake)
 
 # This could be useful, however at the time of CPack
 # I am not able to alter some of the properties,


### PR DESCRIPTION
## Summary
- run `build-vanillapdf-core` job on Ubuntu
- avoid full vcpkg configure using `cmake/nuget.cmake`
- share NuGet config generation via packaging module
- simplify nuget script path logic

## Testing
- `cmake --preset linux-x64-gcc` *(fails: Could not bootstrap vcpkg)*
- `ctest --preset linux-x64-gcc` *(fails: No tests were found)*

------
https://chatgpt.com/codex/tasks/task_e_68695402e794832b8161ad88eee10fee