### PR TITLE
Remove vcpkg submodule

### DIFF
--- a/.github/workflows/build-nuget.yml
+++ b/.github/workflows/build-nuget.yml
@@ -94,6 +94,10 @@ jobs:
             vcpkg-${{ runner.os }}-${{ matrix.config.preset }}-
             vcpkg-${{ runner.os }}-
 
+      - name: Clone vcpkg
+        run: git clone https://github.com/microsoft/vcpkg.git external/vcpkg
+        shell: bash
+
       # Bootstrap vcpkg on Linux
       - name: Bootstrap vcpkg (Linux)
         run: ./external/vcpkg/bootstrap-vcpkg.sh
@@ -159,6 +163,9 @@ jobs:
           restore-keys: |
             vcpkg-${{ runner.os }}-${{ matrix.config.preset }}-
             vcpkg-${{ runner.os }}-
+
+      - name: Clone vcpkg
+        run: git clone https://github.com/microsoft/vcpkg.git external/vcpkg
 
       # Bootstrap vcpkg on Windows
       - name: Bootstrap vcpkg (Windows)
@@ -226,6 +233,10 @@ jobs:
           restore-keys: |
             vcpkg-${{ runner.os }}-${{ matrix.config.preset }}-
             vcpkg-${{ runner.os }}-
+
+      - name: Clone vcpkg
+        run: git clone https://github.com/microsoft/vcpkg.git external/vcpkg
+        shell: bash
 
       # dotnet is available on macOS runners by default
 

--- a/.github/workflows/build-nuget.yml
+++ b/.github/workflows/build-nuget.yml
@@ -96,11 +96,11 @@ jobs:
 
       # Bootstrap vcpkg on Linux
       - name: Bootstrap vcpkg (Linux)
-        run: ./external/vcpkg/bootstrap-vcpkg.sh
+        run: ${{ env.VCPKG_ROOT }}/bootstrap-vcpkg.sh
         shell: bash
 
       - name: Configure ${{ matrix.config.name }}
-        run: cmake --preset ${{ matrix.config.preset }} -DCMAKE_BUILD_TYPE=${{ matrix.config.build_type }} -DVANILLAPDF_VERSION_BUILD_SUFFIX="${{ inputs.build_suffix }}"
+        run: cmake --preset ${{ matrix.config.preset }} -DCMAKE_BUILD_TYPE=${{ matrix.config.build_type }} -DVCPKG_ROOT=${{ env.VCPKG_ROOT }} -DVANILLAPDF_VERSION_BUILD_SUFFIX="${{ inputs.build_suffix }}"
 
       - name: Build ${{ matrix.config.name }}
         run: cmake --build --preset ${{ matrix.config.preset }}
@@ -164,10 +164,10 @@ jobs:
 
       # Bootstrap vcpkg on Windows
       - name: Bootstrap vcpkg (Windows)
-        run: ${{ github.workspace }}\\external\\vcpkg\\bootstrap-vcpkg.bat
+        run: ${{ env.VCPKG_ROOT }}\\bootstrap-vcpkg.bat
 
       - name: Configure ${{ matrix.config.name }}
-        run: cmake --preset ${{ matrix.config.preset }} -DCMAKE_BUILD_TYPE=${{ matrix.config.build_type }} -DVANILLAPDF_VERSION_BUILD_SUFFIX="${{ inputs.build_suffix }}"
+        run: cmake --preset ${{ matrix.config.preset }} -DCMAKE_BUILD_TYPE=${{ matrix.config.build_type }} -DVCPKG_ROOT=${{ env.VCPKG_ROOT }} -DVANILLAPDF_VERSION_BUILD_SUFFIX="${{ inputs.build_suffix }}"
 
       - name: Build ${{ matrix.config.name }}
         run: cmake --build --preset ${{ matrix.config.preset }} --config ${{ matrix.config.build_type }}
@@ -233,11 +233,11 @@ jobs:
 
       # Bootstrap vcpkg on macOS
       - name: Bootstrap vcpkg (macOS)
-        run: ${{ github.workspace }}/external/vcpkg/bootstrap-vcpkg.sh
+        run: ${{ env.VCPKG_ROOT }}/bootstrap-vcpkg.sh
         shell: bash
 
       - name: Configure ${{ matrix.config.name }}
