### PR TITLE
Enable Debian artifacts

### DIFF
--- a/.github/workflows/build-deb-package.yml
+++ b/.github/workflows/build-deb-package.yml
@@ -65,3 +65,39 @@ jobs:
         with:
           name: vanillapdf-deb
           path: build/linux-x64-gcc/*.deb
+
+  install-package:
+    name: Install package
+    runs-on: ubuntu-latest
+    needs: build-package
+    steps:
+      - name: Download Artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: vanillapdf-deb
+          path: ./pkg
+
+      - name: Install .deb
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ./pkg/*.deb
+          sudo ldconfig
+
+      - name: Test native library
+        run: |
+          cat <<'EOF' > verify.c
+          #include <stdio.h>
+          #include <dlfcn.h>
+          int main() {
+              void *handle = dlopen("libvanillapdf.so", RTLD_LAZY);
+              if (!handle) { printf("dlopen failed: %s\n", dlerror()); return 1; }
+              if (!dlsym(handle, "LibraryInfo_GetVersionMajor")) {
+                  printf("dlsym failed: %s\n", dlerror());
+                  return 1;
+              }
+              dlclose(handle);
+              return 0;
+          }
+          EOF
+          gcc verify.c -ldl -o verify
+          ./verify

--- a/.github/workflows/build-deb-package.yml
+++ b/.github/workflows/build-deb-package.yml
@@ -64,4 +64,4 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: vanillapdf-deb
-          path: '*.deb'
+          path: build/linux-x64-gcc/*.deb

--- a/.github/workflows/build-deb-package.yml
+++ b/.github/workflows/build-deb-package.yml
@@ -82,22 +82,3 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y ./pkg/*.deb
           sudo ldconfig
-
-      - name: Test native library
-        run: |
-          cat <<'EOF' > verify.c
-          #include <stdio.h>
-          #include <dlfcn.h>
-          int main() {
-              void *handle = dlopen("libvanillapdf.so", RTLD_LAZY);
-              if (!handle) { printf("dlopen failed: %s\n", dlerror()); return 1; }
-              if (!dlsym(handle, "LibraryInfo_GetVersionMajor")) {
-                  printf("dlsym failed: %s\n", dlerror());
-                  return 1;
-              }
-              dlclose(handle);
-              return 0;
-          }
-          EOF
-          gcc verify.c -ldl -o verify
-          ./verify

--- a/.github/workflows/build-deb-package.yml
+++ b/.github/workflows/build-deb-package.yml
@@ -47,6 +47,7 @@ jobs:
             -DVANILLAPDF_EXTERNAL_ZLIB=ON \
             -DVANILLAPDF_EXTERNAL_SPDLOG=OFF \
             -DVANILLAPDF_EXTERNAL_NLOHMANN_JSON=OFF \
+            -DDETECT_CUSTOM_LINUX_DISTRIBUTION=ON \
             -DVANILLAPDF_ENABLE_TESTS=ON -DVANILLAPDF_EXTERNAL_GTEST=OFF \
             -DVANILLAPDF_ENABLE_BENCHMARK=ON -DVANILLAPDF_EXTERNAL_BENCHMARK=OFF
 
@@ -58,3 +59,9 @@ jobs:
 
       - name: Package
         run: cmake --build --preset linux-x64-gcc --target package
+
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: vanillapdf-deb
+          path: '*.deb'


### PR DESCRIPTION
## Summary
- enable custom linux distribution detection
- upload `.deb` artifacts in debian workflow

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68696f12f6f0832b8777aa5f985f5076