### PR TITLE
Upload DMG file when building native MAC OS packages

### DIFF
--- a/.github/workflows/build-brew-package.yml
+++ b/.github/workflows/build-brew-package.yml
@@ -34,17 +34,8 @@ jobs:
 
       - name: Install system dependencies
         run: |
-          brew update --quiet
-          brew unlink openssl@3 || true
-          for formula in openssl@3 jpeg-turbo zlib; do
-            if brew list --versions "$formula" >/dev/null; then
-              if brew outdated --quiet "$formula" >/dev/null; then
-                brew upgrade --quiet "$formula"
-              fi
-            else
-              brew install --quiet "$formula"
-            fi
-          done
+          brew update
+          brew install openssl@3 jpeg-turbo zlib
 
       - name: Configure
         run: |

--- a/.github/workflows/build-brew-package.yml
+++ b/.github/workflows/build-brew-package.yml
@@ -35,8 +35,16 @@ jobs:
       - name: Install system dependencies
         run: |
           brew update --quiet
-          brew install --quiet openssl@3 jpeg-turbo zlib
-          brew link openssl@3 --force --overwrite
+          brew unlink openssl@3 || true
+          for formula in openssl@3 jpeg-turbo zlib; do
+            if brew list --versions "$formula" >/dev/null; then
+              if brew outdated --quiet "$formula" >/dev/null; then
+                brew upgrade --quiet "$formula"
+              fi
+            else
+              brew install --quiet "$formula"
+            fi
+          done
 
       - name: Configure
         run: |

--- a/.github/workflows/build-brew-package.yml
+++ b/.github/workflows/build-brew-package.yml
@@ -34,8 +34,9 @@ jobs:
 
       - name: Install system dependencies
         run: |
-          brew update
-          brew install openssl@3 jpeg-turbo zlib
+          brew update --quiet
+          brew install --quiet openssl@3 jpeg-turbo zlib
+          brew link openssl@3 --force --overwrite
 
       - name: Configure
         run: |
@@ -58,3 +59,9 @@ jobs:
 
       - name: Package
         run: cmake --build --preset macos-arm64 --target package
+
+      - name: Upload DMG
+        uses: actions/upload-artifact@v4
+        with:
+          name: vanillapdf-dmg
+          path: build/macos-arm64/*.dmg


### PR DESCRIPTION
## Summary
- simplify Homebrew installation with `brew install --quiet openssl@3 jpeg-turbo zlib`
- keep DMG uploaded as artifact

## Testing
- `python3 - <<'PY'
import yaml, sys
yaml.safe_load(open('.github/workflows/build-brew-package.yml'))
print('YAML OK')
PY` *(fails: ModuleNotFoundError: No module named 'yaml')*


------
https://chatgpt.com/codex/tasks/task_e_68696ed47b64832bbc184845131886a3