-        run: cmake --preset ${{ matrix.config.preset }} -DCMAKE_BUILD_TYPE=${{ matrix.config.build_type }} -DVANILLAPDF_VERSION_BUILD_SUFFIX="${{ inputs.build_suffix }}"
+        run: cmake --preset ${{ matrix.config.preset }} -DCMAKE_BUILD_TYPE=${{ matrix.config.build_type }} -DVCPKG_ROOT=${{ env.VCPKG_ROOT }} -DVANILLAPDF_VERSION_BUILD_SUFFIX="${{ inputs.build_suffix }}"
 
       - name: Build ${{ matrix.config.name }}
         run: cmake --build --preset ${{ matrix.config.preset }}

--- a/.github/workflows/build-nuget.yml
+++ b/.github/workflows/build-nuget.yml
@@ -39,7 +39,7 @@ permissions:
 
 env:
   VCPKG_DISABLE_METRICS: 1
-  VCPKG_ROOT: external/vcpkg # vcpkg is by default sending build metrics, we do not need it here
+  VCPKG_ROOT: /usr/local/vcpkg # preinstalled vcpkg location on Unix runners
   VCPKG_BINARY_SOURCES: "clear;files,${{ github.workspace }}/external/vcpkg/bincache,readwrite"
 
 jobs:
@@ -87,16 +87,12 @@ jobs:
         with:
           path: |
             build/${{ matrix.config.preset }}/vcpkg_installed
-            external/vcpkg/downloads
-            external/vcpkg/bincache
+            ${{ env.VCPKG_ROOT }}/downloads
+            ${{ env.VCPKG_ROOT }}/bincache
           key: vcpkg-${{ runner.os }}-${{ matrix.config.preset }}-${{ hashFiles('vcpkg.json', 'cmake/overlays/*.cmake') }}
           restore-keys: |
             vcpkg-${{ runner.os }}-${{ matrix.config.preset }}-
             vcpkg-${{ runner.os }}-
-
-      - name: Clone vcpkg
-        run: git clone https://github.com/microsoft/vcpkg.git external/vcpkg
-        shell: bash
 
       # Bootstrap vcpkg on Linux
       - name: Bootstrap vcpkg (Linux)
@@ -131,6 +127,8 @@ jobs:
   build-windows:
     name: ${{ matrix.config.name }}
     runs-on: windows-latest
+    env:
+      VCPKG_ROOT: C:\\vcpkg
 
     strategy:
       fail-fast: false
@@ -157,15 +155,12 @@ jobs:
         with:
           path: |
             build/${{ matrix.config.preset }}/vcpkg_installed
-            external/vcpkg/downloads
-            external/vcpkg/bincache
+            ${{ env.VCPKG_ROOT }}/downloads
+            ${{ env.VCPKG_ROOT }}/bincache
           key: vcpkg-${{ runner.os }}-${{ matrix.config.preset }}-${{ hashFiles('vcpkg.json', 'cmake/overlays/*.cmake') }}
           restore-keys: |
             vcpkg-${{ runner.os }}-${{ matrix.config.preset }}-
             vcpkg-${{ runner.os }}-
-
-      - name: Clone vcpkg
-        run: git clone https://github.com/microsoft/vcpkg.git external/vcpkg
 
       # Bootstrap vcpkg on Windows
       - name: Bootstrap vcpkg (Windows)
@@ -227,16 +222,12 @@ jobs:
         with:
           path: |
             build/${{ matrix.config.preset }}/vcpkg_installed
-            external/vcpkg/downloads
-            external/vcpkg/bincache
+            ${{ env.VCPKG_ROOT }}/downloads
+            ${{ env.VCPKG_ROOT }}/bincache
           key: vcpkg-${{ runner.os }}-${{ matrix.config.preset }}-${{ hashFiles('vcpkg.json', 'cmake/overlays/*.cmake') }}
           restore-keys: |
             vcpkg-${{ runner.os }}-${{ matrix.config.preset }}-
             vcpkg-${{ runner.os }}-
-
-      - name: Clone vcpkg
-        run: git clone https://github.com/microsoft/vcpkg.git external/vcpkg
-        shell: bash
 
       # dotnet is available on macOS runners by default
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -89,6 +89,10 @@ jobs:
         restore-keys: |
           codeql-vcpkg-${{ runner.os }}-
 
