### PR TITLE
Sanitize nuget version names for dependabot

### DIFF
--- a/.github/workflows/nightly-nuget.yml
+++ b/.github/workflows/nightly-nuget.yml
@@ -41,8 +41,11 @@ jobs:
         run: |
           # Prefer GITHUB_HEAD_REF (for PRs or workflow_dispatch), fallback to ref name
           BRANCH_NAME="${GITHUB_HEAD_REF:-${GITHUB_REF##*/}}"
-          # Clean it up for suffix use (replace '/' and '.' with '-', lowercase)
-          CLEAN_NAME=$(echo "$BRANCH_NAME" | tr '/.' '-' | tr '[:upper:]' '[:lower:]')
+          # Lowercase, replace any non [0-9a-z-] with '-', collapse repeats, and trim edges
+          LOWER=$(echo "$BRANCH_NAME" | tr '[:upper:]' '[:lower:]')
+          CLEAN_NAME=$(echo "$LOWER" | sed -E 's/[^0-9a-z-]+/-/g; s/-{2,}/-/g; s/^-+//; s/-+$//')
+          # Fallback in the unlikely case the cleaned name is empty
+          if [ -z "$CLEAN_NAME" ]; then CLEAN_NAME="branch"; fi
           DATE=$(date +'%Y%m%d')
           echo "nightly_suffix=-nightly-${CLEAN_NAME}-${DATE}" >> "$GITHUB_OUTPUT"
 

--- a/cmake/version.cmake
+++ b/cmake/version.cmake
@@ -11,5 +11,24 @@ if(NOT DEFINED VANILLAPDF_VERSION_BUILD_SUFFIX)
     set(VANILLAPDF_VERSION_BUILD_SUFFIX "")
 endif()
 
+# Sanitize the build suffix to be a valid SemVer pre-release (NuGet) fragment
+# Allow only [0-9A-Za-z.-], collapse multiple dashes, and trim leading/trailing dashes
+if(NOT "${VANILLAPDF_VERSION_BUILD_SUFFIX}" STREQUAL "")
+    set(_suffix "${VANILLAPDF_VERSION_BUILD_SUFFIX}")
+    # Replace any invalid characters with '-'
+    string(REGEX REPLACE "[^0-9A-Za-z\.-]+" "-" _suffix "${_suffix}")
+    # Collapse consecutive dashes
+    string(REGEX REPLACE "-{2,}" "-" _suffix "${_suffix}")
+    # Trim leading and trailing dashes
+    string(REGEX REPLACE "^-+" "" _suffix "${_suffix}")
+    string(REGEX REPLACE "-+$" "" _suffix "${_suffix}")
+    # Guard against empty result
+    if("${_suffix}" STREQUAL "")
+        set(VANILLAPDF_VERSION_BUILD_SUFFIX "-prerelease")
+    else()
+        set(VANILLAPDF_VERSION_BUILD_SUFFIX "-${_suffix}")
+    endif()
+endif()
+
 # Compose full version string for configuration files
 set(VANILLAPDF_VERSION "${VANILLAPDF_VERSION_MAJOR}.${VANILLAPDF_VERSION_MINOR}.${VANILLAPDF_VERSION_PATCH}${VANILLAPDF_VERSION_BUILD_SUFFIX}")


### PR DESCRIPTION
Improve NuGet version suffix sanitization to prevent build failures from invalid branch names.

Dependabot branch names, like `dependabot/github_actions-actions-download-artifact-5`, contain characters (e.g., `_`, `/`) that are not valid in NuGet version strings, causing build errors such as `'...is not a valid version string.'` This PR adds robust sanitization in both the GitHub Actions workflow and the CMake build configuration to ensure valid NuGet versions are always generated.

---
<a href="https://cursor.com/background-agent?bcId=bc-f5c67630-a97f-4f60-9b49-ae116552aec8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f5c67630-a97f-4f60-9b49-ae116552aec8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

