### PR TITLE
Fix memory leak in signature verification

### DIFF
--- a/src/vanillapdf/utils/license_info.cpp
+++ b/src/vanillapdf/utils/license_info.cpp
@@ -252,6 +252,12 @@ bool LicenseInfo::CheckSignature(
     const std::string& signing_certificate,
     MessageDigestAlgorithm digest_algorithm) {
 
+    // Make sure OpenSSL providers are initialized only once. Without this
+    // initialization OpenSSL may implicitly load fallback providers every
+    // time a certificate is parsed which results in small memory leaks
+    // reported by sanitizers.
+    MiscUtils::InitializeOpenSSL();
+
     auto signing_certificate_x509 = LoadCertificate(signing_certificate);
 
     SCOPE_GUARD([signing_certificate_x509]() { X509_free(signing_certificate_x509); });


### PR DESCRIPTION
## Summary
- ensure OpenSSL providers are initialized in `CheckSignature`

## Testing
- `cmake --preset linux-x64-gcc` *(fails: Could not bootstrap vcpkg)*
- `cmake -B build -DVANILLAPDF_STANDALONE=OFF -DVANILLAPDF_ENABLE_TESTS=OFF` *(fails: Could NOT find JPEG)*

------
https://chatgpt.com/codex/tasks/task_e_686cfcb6112c832b8a2e8c5ca989234f