### PR TITLE
Fix PKCS12 cleanup in unit test

### DIFF
--- a/src/vanillapdf.unittest/document_test.cpp
+++ b/src/vanillapdf.unittest/document_test.cpp
@@ -357,6 +357,10 @@ TEST(Document, Sign) {
     ASSERT_EQ(File_Release(destination_file), VANILLAPDF_ERROR_SUCCESS);
     ASSERT_EQ(InputOutputStream_Release(destination_io_stream), VANILLAPDF_ERROR_SUCCESS);
 
+    ASSERT_EQ(SigningKey_Release(signing_key), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(PKCS12Key_Release(signature_pkcs12_key), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Buffer_Release(signing_key_data), VANILLAPDF_ERROR_SUCCESS);
+
     ASSERT_EQ(DocumentSignatureSettings_Release(signature_settings), VANILLAPDF_ERROR_SUCCESS);
     ASSERT_EQ(Document_Release(source_memory_document), VANILLAPDF_ERROR_SUCCESS);
     ASSERT_EQ(File_Release(source_memory_file), VANILLAPDF_ERROR_SUCCESS);


### PR DESCRIPTION
## Summary
- ensure SigningKey and PKCS12 key are released in Document.Sign unit test
- release the temporary buffer used for the certificate

## Testing
- `cmake --preset linux-x64-gcc` *(fails: Could not bootstrap vcpkg)*
- `ctest --preset linux-x64-gcc --output-on-failure` *(fails: No tests were found)*

------
https://chatgpt.com/codex/tasks/task_e_686d3645fd9c832b93f60dabb74e79c1