### PR TITLE
Update installation docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,15 +37,57 @@
 
 ## 📦 Installation Options
 
+Detailed setup instructions are available in the
+[installation guide](https://vanillapdf.github.io/vanillapdf/page_install.html).
+
 ### 🛠 Build from Source
 
 ```bash
 git clone https://github.com/vanillapdf/vanillapdf.git
 cd vanillapdf
-cmake --preset windows-x64-msvc-release
-cmake --build --preset windows-x64-msvc-release
-ctest --preset windows-x64-msvc-release  # Optional
+
+# Fetch the bundled vcpkg submodule (skip if VCPKG_ROOT points to an existing install)
+git submodule sync --recursive
+git submodule update --init --recursive
 ```
+
+To see which build presets are available run:
+
+```bash
+cmake --list-presets
+```
+
+```
+Available configure presets:
+  "windows-x86-ninja"
+  "windows-x64-ninja"
+  "default"
+  "linux-x64-gcc"
+  "linux-arm64-gcc"
+  "linux-x64-clang"
+  "linux-arm64-clang"
+  "linux-x64-musl"
+  "linux-arm64-musl"
+  "linux-arm-musl"
+  "macos-x64"
+  "macos-arm64"
+  "android-arm64"
+  "android-armv7"
+  "android-x86"
+  "android-x86_64"
+```
+
+Choose the preset matching your platform:
+
+```bash
+cmake --preset windows-x64-msvc-17
+cmake --build --preset windows-x64-msvc-17
+ctest --preset windows-x64-msvc-17  # Optional
+```
+
+The repository includes `external/vcpkg` as a submodule. Initializing the
+submodule is required unless you provide `VCPKG_ROOT` or pass your own
+`-DCMAKE_TOOLCHAIN_FILE` pointing to a preinstalled vcpkg.
 
 ### Install Dependencies with vcpkg
 
@@ -85,49 +127,8 @@ corresponding packages will not be installed by vcpkg and CMake will
 search for them on your system instead. The GTest and Benchmark options
 are only available when tests or benchmarks are enabled.
 
-### Building Debian Packages
-
-On Ubuntu systems you can install all required dependencies with apt and
-produce a `.deb` package directly:
-
-```bash
-sudo apt-get update
-sudo apt-get install libssl-dev libjpeg-turbo8 libjpeg-turbo8-dev zlib1g-dev
-
-cmake --preset linux-x64-gcc -DCMAKE_BUILD_TYPE=Release \
-  -DVANILLAPDF_STANDALONE=ON \
-  -DVANILLAPDF_EXTERNAL_OPENSSL=ON \
-  -DVANILLAPDF_EXTERNAL_JPEG=ON \
-  -DVANILLAPDF_EXTERNAL_OPENJPEG=OFF \
-  -DVANILLAPDF_EXTERNAL_ZLIB=ON \
-  -DVANILLAPDF_EXTERNAL_SPDLOG=OFF \
-  -DVANILLAPDF_EXTERNAL_NLOHMANN_JSON=OFF \
-  -DVANILLAPDF_ENABLE_TESTS=ON -DVANILLAPDF_EXTERNAL_GTEST=OFF \
-  -DVANILLAPDF_ENABLE_BENCHMARK=ON -DVANILLAPDF_EXTERNAL_BENCHMARK=OFF
-cmake --build --preset linux-x64-gcc --target package
-```
-
-### Building Homebrew Packages
-
-On macOS systems you can use Homebrew to install the required
-dependencies and generate a package:
-
-```bash
-brew install openssl@3 jpeg-turbo zlib
-
-cmake --preset macos-arm64 -DCMAKE_BUILD_TYPE=Release \
-  -DVANILLAPDF_STANDALONE=ON \
-  -DVANILLAPDF_EXTERNAL_OPENSSL=ON \
-  -DVANILLAPDF_EXTERNAL_JPEG=ON \
-  -DVANILLAPDF_EXTERNAL_OPENJPEG=OFF \
-  -DVANILLAPDF_EXTERNAL_ZLIB=ON \
-  -DVANILLAPDF_EXTERNAL_SPDLOG=OFF \
-  -DVANILLAPDF_EXTERNAL_NLOHMANN_JSON=OFF \
-  -DVANILLAPDF_ENABLE_TESTS=ON -DVANILLAPDF_EXTERNAL_GTEST=OFF \
-  -DVANILLAPDF_ENABLE_BENCHMARK=ON -DVANILLAPDF_EXTERNAL_BENCHMARK=OFF
-
-cmake --build --preset macos-arm64 --target package
-```
+For instructions on generating Debian or Homebrew packages see the
+[packaging guide](https://vanillapdf.github.io/vanillapdf/page_packaging.html).
 
 ---
 

--- a/doc/src/input/install.dox
+++ b/doc/src/input/install.dox
@@ -2,22 +2,106 @@
 \page page_install Installation
 \tableofcontents
 
-Installation packages comes in two variants. Either a self-installing archive or compressed package.
+This page describes how to obtain and build Vanilla.PDF along with its
+dependencies.
 
-Self-installing archives are very easy to install, as they use the standard installation process for each platform.
+\section install_vcpkg Install with vcpkg
 
-\section install_compressed Installing compressed package
-
-Compressed package for UNIX does not include package dependencies runtime, which has to be installed separately.
-
-For debian, the installation would require:
-
-\code{.unparsed}
-apt-get install libjpeg9
-apt-get install libssl1.0.0
-apt-get install zlib1g
+The simplest way to get started is using
+<a href="https://github.com/microsoft/vcpkg">vcpkg</a>:
+\code{.bash}
+vcpkg install vanillapdf
 \endcode
 
-After the package contents are extracted, the application should be ready to run.
+After installation point CMake at your vcpkg instance:
+\code{.bash}
+cmake -S . -B build \
+  -DCMAKE_TOOLCHAIN_FILE=<vcpkg-root>/scripts/buildsystems/vcpkg.cmake
+cmake --build build
+\endcode
+
+\section install_source Build from source
+
+Clone the repository and initialize the bundled vcpkg submodule:
+\code{.bash}
+git clone https://github.com/vanillapdf/vanillapdf.git
+cd vanillapdf
+# fetch submodules for bundled vcpkg
+git submodule sync --recursive
+git submodule update --init --recursive
+\endcode
+
+List the available build presets:
+\code{.bash}
+cmake --list-presets
+\endcode
+
+\code{.unparsed}
+Available configure presets:
+  "windows-x86-ninja"
+  "windows-x64-ninja"
+  "default"
+  "linux-x64-gcc"
+  "linux-arm64-gcc"
+  "linux-x64-clang"
+  "linux-arm64-clang"
+  "linux-x64-musl"
+  "linux-arm64-musl"
+  "linux-arm-musl"
+  "macos-x64"
+  "macos-arm64"
+  "android-arm64"
+  "android-armv7"
+  "android-x86"
+  "android-x86_64"
+\endcode
+
+Configure and build with the preset matching your platform:
+\code{.bash}
+cmake --preset windows-x64-msvc-17
+cmake --build --preset windows-x64-msvc-17
+ctest --preset windows-x64-msvc-17  # optional
+\endcode
+
+If you already have vcpkg installed, set the `VCPKG_ROOT` environment variable
+or pass your own `-DCMAKE_TOOLCHAIN_FILE` to use it instead of the submodule.
+
+\section install_external_vcpkg Using your own vcpkg instance
+
+You may manage vcpkg yourself and install the required packages manually:
+\code{.bash}
+git clone https://github.com/microsoft/vcpkg.git
+cd vcpkg
+./bootstrap-vcpkg.sh
+./vcpkg install openssl libjpeg-turbo
+\endcode
+
+Configure Vanilla.PDF with the vcpkg toolchain:
+\code{.bash}
+cmake -S . -B build/vcpkg \
+  -DCMAKE_TOOLCHAIN_FILE=</path/to/vcpkg>/scripts/buildsystems/vcpkg.cmake
+cmake --build build/vcpkg
+\endcode
+
+\section install_system Using system dependencies
+
+If some libraries should come from your package manager or Conan rather than
+vcpkg, enable the matching `VANILLAPDF_EXTERNAL_*` options when configuring:
+\code{.bash}
+cmake -B build \
+  -DVANILLAPDF_EXTERNAL_OPENSSL=ON \
+  -DVANILLAPDF_EXTERNAL_JPEG=ON
+cmake --build build
+\endcode
+
+Options exist for OpenSSL, libjpeg-turbo, openjpeg, zlib, spdlog,
+nlohmann-json, GTest and Google Benchmark. When these are set, the
+corresponding packages will not be installed by vcpkg and CMake will search for
+them on your system instead.
+
+\section install_packages Building packages
+
+Instructions for creating Debian or Homebrew packages are provided in the
+\ref page_packaging "packaging guide".
 
 */

--- a/doc/src/input/overview.dox
+++ b/doc/src/input/overview.dox
@@ -6,6 +6,7 @@ Getting started:
 
 <ul>
 <li>Section \ref page_install discusses how to download and install Vanilla.PDF for your platform
+<li>Section \ref page_packaging explains how to create installable packages
 <li>Section \ref page_interface_overview explains basic premises the whole interface is built upon
 <li>Section \ref page_pdf_course contains a very brief description of the PDF file format
 <li>Section \ref page_licensing tells how the product is licensed

--- a/doc/src/input/packaging.dox
+++ b/doc/src/input/packaging.dox
@@ -1,0 +1,52 @@
+/*!
+\page page_packaging Packaging
+\tableofcontents
+
+This page details how to generate installable packages for Vanilla.PDF on
+common platforms.
+
+\section packaging_debian Debian packages
+
+On Debian based systems the project ships CMake presets to produce a `.deb`
+package. First install the required dependencies:
+\code{.bash}
+sudo apt-get update
+sudo apt-get install libssl-dev libjpeg-turbo8 libjpeg-turbo8-dev zlib1g-dev
+\endcode
+
+Then build the package:
+\code{.bash}
+cmake --preset linux-x64-gcc -DCMAKE_BUILD_TYPE=Release \
+  -DVANILLAPDF_STANDALONE=ON \
+  -DVANILLAPDF_EXTERNAL_OPENSSL=ON \
+  -DVANILLAPDF_EXTERNAL_JPEG=ON \
+  -DVANILLAPDF_EXTERNAL_OPENJPEG=OFF \
+  -DVANILLAPDF_EXTERNAL_ZLIB=ON \
+  -DVANILLAPDF_EXTERNAL_SPDLOG=OFF \
+  -DVANILLAPDF_EXTERNAL_NLOHMANN_JSON=OFF \
+  -DVANILLAPDF_ENABLE_TESTS=ON -DVANILLAPDF_EXTERNAL_GTEST=OFF \
+  -DVANILLAPDF_ENABLE_BENCHMARK=ON -DVANILLAPDF_EXTERNAL_BENCHMARK=OFF
+cmake --build --preset linux-x64-gcc --target package
+\endcode
+
+\section packaging_homebrew Homebrew packages
+
+On macOS you can generate a Homebrew formula using the following commands:
+\code{.bash}
+brew install openssl@3 jpeg-turbo zlib
+
+cmake --preset macos-arm64 -DCMAKE_BUILD_TYPE=Release \
+  -DVANILLAPDF_STANDALONE=ON \
+  -DVANILLAPDF_EXTERNAL_OPENSSL=ON \
+  -DVANILLAPDF_EXTERNAL_JPEG=ON \
+  -DVANILLAPDF_EXTERNAL_OPENJPEG=OFF \
+  -DVANILLAPDF_EXTERNAL_ZLIB=ON \
+  -DVANILLAPDF_EXTERNAL_SPDLOG=OFF \
+  -DVANILLAPDF_EXTERNAL_NLOHMANN_JSON=OFF \
+  -DVANILLAPDF_ENABLE_TESTS=ON -DVANILLAPDF_EXTERNAL_GTEST=OFF \
+  -DVANILLAPDF_ENABLE_BENCHMARK=ON -DVANILLAPDF_EXTERNAL_BENCHMARK=OFF
+
+cmake --build --preset macos-arm64 --target package
+\endcode
+
+*/


### PR DESCRIPTION
## Summary
- mention git submodule init for vcpkg and show available presets
- highlight vcpkg install option in documentation
- link packaging page from install docs

## Testing
- `ctest -N`


------
https://chatgpt.com/codex/tasks/task_e_68715bdcdc94832bb8a8e5ea810c21aa