### PR TITLE
Fix disposing of found object in TryFind test

### DIFF
--- a/src/vanillapdf.unittest/objects_test.cpp
+++ b/src/vanillapdf.unittest/objects_test.cpp
@@ -316,6 +316,9 @@ TEST(DictionaryObject, TryFind) {
     EXPECT_EQ(object_found, true);
     EXPECT_EQ(found_object_reference, author_base_object);
 
+    // Release the found object reference
+    ASSERT_EQ(Object_Release(found_object_reference), VANILLAPDF_ERROR_SUCCESS);
+
     // Release the original inserted objects
     ASSERT_EQ(Object_Release(author_base_object), VANILLAPDF_ERROR_SUCCESS);
     ASSERT_EQ(StringObject_Release(author_string_object), VANILLAPDF_ERROR_SUCCESS);


### PR DESCRIPTION
## Summary
- ensure TryFind test releases found object reference and add comment

## Testing
- `cmake --preset linux-x64-gcc` *(fails: Could not bootstrap vcpkg)*
- `cmake --build --preset linux-x64-gcc` *(fails: could not find CMAKE_PROJECT_NAME)*
- `ctest --preset linux-x64-gcc` *(fails: No tests were found)*


------
https://chatgpt.com/codex/tasks/task_e_686d28527c9c832ba5cceaa1956eee5e