### PR TITLE
Centralize minimum CMake version requirement

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,7 @@
-# Require minimum CMAKE version
-
-# Update 29.04.2025
-# Minimum version 3.21 is due vcpkg manifest mode.
-# Minimum version 3.28 is due CMakePresets.json file version 8.
-cmake_minimum_required(VERSION 3.28)
+# Configure the minimum supported CMake version in a single place.
+# The actual version number is defined in `cmake/minimum_version.cmake`.
+include(cmake/minimum_version.cmake)
+cmake_minimum_required(VERSION ${VANILLAPDF_MINIMUM_CMAKE_VERSION})
 
 # Vanilla.PDF is a c++ library built using c++17 standard
 # In order to make it portable across all platforms we strictly adhere to the standard by enforcing it and disabling the extensions

--- a/cmake/docs.cmake
+++ b/cmake/docs.cmake
@@ -1,7 +1,8 @@
 # Generate documentation configuration
 # Usage: cmake -P cmake/docs.cmake
 
-cmake_minimum_required(VERSION 3.15)
+include(${CMAKE_CURRENT_LIST_DIR}/minimum_version.cmake)
+cmake_minimum_required(VERSION ${VANILLAPDF_MINIMUM_CMAKE_VERSION})
 
 # The script assumes it is run from the project root
 set(CMAKE_CURRENT_SOURCE_DIR "${CMAKE_CURRENT_LIST_DIR}/..")

--- a/cmake/minimum_version.cmake
+++ b/cmake/minimum_version.cmake
@@ -1,0 +1,4 @@
+# Minimum supported CMake version for Vanilla.PDF.
+# CMakePresets.json uses file API version 8, which requires CMake 3.28 or newer.
+# Update this file when the project requires a newer CMake release.
+set(VANILLAPDF_MINIMUM_CMAKE_VERSION 3.28)

--- a/cmake/nuget.cmake
+++ b/cmake/nuget.cmake
@@ -1,4 +1,5 @@
-cmake_minimum_required(VERSION 3.15)
+include(${CMAKE_CURRENT_LIST_DIR}/minimum_version.cmake)
+cmake_minimum_required(VERSION ${VANILLAPDF_MINIMUM_CMAKE_VERSION})
 
 # Configure NuGet project templates. This script can be included from a regular
 # build or executed directly via `cmake -P`. In both cases


### PR DESCRIPTION
## Summary
- define minimum supported CMake version in a single script
- reference the centralized version from the main build and utility scripts

## Testing
- `cmake -P cmake/nuget.cmake`
- `cmake -P cmake/docs.cmake`
- `cmake --version`


------
https://chatgpt.com/codex/tasks/task_e_68947704ea40832bb10e553ed4e77ffa