+    - name: Clone vcpkg
+      run: git clone https://github.com/microsoft/vcpkg.git external/vcpkg
+      shell: bash
+
     - name: Bootstrap vcpkg
       run: ./external/vcpkg/bootstrap-vcpkg.sh
       shell: bash

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -30,7 +30,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  VCPKG_ROOT: external/vcpkg
+  VCPKG_ROOT: /usr/local/vcpkg
   VCPKG_DISABLE_METRICS: 1
   VCPKG_BINARY_SOURCES: "clear;files,${{ github.workspace }}/external/vcpkg/bincache,readwrite"
 
@@ -83,18 +83,14 @@ jobs:
       with:
         path: |
           build/**/vcpkg_installed
-          external/vcpkg/downloads
-          external/vcpkg/bincache
+          ${{ env.VCPKG_ROOT }}/downloads
+          ${{ env.VCPKG_ROOT }}/bincache
         key: codeql-vcpkg-${{ runner.os }}-${{ hashFiles('vcpkg.json', 'cmake/overlays/*.cmake') }}
         restore-keys: |
           codeql-vcpkg-${{ runner.os }}-
 
-    - name: Clone vcpkg
-      run: git clone https://github.com/microsoft/vcpkg.git external/vcpkg
-      shell: bash
-
     - name: Bootstrap vcpkg
-      run: ./external/vcpkg/bootstrap-vcpkg.sh
+      run: ${{ env.VCPKG_ROOT }}/bootstrap-vcpkg.sh
       shell: bash
 
     # Add any setup steps before running the `github/codeql-action/init` action.

--- a/.github/workflows/nightly-check.yml
+++ b/.github/workflows/nightly-check.yml
@@ -32,7 +32,7 @@ permissions:
   packages: read    # Needed to load container images
 
 env:
-  VCPKG_ROOT: external/vcpkg
+  VCPKG_ROOT: /usr/local/vcpkg
   VCPKG_DISABLE_METRICS: 1 # vcpkg is by default sending build metrics, we do not need it here
   VCPKG_BINARY_SOURCES: "clear;files,${{ github.workspace }}/external/vcpkg/bincache,readwrite"
 
@@ -114,19 +114,15 @@ jobs:
         with:
           path: |
             build/${{ matrix.config.preset }}/vcpkg_installed
-            external/vcpkg/downloads
-            external/vcpkg/bincache
+            ${{ env.VCPKG_ROOT }}/downloads
+            ${{ env.VCPKG_ROOT }}/bincache
           key: vcpkg-${{ runner.os }}-${{ matrix.config.preset }}-${{ hashFiles('vcpkg.json', 'cmake/overlays/*.cmake') }}
           restore-keys: |
             vcpkg-${{ runner.os }}-${{ matrix.config.preset }}-
             vcpkg-${{ runner.os }}-
 
-      - name: Clone vcpkg
-        run: git clone https://github.com/microsoft/vcpkg.git external/vcpkg
-        shell: bash
-
       - name: Bootstrap vcpkg (Linux)
-        run: ./external/vcpkg/bootstrap-vcpkg.sh
+        run: ${{ env.VCPKG_ROOT }}/bootstrap-vcpkg.sh
         shell: bash
 
       - name: Configure ${{ matrix.config.preset }}
@@ -142,6 +138,8 @@ jobs:
   windows:
     name: ${{ matrix.config.name }} - ${{ matrix.build_type }}
     runs-on: ${{ matrix.config.os }}
+    env:
+      VCPKG_ROOT: C:\\vcpkg
 
     strategy:
       fail-fast: false
@@ -167,18 +165,15 @@ jobs:
         with:
           path: |
             build/${{ matrix.config.preset }}/vcpkg_installed
-            external/vcpkg/downloads
-            external/vcpkg/bincache
+            ${{ env.VCPKG_ROOT }}/downloads
+            ${{ env.VCPKG_ROOT }}/bincache
           key: vcpkg-${{ runner.os }}-${{ matrix.config.preset }}-${{ hashFiles('vcpkg.json', 'cmake/overlays/*.cmake') }}
           restore-keys: |
             vcpkg-${{ runner.os }}-${{ matrix.config.preset }}-
             vcpkg-${{ runner.os }}-
 
