### PR TITLE
Fix AutoSubscribe move semantics

### DIFF
--- a/.github/workflows/nightly-check.yml
+++ b/.github/workflows/nightly-check.yml
@@ -100,6 +100,30 @@ jobs:
             platform: linux/arm64
             preset: linux-arm64-gcc
 
+          - name: fedora.41-x64
+            os: ubuntu-24.04
+            image: ghcr.io/vanillapdf/vanillapdf-fedora-amd64:41
+            platform: linux/amd64
+            preset: linux-x64-gcc
+
+          - name: fedora.41-arm64
+            os: ubuntu-24.04-arm
+            image: ghcr.io/vanillapdf/vanillapdf-fedora-arm64v8:41
+            platform: linux/arm64
+            preset: linux-arm64-gcc
+
+          - name: fedora.42-x64
+            os: ubuntu-24.04
+            image: ghcr.io/vanillapdf/vanillapdf-fedora-amd64:42
+            platform: linux/amd64
+            preset: linux-x64-gcc
+
+          - name: fedora.42-arm64
+            os: ubuntu-24.04-arm
+            image: ghcr.io/vanillapdf/vanillapdf-fedora-arm64v8:42
+            platform: linux/arm64
+            preset: linux-arm64-gcc
+
     container:
       image: ${{ matrix.config.image }}
       options: --platform=${{ matrix.config.platform }}

--- a/src/vanillapdf/utils/util.h
+++ b/src/vanillapdf/utils/util.h
@@ -2,6 +2,7 @@
 #define _UTIL_H
 
 #include <memory>
+#include <utility>
 
 namespace vanillapdf {
 
@@ -62,38 +63,44 @@ template <
 class AutoSubscribe {
 public:
     explicit AutoSubscribe(const T& observable, U* observer) : _observable(observable), _observer(observer) {
-        _observable->Subscribe(_observer);
+        if (_observer) {
+            _observable->Subscribe(_observer);
+        }
     }
 
     AutoSubscribe(const AutoSubscribe& rhs) = delete;
 
-    AutoSubscribe(AutoSubscribe&& rhs) {
-
-        // Unsubscribe the original objects
-        _observable->Unsubscribe(_observer);
-
-        // Move the data from the object that is being moved
-        _observable = rhs._observable;
-        _observer = rhs._observer;
-
-        // Subscribe to new objects
-        _observable->Subscribe(_observer);
+    // Moving simply transfers ownership of the subscription. The observer
+    // remains subscribed to the same observable and the moved-from instance no
+    // longer unsubscribes on destruction.
+    AutoSubscribe(AutoSubscribe&& rhs) noexcept
+        : _observable(std::move(rhs._observable)),
+          _observer(rhs._observer) {
+        rhs._observer = nullptr;
     }
 
     AutoSubscribe& operator=(const AutoSubscribe& rhs) = delete;
 
-    AutoSubscribe& operator=(AutoSubscribe&& rhs) {
-        AutoSubscribe(rhs).swap(*this);
+    AutoSubscribe& operator=(AutoSubscribe&& rhs) noexcept {
+        AutoSubscribe(std::move(rhs)).swap(*this);
         return *this;
     }
 
+    void swap(AutoSubscribe& rhs) noexcept {
+        using std::swap;
+        swap(_observable, rhs._observable);
+        swap(_observer, rhs._observer);
+    }
+
     ~AutoSubscribe() {
-        _observable->Unsubscribe(_observer);
+        if (_observer) {
+            _observable->Unsubscribe(_observer);
+        }
     }
 
 private:
-    T _observable;
-    U* _observer;
+    T _observable{};
+    U* _observer{nullptr};
 };
 
 #if (__cplusplus < 201402L) && !defined(COMPILER_MICROSOFT_VISUAL_STUDIO)


### PR DESCRIPTION
## Summary
- fix missing `swap` in `AutoSubscribe`
- handle move constructor/assignment safely
- include `<utility>`
- clarify why move operations don't resubscribe
- include Fedora 41 & 42 containers in nightly checks

## Testing
- `cmake --preset linux-x64-gcc` *(fails: vcpkg install requires internet)*

------
https://chatgpt.com/codex/tasks/task_e_687170dc0458832b83516b7db1d4afe8