### PR TITLE
Fix OpenSSL provider leak

### DIFF
--- a/include/files.cmake
+++ b/include/files.cmake
@@ -18,6 +18,7 @@ set(VANILLAPDF_INCLUDE_UTILS_HEADERS
     "${VANILLAPDF_SOLUTION_SOURCE_DIR}/include/vanillapdf/utils/c_library_info.h"
     "${VANILLAPDF_SOLUTION_SOURCE_DIR}/include/vanillapdf/utils/c_license_info.h"
     "${VANILLAPDF_SOLUTION_SOURCE_DIR}/include/vanillapdf/utils/c_logging.h"
+    "${VANILLAPDF_SOLUTION_SOURCE_DIR}/include/vanillapdf/utils/c_misc_utils.h"
     "${VANILLAPDF_SOLUTION_SOURCE_DIR}/include/vanillapdf/utils/c_message_digest_algorithm.h"
     "${VANILLAPDF_SOLUTION_SOURCE_DIR}/include/vanillapdf/utils/c_output_stream.h"
     "${VANILLAPDF_SOLUTION_SOURCE_DIR}/include/vanillapdf/utils/c_memory_buffer_output_stream.h"

--- a/include/vanillapdf/c_vanillapdf_api.h
+++ b/include/vanillapdf/c_vanillapdf_api.h
@@ -75,6 +75,7 @@
 #include "vanillapdf/utils/c_pdf_version.h"
 #include "vanillapdf/utils/c_library_info.h"
 #include "vanillapdf/utils/c_license_info.h"
+#include "vanillapdf/utils/c_misc_utils.h"
 #include "vanillapdf/utils/c_errors.h"
 #include "vanillapdf/utils/c_pkcs12_key.h"
 #include "vanillapdf/utils/c_signing_key.h"

--- a/include/vanillapdf/utils/c_misc_utils.h
+++ b/include/vanillapdf/utils/c_misc_utils.h
@@ -1,0 +1,32 @@
+#ifndef _C_MISC_UTILS_H
+#define _C_MISC_UTILS_H
+
+#include "vanillapdf/c_export.h"
+#include "vanillapdf/c_values.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+    /**
+    * \file c_misc_utils.h
+    * \brief Initialization and cleanup helpers for miscellaneous utilities.
+    */
+
+    /**
+    * \memberof MiscUtils
+    * @{ */
+
+    /** \brief Initialize OpenSSL providers and algorithms. */
+    VANILLAPDF_API error_type CALLING_CONVENTION MiscUtils_InitializeOpenSSL();
+
+    /** \brief Cleanup OpenSSL providers and algorithms. */
+    VANILLAPDF_API error_type CALLING_CONVENTION MiscUtils_CleanupOpenSSL();
+
+    /** @} */
+
+#ifdef __cplusplus
+};
+#endif
+
+#endif /* _C_MISC_UTILS_H */