-      - name: Clone vcpkg
-        run: git clone https://github.com/microsoft/vcpkg.git external/vcpkg
-
       - name: Bootstrap vcpkg (Windows)
-        run: ${{ github.workspace }}\\external\\vcpkg\\bootstrap-vcpkg.bat
+        run: ${{ env.VCPKG_ROOT }}\\bootstrap-vcpkg.bat
 
       - name: Configure ${{ matrix.config.preset }}
         run: cmake --preset ${{ matrix.config.preset }} -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
@@ -214,22 +209,18 @@ jobs:
         with:
           path: |
             build/${{ matrix.config.preset }}/vcpkg_installed
-            external/vcpkg/downloads
-            external/vcpkg/bincache
+            ${{ env.VCPKG_ROOT }}/downloads
+            ${{ env.VCPKG_ROOT }}/bincache
           key: vcpkg-${{ runner.os }}-${{ matrix.config.preset }}-${{ hashFiles('vcpkg.json', 'cmake/overlays/*.cmake') }}
           restore-keys: |
             vcpkg-${{ runner.os }}-${{ matrix.config.preset }}-
             vcpkg-${{ runner.os }}-
 
-      - name: Clone vcpkg
-        run: git clone https://github.com/microsoft/vcpkg.git external/vcpkg
-        shell: bash
-
       - name: Install build tools (macOS)
         run: brew install --quiet autoconf automake autoconf-archive
 
       - name: Bootstrap vcpkg (macOS)
-        run: ${{ github.workspace }}/external/vcpkg/bootstrap-vcpkg.sh
+        run: ${{ env.VCPKG_ROOT }}/bootstrap-vcpkg.sh
         shell: bash
 
       - name: Configure

--- a/.github/workflows/nightly-check.yml
+++ b/.github/workflows/nightly-check.yml
@@ -121,6 +121,10 @@ jobs:
             vcpkg-${{ runner.os }}-${{ matrix.config.preset }}-
             vcpkg-${{ runner.os }}-
 
+      - name: Clone vcpkg
+        run: git clone https://github.com/microsoft/vcpkg.git external/vcpkg
+        shell: bash
+
       - name: Bootstrap vcpkg (Linux)
         run: ./external/vcpkg/bootstrap-vcpkg.sh
         shell: bash
@@ -170,6 +174,9 @@ jobs:
             vcpkg-${{ runner.os }}-${{ matrix.config.preset }}-
             vcpkg-${{ runner.os }}-
 
+      - name: Clone vcpkg
+        run: git clone https://github.com/microsoft/vcpkg.git external/vcpkg
+
       - name: Bootstrap vcpkg (Windows)
         run: ${{ github.workspace }}\\external\\vcpkg\\bootstrap-vcpkg.bat
 
@@ -213,6 +220,10 @@ jobs:
           restore-keys: |
             vcpkg-${{ runner.os }}-${{ matrix.config.preset }}-
             vcpkg-${{ runner.os }}-
+
+      - name: Clone vcpkg
+        run: git clone https://github.com/microsoft/vcpkg.git external/vcpkg
+        shell: bash
 
       - name: Install build tools (macOS)
         run: brew install --quiet autoconf automake autoconf-archive

--- a/.github/workflows/nightly-check.yml
+++ b/.github/workflows/nightly-check.yml
@@ -126,7 +126,7 @@ jobs:
         shell: bash
 
       - name: Configure ${{ matrix.config.preset }}
-        run: cmake --preset ${{ matrix.config.preset }} -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
+        run: cmake --preset ${{ matrix.config.preset }} -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DVCPKG_ROOT=${{ env.VCPKG_ROOT }}
 
       - name: Build ${{ matrix.config.preset }}
         run: cmake --build --preset ${{ matrix.config.preset }}
@@ -176,7 +176,7 @@ jobs:
         run: ${{ env.VCPKG_ROOT }}\\bootstrap-vcpkg.bat
 
       - name: Configure ${{ matrix.config.preset }}
