### PR TITLE
Fix memory leak in PKCS12 parsing

### DIFF
--- a/src/vanillapdf/utils/pkcs12_key.cpp
+++ b/src/vanillapdf/utils/pkcs12_key.cpp
@@ -24,6 +24,7 @@ public:
     explicit PKCS12KeyImpl(const std::string& path);
     PKCS12KeyImpl(const std::string& path, const Buffer& password);
     PKCS12KeyImpl(const Buffer& data, const Buffer& password);
+    ~PKCS12KeyImpl();
 
     // IEncryptionKey
     BufferPtr Decrypt(const Buffer& data);
@@ -458,6 +459,10 @@ void PKCS12Key::PKCS12KeyImpl::SignCleanup() {
     }
 
 #endif
+}
+
+PKCS12Key::PKCS12KeyImpl::~PKCS12KeyImpl() {
+    SignCleanup();
 }
 
 } // vanillapdf


### PR DESCRIPTION
## Summary
- call `SignCleanup` from the PKCS12 implementation destructor

## Testing
- `ctest --preset linux-x64-gcc`

------
https://chatgpt.com/codex/tasks/task_e_686d3d092644832bb611e6621a1bd881