### PR TITLE
Fix buffer cleanup in CheckBaseFontRangeValue

### DIFF
--- a/src/vanillapdf.unittest/main.cpp
+++ b/src/vanillapdf.unittest/main.cpp
@@ -50,6 +50,7 @@ void CheckBaseFontRangeValue(BaseFontRangeHandle* font_range, const std::vector<
     }
 
     ASSERT_EQ(Buffer_Release(request_data), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Buffer_Release(response_data), VANILLAPDF_ERROR_SUCCESS);
 }
 
 TEST(BaseFontRange, IncrementMapping) {


### PR DESCRIPTION
## Summary
- release `response_data` buffer in the CheckBaseFontRangeValue helper test

## Testing
- `cmake --preset linux-x64-gcc` *(fails: Could not bootstrap vcpkg)*

------
https://chatgpt.com/codex/tasks/task_e_686d369bae48832bb06dbf859ea32df7