--- a/src/vanillapdf.unittest/test_environment.cpp
+++ b/src/vanillapdf.unittest/test_environment.cpp
@@ -21,6 +21,8 @@ TestEnvironment::~TestEnvironment() {
 
 void TestEnvironment::SetUp() {
 
+    ASSERT_EQ(MiscUtils_InitializeOpenSSL(), VANILLAPDF_ERROR_SUCCESS);
+
     BufferHandle* license_buffer = nullptr;
     boolean_type is_valid = VANILLAPDF_RV_FALSE;
     
@@ -36,4 +38,5 @@ void TestEnvironment::SetUp() {
 
 void TestEnvironment::TearDown() {
     ASSERT_EQ(Logging_Shutdown(), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(MiscUtils_CleanupOpenSSL(), VANILLAPDF_ERROR_SUCCESS);
 }

--- a/src/vanillapdf/CMakeLists.txt
+++ b/src/vanillapdf/CMakeLists.txt
@@ -24,6 +24,7 @@ set(VANILLAPDF_C_IMPLEMENTATION_UTILS_SOURCES
     implementation/utils/c_library_info.cpp
     implementation/utils/c_license_info.cpp
     implementation/utils/c_logging.cpp
+    implementation/utils/c_misc_utils.cpp
     implementation/utils/c_output_stream.cpp
     implementation/utils/c_memory_buffer_output_stream.cpp
     implementation/utils/c_pkcs12_key.cpp

--- a/src/vanillapdf/implementation/utils/c_misc_utils.cpp
+++ b/src/vanillapdf/implementation/utils/c_misc_utils.cpp
@@ -1,0 +1,21 @@
+#include "precompiled.h"
+#include "utils/misc_utils.h"
+
+#include "vanillapdf/utils/c_misc_utils.h"
+#include "implementation/c_helper.h"
+
+using namespace vanillapdf;
+
+VANILLAPDF_API error_type CALLING_CONVENTION MiscUtils_InitializeOpenSSL() {
+    try {
+        MiscUtils::InitializeOpenSSL();
+        return VANILLAPDF_ERROR_SUCCESS;
+    } CATCH_VANILLAPDF_EXCEPTIONS
+}
+
+VANILLAPDF_API error_type CALLING_CONVENTION MiscUtils_CleanupOpenSSL() {
+    try {
+        MiscUtils::CleanupOpenSSL();
+        return VANILLAPDF_ERROR_SUCCESS;
+    } CATCH_VANILLAPDF_EXCEPTIONS
+}

--- a/src/vanillapdf/utils/misc_utils.cpp
+++ b/src/vanillapdf/utils/misc_utils.cpp
@@ -16,6 +16,13 @@
 
 namespace vanillapdf {
 
+#if defined(VANILLAPDF_HAVE_OPENSSL) && OPENSSL_VERSION_MAJOR >= 3
+static std::mutex g_openssl_lock;
+static bool g_openssl_initialized = false;
+static OSSL_PROVIDER* g_legacy_provider = nullptr;
+static OSSL_PROVIDER* g_default_provider = nullptr;
+#endif
+
 BufferPtr MiscUtils::ToBase64(const Buffer& value) {
 
     auto memory_bio = BIO_new(BIO_s_mem());
@@ -255,26 +262,23 @@ void MiscUtils::InitializeOpenSSL() {
 
 #if defined(VANILLAPDF_HAVE_OPENSSL)
 
-    static bool initialized = false;
-    if (initialized) {
+    if (g_openssl_initialized) {
         return;
     }
-
-    static std::mutex openssl_lock;
-    std::lock_guard<std::mutex> lock(openssl_lock);
-    if (initialized) {
+    std::lock_guard<std::mutex> lock(g_openssl_lock);
+    if (g_openssl_initialized) {
         return;
     }
 
 #if OPENSSL_VERSION_MAJOR >= 3
 
-    auto legacy_provider = OSSL_PROVIDER_load(nullptr, "legacy");
-    if (legacy_provider == nullptr) {
+    g_legacy_provider = OSSL_PROVIDER_load(nullptr, "legacy");
+    if (g_legacy_provider == nullptr) {
         throw GeneralException("Failed to initialize legacy OSSL provider, " + GetLastOpensslError());
     }
 
-    auto default_provider = OSSL_PROVIDER_load(nullptr, "default");
-    if (default_provider == nullptr) {
+    g_default_provider = OSSL_PROVIDER_load(nullptr, "default");
+    if (g_default_provider == nullptr) {
         throw GeneralException("Failed to initialize default OSSL provider, " + GetLastOpensslError());
     }
 
@@ -282,7 +286,11 @@ void MiscUtils::InitializeOpenSSL() {
 
     OpenSSL_add_all_algorithms();
 
-    initialized = true;
+    g_openssl_initialized = true;
+
+#if OPENSSL_VERSION_MAJOR >= 3
+    std::atexit(MiscUtils::CleanupOpenSSL);
+#endif /* OPENSSL_VERSION_MAJOR >= 3 */
 
 #else
 
@@ -330,6 +338,39 @@ std::string MiscUtils::GetLastOpensslError() {
 #else
 
     throw NotSupportedException("This library was compiled without OpenSSL support");
+
+#endif
+
+}
+
+void MiscUtils::CleanupOpenSSL() {
+
+#if defined(VANILLAPDF_HAVE_OPENSSL) && OPENSSL_VERSION_MAJOR >= 3
+
+    if (!g_openssl_initialized) {
+        return;
+    }
+    std::lock_guard<std::mutex> lock(g_openssl_lock);
+    if (!g_openssl_initialized) {
+        return;
+    }
+
+    if (g_legacy_provider != nullptr) {
+        OSSL_PROVIDER_unload(g_legacy_provider);
+        g_legacy_provider = nullptr;
+    }
+
+    if (g_default_provider != nullptr) {
+        OSSL_PROVIDER_unload(g_default_provider);
+        g_default_provider = nullptr;
+    }
+
+    OPENSSL_cleanup();
+    g_openssl_initialized = false;
+
+#else
+
+    // Ignore when OpenSSL support is disabled
 
 #endif
 

--- a/src/vanillapdf/utils/misc_utils.h
+++ b/src/vanillapdf/utils/misc_utils.h
@@ -31,6 +31,7 @@ public:
     static bool CaseInsensitiveCompare(const std::string& left, const std::string& right);
 
     static void InitializeOpenSSL();
+    static void CleanupOpenSSL();
     static std::string GetLastOpensslError();
 
     template <typename T>


### PR DESCRIPTION
## Summary
- guard OpenSSL initialization and cleanup with double-checked locking

## Testing
- `cmake --preset linux-x64-gcc -DVANILLAPDF_ENABLE_TESTS=ON` *(fails: could not bootstrap vcpkg)*

------
https://chatgpt.com/codex/tasks/task_e_686cfbe61868832bb935a1c7642584ee