### PR TITLE
Add stack sanitizer option

### DIFF
--- a/.github/workflows/nightly-check.yml
+++ b/.github/workflows/nightly-check.yml
@@ -125,8 +125,13 @@ jobs:
         run: ./external/vcpkg/bootstrap-vcpkg.sh
         shell: bash
 
+      - name: Prepare CMake arguments
+        if: matrix.build_type == 'Debug'
+        run: echo "CMAKE_ADDITIONAL_ARGS=-DVANILLAPDF_ENABLE_STACK_SANITIZER=ON" >> $GITHUB_ENV
+        shell: bash
+
       - name: Configure ${{ matrix.config.preset }}
-        run: cmake --preset ${{ matrix.config.preset }} -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
+        run: cmake --preset ${{ matrix.config.preset }} -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} ${{ env.CMAKE_ADDITIONAL_ARGS }}
 
       - name: Build ${{ matrix.config.preset }}
         run: cmake --build --preset ${{ matrix.config.preset }}
@@ -173,8 +178,13 @@ jobs:
       - name: Bootstrap vcpkg (Windows)
         run: ${{ github.workspace }}\\external\\vcpkg\\bootstrap-vcpkg.bat
 
+      - name: Prepare CMake arguments
+        if: matrix.build_type == 'Debug'
+        run: echo "CMAKE_ADDITIONAL_ARGS=-DVANILLAPDF_ENABLE_STACK_SANITIZER=ON" >> $GITHUB_ENV
+        shell: bash
+
       - name: Configure ${{ matrix.config.preset }}
-        run: cmake --preset ${{ matrix.config.preset }} -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
+        run: cmake --preset ${{ matrix.config.preset }} -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} ${{ env.CMAKE_ADDITIONAL_ARGS }}
 
       - name: Build ${{ matrix.config.preset }}
         run: cmake --build --preset ${{ matrix.config.preset }} --config ${{ matrix.build_type }}
@@ -221,8 +231,13 @@ jobs:
         run: ${{ github.workspace }}/external/vcpkg/bootstrap-vcpkg.sh
         shell: bash
 
+      - name: Prepare CMake arguments
+        if: matrix.build_type == 'Debug'
+        run: echo "CMAKE_ADDITIONAL_ARGS=-DVANILLAPDF_ENABLE_STACK_SANITIZER=ON" >> $GITHUB_ENV
+        shell: bash
+
       - name: Configure
-        run: cmake --preset ${{ matrix.config.preset }} -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
+        run: cmake --preset ${{ matrix.config.preset }} -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} ${{ env.CMAKE_ADDITIONAL_ARGS }}
 
       - name: Build
         run: cmake --build --preset ${{ matrix.config.preset }}

--- a/.github/workflows/sanity-check.yml
+++ b/.github/workflows/sanity-check.yml
@@ -113,8 +113,13 @@ jobs:
         run: ./external/vcpkg/bootstrap-vcpkg.sh
         shell: bash
 
+      - name: Prepare CMake arguments
+        if: matrix.build_type == 'Debug'
+        run: echo "CMAKE_ADDITIONAL_ARGS=-DVANILLAPDF_ENABLE_STACK_SANITIZER=ON" >> $GITHUB_ENV
+        shell: bash
+
       - name: Generate build files
-        run: cmake --preset ${{ matrix.config.preset }} -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
+        run: cmake --preset ${{ matrix.config.preset }} -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} ${{ env.CMAKE_ADDITIONAL_ARGS }}
 
       - name: Build
         run: cmake --build --preset ${{ matrix.config.preset }}
@@ -164,8 +169,13 @@ jobs:
       - name: Bootstrap vcpkg (Windows)
         run: ${{ github.workspace }}\\external\\vcpkg\\bootstrap-vcpkg.bat
 
+      - name: Prepare CMake arguments
+        if: matrix.build_type == 'Debug'
+        run: echo "CMAKE_ADDITIONAL_ARGS=-DVANILLAPDF_ENABLE_STACK_SANITIZER=ON" >> $GITHUB_ENV
+        shell: bash
+
       - name: Generate build files ${{ matrix.config.preset }}
-        run: cmake --preset ${{ matrix.config.preset }} -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
+        run: cmake --preset ${{ matrix.config.preset }} -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} ${{ env.CMAKE_ADDITIONAL_ARGS }}
 
       - name: Build ${{ matrix.config.preset }}
         run: cmake --build --preset ${{ matrix.config.preset }} --config ${{ matrix.build_type }}
@@ -218,8 +228,13 @@ jobs:
         run: ${{ github.workspace }}/external/vcpkg/bootstrap-vcpkg.sh
         shell: bash
 
+      - name: Prepare CMake arguments
+        if: matrix.build_type == 'Debug'
+        run: echo "CMAKE_ADDITIONAL_ARGS=-DVANILLAPDF_ENABLE_STACK_SANITIZER=ON" >> $GITHUB_ENV
+        shell: bash
+
       - name: Generate build files
