### PR TITLE
ci: use windows-2025 runner

### DIFF
--- a/.github/workflows/build-nuget.yml
+++ b/.github/workflows/build-nuget.yml
@@ -126,7 +126,7 @@ jobs:
 
   build-windows:
     name: ${{ matrix.config.name }}
-    runs-on: windows-latest
+    runs-on: windows-2025
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Summary
- use Windows Server 2025 image for NuGet builds

## Testing
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release` *(fails: vcpkg install failed and build tools missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a04c90afe8832b8f9f217d4e397878