### PR TITLE
Fix dictionary test memory leak

### DIFF
--- a/src/vanillapdf.unittest/objects_test.cpp
+++ b/src/vanillapdf.unittest/objects_test.cpp
@@ -268,6 +268,7 @@ TEST(DictionaryObject, InsertOverwrite) {
     }
 
     // Release the check objects
+    ASSERT_EQ(Buffer_Release(check_string_buffer), VANILLAPDF_ERROR_SUCCESS);
     ASSERT_EQ(LiteralStringObject_Release(check_literal_string_object), VANILLAPDF_ERROR_SUCCESS);
     ASSERT_EQ(StringObject_Release(check_string_object), VANILLAPDF_ERROR_SUCCESS);
     ASSERT_EQ(Object_Release(check_base_object), VANILLAPDF_ERROR_SUCCESS);


### PR DESCRIPTION
## Summary
- release the buffer returned by `LiteralStringObject_GetValue` in `DictionaryObject.TryFind` unit test

## Testing
- `cmake --preset linux-x64-gcc` *(fails: could not bootstrap vcpkg)*

------
https://chatgpt.com/codex/tasks/task_e_686d23359470832ba11231693b218fce