-        run: cmake --preset ${{ matrix.config.preset }} -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
+        run: cmake --preset ${{ matrix.config.preset }} -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} ${{ env.CMAKE_ADDITIONAL_ARGS }}
 
       - name: Build
         run: cmake --build --preset ${{ matrix.config.preset }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,6 +85,9 @@ include(cmake/compiler_checks.cmake)
 # Allow code coverage configuration
 include(cmake/coverage.cmake)
 
+# Optional sanitizer configuration
+include(cmake/sanitizers.cmake)
+
 # Turn on the ability to create folders to organize projects (.vcproj)
 # It creates "CMakePredefinedTargets" folder by default and adds CMake
 # defined projects like INSTALL.vcproj and ZERO_CHECK.vcproj

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 - 🛠️ **Advanced Editing**: Modify content streams, metadata, and page structure
 - 🔍 **PDF Parsing**: Inspect low-level internals like XRef tables and objects
 - 🔐 **Encryption & Permissions**: Work with standard PDF security models
-- 🧪 **Test Coverage**: Unit-tested core with CI pipelines and sanitizers
+- 🧪 **Test Coverage**: Unit-tested core with CI pipelines and sanitizers (enable stack sanitizer in Debug builds with `-DVANILLAPDF_ENABLE_STACK_SANITIZER=ON`)
 - 🧰 **CLI Tools**: Batch-process PDFs directly from the terminal
 - ⚙️ **Cross-Platform**: Build on Windows, Linux, and macOS via CMakePresets
 - 📦 **Minimal Dependencies**: Statically linkable; vcpkg and Conan compatible

--- a/cmake/sanitizers.cmake
+++ b/cmake/sanitizers.cmake
@@ -1,0 +1,18 @@
+option(VANILLAPDF_ENABLE_STACK_SANITIZER "Enable stack sanitizer instrumentation (use with Debug builds)" OFF)
+
+function(enable_stack_sanitizer_for_target target)
+    # Sanitizers are primarily useful while debugging
+    if (VANILLAPDF_ENABLE_STACK_SANITIZER)
+        if (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang|AppleClang")
+            message(STATUS "Stack sanitizer enabled for target: ${target}")
+            target_compile_options(${target} PRIVATE -fsanitize=address -fno-omit-frame-pointer)
+            target_link_options(${target} PRIVATE -fsanitize=address)
+        elseif (MSVC)
+            message(STATUS "Stack sanitizer enabled for target: ${target}")
+            target_compile_options(${target} PRIVATE /fsanitize=address /Zi)
+            target_link_options(${target} PRIVATE /fsanitize=address)
+        else()
+            message(WARNING "Stack sanitizer is not supported for this compiler")
+        endif()
+    endif()
+endfunction()

--- a/src/vanillapdf.benchmark/CMakeLists.txt
+++ b/src/vanillapdf.benchmark/CMakeLists.txt
@@ -40,6 +40,9 @@ add_executable(vanillapdf.benchmark
 # Configure default compilation parameters, strict warnings, config based definition for DEBUG/RELEASE, etc.
 vanillapdf_target_compile_defaults(vanillapdf.benchmark)
 
+# Optional stack sanitizer
+enable_stack_sanitizer_for_target(vanillapdf.benchmark)
+
 if(WIN32)
     # Copy DLL dependencies on windows to our build directory
     add_custom_command(

--- a/src/vanillapdf.test/CMakeLists.txt
+++ b/src/vanillapdf.test/CMakeLists.txt
@@ -47,6 +47,9 @@ add_executable(vanillapdf.test
 # Configure default compilation parameters, strict warnings, config based definition for DEBUG/RELEASE, etc.
 vanillapdf_target_compile_defaults(vanillapdf.test)
 
+# Optional stack sanitizer
+enable_stack_sanitizer_for_target(vanillapdf.test)
+
 if(WIN32)
     # Copy DLL dependencies on windows to our build directory
     add_custom_command(

--- a/src/vanillapdf.tools/CMakeLists.txt
+++ b/src/vanillapdf.tools/CMakeLists.txt
@@ -52,6 +52,9 @@ add_executable(vanillapdf.tools
 # Configure default compilation parameters, strict warnings, config based definition for DEBUG/RELEASE, etc.
 vanillapdf_target_compile_defaults(vanillapdf.tools)
 
+# Optional stack sanitizer
+enable_stack_sanitizer_for_target(vanillapdf.tools)
+
 if(WIN32)
 
     # Copy DLL dependencies on windows to our build directory

--- a/src/vanillapdf.unittest/CMakeLists.txt
+++ b/src/vanillapdf.unittest/CMakeLists.txt
@@ -45,6 +45,9 @@ add_executable(vanillapdf.unittest
 # Configure default compilation parameters, strict warnings, config based definition for DEBUG/RELEASE, etc.
 vanillapdf_target_compile_defaults(vanillapdf.unittest)
 
+# Optional stack sanitizer
+enable_stack_sanitizer_for_target(vanillapdf.unittest)
+
 if(WIN32)
     # Copy DLL dependencies on windows to our build directory
     add_custom_command(

--- a/src/vanillapdf/CMakeLists.txt
+++ b/src/vanillapdf/CMakeLists.txt
@@ -606,6 +606,9 @@ if(VANILLAPDF_ENABLE_COVERAGE)
     enable_coverage_for_target(vanillapdf)
 endif()
 
+# Optional stack sanitizer
+enable_stack_sanitizer_for_target(vanillapdf)
+
 # Update 30.04.2025
 # We have switched to vcpkg manifest mode, which makes sure all dependencies are automatically installed
 


### PR DESCRIPTION
## Summary
- add the stack sanitizer cmake option and enable it when explicitly requested
- document the option in README
- enable `VANILLAPDF_ENABLE_STACK_SANITIZER` for debug jobs in CI workflows
- refine workflow condition by preparing `CMAKE_ADDITIONAL_ARGS` when `build_type` is Debug

## Testing
- `cmake -B build -DVANILLAPDF_STANDALONE=OFF -DVANILLAPDF_ENABLE_TESTS=OFF -DVANILLAPDF_ENABLE_BENCHMARK=OFF` *(fails: Could NOT find JPEG)*


------
https://chatgpt.com/codex/tasks/task_e_68697a866840832b92b45fde31eaedd5