-        run: cmake --preset ${{ matrix.config.preset }} -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
+        run: cmake --preset ${{ matrix.config.preset }} -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DVCPKG_ROOT=${{ env.VCPKG_ROOT }}
 
       - name: Build ${{ matrix.config.preset }}
         run: cmake --build --preset ${{ matrix.config.preset }} --config ${{ matrix.build_type }}
@@ -224,7 +224,7 @@ jobs:
         shell: bash
 
       - name: Configure
-        run: cmake --preset ${{ matrix.config.preset }} -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
+        run: cmake --preset ${{ matrix.config.preset }} -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DVCPKG_ROOT=${{ env.VCPKG_ROOT }}
 
       - name: Build
         run: cmake --build --preset ${{ matrix.config.preset }}

--- a/.github/workflows/sanity-check.yml
+++ b/.github/workflows/sanity-check.yml
@@ -114,7 +114,7 @@ jobs:
         shell: bash
 
       - name: Generate build files
-        run: cmake --preset ${{ matrix.config.preset }} -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
+        run: cmake --preset ${{ matrix.config.preset }} -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DVCPKG_ROOT=${{ env.VCPKG_ROOT }}
 
       - name: Build
         run: cmake --build --preset ${{ matrix.config.preset }}
@@ -167,7 +167,7 @@ jobs:
         run: ${{ env.VCPKG_ROOT }}\\bootstrap-vcpkg.bat
 
       - name: Generate build files ${{ matrix.config.preset }}
-        run: cmake --preset ${{ matrix.config.preset }} -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
+        run: cmake --preset ${{ matrix.config.preset }} -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DVCPKG_ROOT=${{ env.VCPKG_ROOT }}
 
       - name: Build ${{ matrix.config.preset }}
         run: cmake --build --preset ${{ matrix.config.preset }} --config ${{ matrix.build_type }}
@@ -223,7 +223,7 @@ jobs:
         shell: bash
 
       - name: Generate build files
-        run: cmake --preset ${{ matrix.config.preset }} -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
+        run: cmake --preset ${{ matrix.config.preset }} -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DVCPKG_ROOT=${{ env.VCPKG_ROOT }}
 
       - name: Build
         run: cmake --build --preset ${{ matrix.config.preset }}

--- a/.github/workflows/sanity-check.yml
+++ b/.github/workflows/sanity-check.yml
@@ -44,7 +44,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  VCPKG_ROOT: external/vcpkg
+  VCPKG_ROOT: /usr/local/vcpkg
   VCPKG_DISABLE_METRICS: 1 # vcpkg is by default sending build metrics, we do not need it here
   VCPKG_BINARY_SOURCES: "clear;files,${{ github.workspace }}/external/vcpkg/bincache,readwrite"
 
@@ -101,20 +101,16 @@ jobs:
         with:
           path: |
             build/${{ matrix.config.preset }}/vcpkg_installed
-            external/vcpkg/downloads
-            external/vcpkg/bincache
+            ${{ env.VCPKG_ROOT }}/downloads
+            ${{ env.VCPKG_ROOT }}/bincache
           key: vcpkg-${{ runner.os }}-${{ matrix.config.preset }}-${{ hashFiles('vcpkg.json', 'cmake/overlays/*.cmake') }}
           restore-keys: |
             vcpkg-${{ runner.os }}-${{ matrix.config.preset }}-
             vcpkg-${{ runner.os }}-
 
-      - name: Clone vcpkg
-        run: git clone https://github.com/microsoft/vcpkg.git external/vcpkg
-        shell: bash
-
       # Bootstrap vcpkg on Linux
       - name: Bootstrap vcpkg (Linux)
-        run: ./external/vcpkg/bootstrap-vcpkg.sh
+        run: ${{ env.VCPKG_ROOT }}/bootstrap-vcpkg.sh
         shell: bash
 
       - name: Generate build files
@@ -130,6 +126,8 @@ jobs:
   windows:
     name: ${{ matrix.config.name }} - ${{ matrix.build_type }}
     runs-on: windows-2025
+    env:
+      VCPKG_ROOT: C:\\vcpkg
 
     strategy:
       fail-fast: false # We would like to see the results of all jobs even in case one of them fails
@@ -157,19 +155,16 @@ jobs:
         with:
           path: |
             build/${{ matrix.config.preset }}/vcpkg_installed
-            external/vcpkg/downloads
-            external/vcpkg/bincache
+            ${{ env.VCPKG_ROOT }}/downloads
+            ${{ env.VCPKG_ROOT }}/bincache
           key: vcpkg-${{ runner.os }}-${{ matrix.config.preset }}-${{ hashFiles('vcpkg.json', 'cmake/overlays/*.cmake') }}
           restore-keys: |
             vcpkg-${{ runner.os }}-${{ matrix.config.preset }}-
             vcpkg-${{ runner.os }}-
 
-      - name: Clone vcpkg
-        run: git clone https://github.com/microsoft/vcpkg.git external/vcpkg
-
       # Bootstrap vcpkg on Windows
       - name: Bootstrap vcpkg (Windows)
-        run: ${{ github.workspace }}\\external\\vcpkg\\bootstrap-vcpkg.bat
+        run: ${{ env.VCPKG_ROOT }}\\bootstrap-vcpkg.bat
 
       - name: Generate build files ${{ matrix.config.preset }}
         run: cmake --preset ${{ matrix.config.preset }} -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
@@ -183,6 +178,8 @@ jobs:
   macos:
     name: ${{ matrix.config.name }} - ${{ matrix.build_type }}
     runs-on: ${{ matrix.config.runner }}
+    env:
+      VCPKG_ROOT: /usr/local/vcpkg
 
     strategy:
       fail-fast: false # We would like to see the results of all jobs even in case one of them fails
@@ -210,23 +207,19 @@ jobs:
         with:
           path: |
             build/${{ matrix.config.preset }}/vcpkg_installed
-            external/vcpkg/downloads
-            external/vcpkg/bincache
+            ${{ env.VCPKG_ROOT }}/downloads
+            ${{ env.VCPKG_ROOT }}/bincache
           key: vcpkg-${{ runner.os }}-${{ matrix.config.preset }}-${{ hashFiles('vcpkg.json', 'cmake/overlays/*.cmake') }}
           restore-keys: |
             vcpkg-${{ runner.os }}-${{ matrix.config.preset }}-
             vcpkg-${{ runner.os }}-
-
-      - name: Clone vcpkg
-        run: git clone https://github.com/microsoft/vcpkg.git external/vcpkg
-        shell: bash
 
       - name: Install build tools (macOS)
         run: brew install --quiet autoconf automake autoconf-archive
 
       # Bootstrap vcpkg on macOS
       - name: Bootstrap vcpkg (macOS)
-        run: ${{ github.workspace }}/external/vcpkg/bootstrap-vcpkg.sh
+        run: ${{ env.VCPKG_ROOT }}/bootstrap-vcpkg.sh
         shell: bash
 
       - name: Generate build files

--- a/.github/workflows/sanity-check.yml
+++ b/.github/workflows/sanity-check.yml
@@ -108,6 +108,10 @@ jobs:
             vcpkg-${{ runner.os }}-${{ matrix.config.preset }}-
             vcpkg-${{ runner.os }}-
 
+      - name: Clone vcpkg
+        run: git clone https://github.com/microsoft/vcpkg.git external/vcpkg
+        shell: bash
+
       # Bootstrap vcpkg on Linux
       - name: Bootstrap vcpkg (Linux)
         run: ./external/vcpkg/bootstrap-vcpkg.sh
@@ -160,6 +164,9 @@ jobs:
             vcpkg-${{ runner.os }}-${{ matrix.config.preset }}-
             vcpkg-${{ runner.os }}-
 
+      - name: Clone vcpkg
+        run: git clone https://github.com/microsoft/vcpkg.git external/vcpkg
+
       # Bootstrap vcpkg on Windows
       - name: Bootstrap vcpkg (Windows)
         run: ${{ github.workspace }}\\external\\vcpkg\\bootstrap-vcpkg.bat
@@ -209,6 +216,10 @@ jobs:
           restore-keys: |
             vcpkg-${{ runner.os }}-${{ matrix.config.preset }}-
             vcpkg-${{ runner.os }}-
+
+      - name: Clone vcpkg
+        run: git clone https://github.com/microsoft/vcpkg.git external/vcpkg
+        shell: bash
 
       - name: Install build tools (macOS)
         run: brew install --quiet autoconf automake autoconf-archive

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ CMakeSettings.json
 /*.nupkg
 /nuget/*.csproj
 /doc/doxyfile
+external/vcpkg/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "external/vcpkg"]
-	path = external/vcpkg
-	url = https://github.com/microsoft/vcpkg.git
-	branch = master

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,7 @@ set(VANILLAPDF_SOLUTION_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 
 # Configurable option, if this is a primary project or just a submodule
 option(VANILLAPDF_STANDALONE "Enable internal vcpkg setup for standalone builds" ON)
+option(VANILLAPDF_AUTO_VCPKG_CLONE "Automatically clone vcpkg when missing" OFF)
 option(VANILLAPDF_ENABLE_TESTS "Perform test scenarios to ensure stable releases" ON)
 option(VANILLAPDF_ENABLE_BENCHMARK "Include benchmarking project to measure performance" ON)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ set(VANILLAPDF_SOLUTION_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 
 # Configurable option, if this is a primary project or just a submodule
 option(VANILLAPDF_STANDALONE "Enable internal vcpkg setup for standalone builds" ON)
-option(VANILLAPDF_AUTO_VCPKG_CLONE "Automatically clone vcpkg when missing" OFF)
+option(VANILLAPDF_AUTO_VCPKG_BOOTSTRAP "Clone and bootstrap vcpkg if missing" OFF)
 option(VANILLAPDF_ENABLE_TESTS "Perform test scenarios to ensure stable releases" ON)
 option(VANILLAPDF_ENABLE_BENCHMARK "Include benchmarking project to measure performance" ON)
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,11 @@ cmake --build --preset windows-x64-msvc-release
 ctest --preset windows-x64-msvc-release  # Optional
 ```
 
+If vcpkg cannot be found, configuration fails by default. Pass
+`-DVANILLAPDF_AUTO_VCPKG_CLONE=ON` to automatically clone vcpkg into
+`external/vcpkg`. The bootstrapping step will still run automatically
+when needed.
+
 ### Install Dependencies with vcpkg
 
 If you prefer to use [vcpkg](https://github.com/microsoft/vcpkg) for dependency

--- a/README.md
+++ b/README.md
@@ -48,9 +48,8 @@ ctest --preset windows-x64-msvc-release  # Optional
 ```
 
 If vcpkg cannot be found, configuration fails by default. Pass
-`-DVANILLAPDF_AUTO_VCPKG_CLONE=ON` to automatically clone vcpkg into
-`external/vcpkg`. The bootstrapping step will still run automatically
-when needed.
+`-DVANILLAPDF_AUTO_VCPKG_BOOTSTRAP=ON` to automatically clone and bootstrap
+vcpkg into `external/vcpkg`.
 
 ### Install Dependencies with vcpkg
 

--- a/README.md
+++ b/README.md
@@ -42,11 +42,11 @@
 ```bash
 git clone https://github.com/vanillapdf/vanillapdf.git
 cd vanillapdf
-cmake --preset windows-x64-msvc-release
+cmake --preset windows-x64-msvc-release -DVCPKG_ROOT=</path/to/vcpkg>
 cmake --build --preset windows-x64-msvc-release
 ctest --preset windows-x64-msvc-release  # Optional
 ```
-
+Set `VCPKG_ROOT` to your vcpkg installation or provide it via an environment variable.
 If vcpkg cannot be found, configuration fails by default. Pass
 `-DVANILLAPDF_AUTO_VCPKG_BOOTSTRAP=ON` to automatically clone and bootstrap
 vcpkg into `external/vcpkg`.

--- a/cmake/presets/shared.json
+++ b/cmake/presets/shared.json
@@ -6,7 +6,6 @@
             "generator": "Ninja",
             "binaryDir": "${sourceDir}/build/${presetName}",
             "cacheVariables": {
-                "CMAKE_TOOLCHAIN_FILE": "${sourceDir}/external/vcpkg/scripts/buildsystems/vcpkg.cmake",
                 "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
                 "VCPKG_OVERLAY_TRIPLETS": "${sourceDir}/cmake/overlays"
             }

--- a/cmake/vcpkg_init.cmake
+++ b/cmake/vcpkg_init.cmake
@@ -6,9 +6,13 @@ if(NOT VANILLAPDF_STANDALONE)
   return()
 endif()
 
-# In case we are in STANDALONE configuration and VCPKG_ROOT is not defined, let's try to fallback
+# Determine VCPKG_ROOT from cache variable, environment or fallback location
 if(NOT DEFINED VCPKG_ROOT)
-  set(VCPKG_ROOT "${VANILLAPDF_SOLUTION_SOURCE_DIR}/external/vcpkg")
+  if(DEFINED ENV{VCPKG_ROOT})
+    set(VCPKG_ROOT "$ENV{VCPKG_ROOT}")
+  else()
+    set(VCPKG_ROOT "${VANILLAPDF_SOLUTION_SOURCE_DIR}/external/vcpkg")
+  endif()
 endif()
 
 # Clone vcpkg when requested

--- a/cmake/vcpkg_init.cmake
+++ b/cmake/vcpkg_init.cmake
@@ -11,6 +11,22 @@ if(NOT DEFINED VCPKG_ROOT)
   set(VCPKG_ROOT "${VANILLAPDF_SOLUTION_SOURCE_DIR}/external/vcpkg")
 endif()
 
+# Clone vcpkg when requested
+if(NOT EXISTS "${VCPKG_ROOT}")
+  if(VANILLAPDF_AUTO_VCPKG_CLONE)
+    message(STATUS "Cloning vcpkg into ${VCPKG_ROOT}")
+    execute_process(
+      COMMAND git clone https://github.com/microsoft/vcpkg.git "${VCPKG_ROOT}"
+      RESULT_VARIABLE VANILLAPDF_GIT_CLONE_RESULT
+    )
+    if(NOT VANILLAPDF_GIT_CLONE_RESULT EQUAL 0)
+      message(FATAL_ERROR "***** FATAL ERROR: Failed to clone vcpkg *****")
+    endif()
+  else()
+    message(FATAL_ERROR "***** FATAL ERROR: VCPKG_ROOT not found. Set VCPKG_ROOT or enable VANILLAPDF_AUTO_VCPKG_CLONE *****")
+  endif()
+endif()
+
 # In case we are in STANDALONE configuration and CMAKE_TOOLCHAIN_FILE is not defined, let's try to fallback
 # This only works in case it is defined before the first call to project(), which is our case
 if(NOT DEFINED CMAKE_TOOLCHAIN_FILE AND DEFINED VCPKG_ROOT)

--- a/cmake/vcpkg_init.cmake
+++ b/cmake/vcpkg_init.cmake
@@ -13,7 +13,7 @@ endif()
 
 # Clone vcpkg when requested
 if(NOT EXISTS "${VCPKG_ROOT}")
-  if(VANILLAPDF_AUTO_VCPKG_CLONE)
+  if(VANILLAPDF_AUTO_VCPKG_BOOTSTRAP)
     message(STATUS "Cloning vcpkg into ${VCPKG_ROOT}")
     execute_process(
       COMMAND git clone https://github.com/microsoft/vcpkg.git "${VCPKG_ROOT}"
@@ -23,7 +23,7 @@ if(NOT EXISTS "${VCPKG_ROOT}")
       message(FATAL_ERROR "***** FATAL ERROR: Failed to clone vcpkg *****")
     endif()
   else()
-    message(FATAL_ERROR "***** FATAL ERROR: VCPKG_ROOT not found. Set VCPKG_ROOT or enable VANILLAPDF_AUTO_VCPKG_CLONE *****")
+    message(FATAL_ERROR "***** FATAL ERROR: VCPKG_ROOT not found. Set VCPKG_ROOT or enable VANILLAPDF_AUTO_VCPKG_BOOTSTRAP *****")
   endif()
 endif()
 


### PR DESCRIPTION
## Summary
- rename the clone result variable to `VANILLAPDF_GIT_CLONE_RESULT`
- drop the `external/vcpkg` git submodule
- ignore the local `external/vcpkg` directory so it won't be committed again

## Testing
- `cmake -S . -B build -DVANILLAPDF_AUTO_VCPKG_CLONE=ON` *(fails: Could not bootstrap vcpkg)*

------
https://chatgpt.com/codex/tasks/task_e_686970b3dcfc832bb4650d69ba9cae08