### PR TITLE
Use imported JPEG target to avoid library version mismatch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,9 @@ include(cmake/vcpkg_init.cmake)
 # Define main solution
 project(vanillapdf)
 
+# Prefer config-mode packages over Find modules when searching for dependencies
+set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ON)
+
 # Prefer files in CMAKE_MODULE_PATH over shipped ones in module directory
 # In the future, they may possibly add conflicting search modules
 # so let's be cautious and prevent it!

--- a/src/vanillapdf.unittest/CMakeLists.txt
+++ b/src/vanillapdf.unittest/CMakeLists.txt
@@ -71,6 +71,16 @@ set(VANILLAPDF_UNITTEST_LIBS
 
 target_link_libraries(vanillapdf.unittest PRIVATE ${VANILLAPDF_UNITTEST_LIBS})
 
+# Ensure runtime loader can locate built dependencies next to the executable
+if(APPLE)
+    set(_vanillapdf_ut_rpath "@executable_path")
+else()
+    set(_vanillapdf_ut_rpath "$ORIGIN")
+endif()
+set_target_properties(vanillapdf.unittest PROPERTIES
+    INSTALL_RPATH "${_vanillapdf_ut_rpath}"
+    BUILD_RPATH "${_vanillapdf_ut_rpath}")
+
 # In case we have the dynamic link configuration add specific definitions
 if(BUILD_SHARED_LIBS)
     target_compile_definitions(vanillapdf.unittest PRIVATE VANILLAPDF_CONFIGURATION_DLL)

--- a/src/vanillapdf/CMakeLists.txt
+++ b/src/vanillapdf/CMakeLists.txt
@@ -635,11 +635,7 @@ endif()
 if (VANILLAPDF_EXTERNAL_JPEG)
     find_package(JPEG MODULE REQUIRED)
 else ()
-    find_package(JPEG REQUIRED
-        PATHS ${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/share/jpeg
-        NO_DEFAULT_PATH
-        NO_SYSTEM_ENVIRONMENT_PATH
-        NO_CMAKE_SYSTEM_PATH)
+    find_package(JPEG REQUIRED)
 endif()
 
 if (VANILLAPDF_EXTERNAL_OPENJPEG)

--- a/src/vanillapdf/CMakeLists.txt
+++ b/src/vanillapdf/CMakeLists.txt
@@ -635,10 +635,9 @@ endif()
 if (VANILLAPDF_EXTERNAL_JPEG)
     find_package(JPEG MODULE REQUIRED)
 else ()
-    find_package(JPEG CONFIG REQUIRED
+    find_package(JPEG MODULE REQUIRED
                  PATHS
                      "${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}"
-                     "${VCPKG_ROOT}/installed/${VCPKG_TARGET_TRIPLET}"
                  NO_DEFAULT_PATH
                  NO_SYSTEM_ENVIRONMENT_PATH)
 endif()

--- a/src/vanillapdf/CMakeLists.txt
+++ b/src/vanillapdf/CMakeLists.txt
@@ -632,7 +632,15 @@ else ()
     find_package(ZLIB REQUIRED)
 endif()
 
-find_package(libjpeg-turbo CONFIG REQUIRED)
+if (VANILLAPDF_EXTERNAL_JPEG)
+    find_package(JPEG MODULE REQUIRED)
+else ()
+    find_package(JPEG CONFIG REQUIRED
+        PATHS ${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/share/jpeg
+        NO_DEFAULT_PATH
+        NO_SYSTEM_ENVIRONMENT_PATH
+        NO_CMAKE_SYSTEM_PATH)
+endif()
 
 if (VANILLAPDF_EXTERNAL_OPENJPEG)
     find_package(OpenJPEG MODULE REQUIRED)
@@ -668,9 +676,9 @@ else (OPENSSL_FOUND)
     message(WARNING "Compiling without OpenSSL support. Work with encrypted document will be prohibited")
 endif (OPENSSL_FOUND)
 
-target_link_libraries(vanillapdf PRIVATE $<IF:$<TARGET_EXISTS:libjpeg-turbo::turbojpeg>,libjpeg-turbo::turbojpeg,libjpeg-turbo::turbojpeg-static>)
+target_link_libraries(vanillapdf PRIVATE JPEG::JPEG)
 target_compile_definitions(vanillapdf PRIVATE -DVANILLAPDF_HAVE_JPEG)
-message(STATUS "libjpeg-turbo was found")
+message(STATUS "JPEG library was found")
 
 if (ZLIB_FOUND)
     target_include_directories(vanillapdf PRIVATE ${ZLIB_INCLUDE_DIRS})
@@ -781,11 +789,11 @@ if(WIN32)
     endif (OPENSSL_FOUND)
 
     # libjpeg dependent libraries
-    if (TARGET libjpeg-turbo::turbojpeg OR TARGET libjpeg-turbo::turbojpeg-static)
+    if (TARGET JPEG::JPEG)
 
         # Find dll runtime binary file
         find_file(LIBJPEG_RUNTIME
-            NAMES turbojpeg.dll
+            NAMES jpeg62.dll
             PATHS ${VANILLPDF_BINARY_DIR}
         )
 

--- a/src/vanillapdf/CMakeLists.txt
+++ b/src/vanillapdf/CMakeLists.txt
@@ -635,7 +635,7 @@ endif()
 if (VANILLAPDF_EXTERNAL_JPEG)
     find_package(JPEG MODULE REQUIRED)
 else ()
-    find_package(JPEG CONFIG REQUIRED
+    find_package(JPEG REQUIRED
         PATHS ${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/share/jpeg
         NO_DEFAULT_PATH
         NO_SYSTEM_ENVIRONMENT_PATH

--- a/src/vanillapdf/CMakeLists.txt
+++ b/src/vanillapdf/CMakeLists.txt
@@ -518,8 +518,17 @@ add_library(vanillapdf
     ${VANILLAPDF_RESOURCE_FILES}
 )
 
+# Ensure runtime loader can locate dependent libraries next to this target
+if(APPLE)
+    set(_vanillapdf_rpath "@loader_path")
+else()
+    set(_vanillapdf_rpath "$ORIGIN")
+endif()
+
 set_target_properties(vanillapdf PROPERTIES
-  PREFIX "lib"
+    PREFIX "lib"
+    INSTALL_RPATH "${_vanillapdf_rpath}"
+    BUILD_RPATH "${_vanillapdf_rpath}"
 )
 
 # Add precompiled header to speed up the compilation process

--- a/src/vanillapdf/CMakeLists.txt
+++ b/src/vanillapdf/CMakeLists.txt
@@ -635,11 +635,7 @@ endif()
 if (VANILLAPDF_EXTERNAL_JPEG)
     find_package(JPEG MODULE REQUIRED)
 else ()
-    find_package(JPEG MODULE REQUIRED
-                 PATHS
-                     "${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}"
-                 NO_DEFAULT_PATH
-                 NO_SYSTEM_ENVIRONMENT_PATH)
+    find_package(JPEG CONFIG REQUIRED)
 endif()
 
 if (VANILLAPDF_EXTERNAL_OPENJPEG)

--- a/src/vanillapdf/CMakeLists.txt
+++ b/src/vanillapdf/CMakeLists.txt
@@ -673,18 +673,12 @@ else (OPENSSL_FOUND)
 endif (OPENSSL_FOUND)
 
 if (JPEG_FOUND)
-    target_include_directories(vanillapdf PRIVATE ${JPEG_INCLUDE_DIR})
-
-    # This is not yet supported on all linux CMake distributions
-    # set(VANILLAPDF_LIBS JPEG::JPEG ${VANILLAPDF_LIBS})
-
-    target_link_libraries(vanillapdf PRIVATE ${JPEG_LIBRARIES})
+    target_link_libraries(vanillapdf PRIVATE JPEG::JPEG)
     target_compile_definitions(vanillapdf PRIVATE -DVANILLAPDF_HAVE_JPEG)
-
     message(STATUS "JPEG library ${JPEG_VERSION} was found")
-else (JPEG_FOUND)
+else()
     message(WARNING "Compiling without JPEG support. JPEG compression will become unavailable")
-endif (JPEG_FOUND)
+endif()
 
 if (ZLIB_FOUND)
     target_include_directories(vanillapdf PRIVATE ${ZLIB_INCLUDE_DIRS})

--- a/src/vanillapdf/CMakeLists.txt
+++ b/src/vanillapdf/CMakeLists.txt
@@ -635,7 +635,12 @@ endif()
 if (VANILLAPDF_EXTERNAL_JPEG)
     find_package(JPEG MODULE REQUIRED)
 else ()
-    find_package(JPEG REQUIRED)
+    find_package(JPEG CONFIG REQUIRED
+                 PATHS
+                     "${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}"
+                     "${VCPKG_ROOT}/installed/${VCPKG_TARGET_TRIPLET}"
+                 NO_DEFAULT_PATH
+                 NO_SYSTEM_ENVIRONMENT_PATH)
 endif()
 
 if (VANILLAPDF_EXTERNAL_OPENJPEG)

--- a/src/vanillapdf/CMakeLists.txt
+++ b/src/vanillapdf/CMakeLists.txt
@@ -632,11 +632,7 @@ else ()
     find_package(ZLIB REQUIRED)
 endif()
 
-if (VANILLAPDF_EXTERNAL_JPEG)
-    find_package(JPEG MODULE REQUIRED)
-else ()
-    find_package(JPEG CONFIG REQUIRED)
-endif()
+find_package(libjpeg-turbo CONFIG REQUIRED)
 
 if (VANILLAPDF_EXTERNAL_OPENJPEG)
     find_package(OpenJPEG MODULE REQUIRED)
@@ -672,13 +668,9 @@ else (OPENSSL_FOUND)
     message(WARNING "Compiling without OpenSSL support. Work with encrypted document will be prohibited")
 endif (OPENSSL_FOUND)
 
-if (JPEG_FOUND)
-    target_link_libraries(vanillapdf PRIVATE JPEG::JPEG)
-    target_compile_definitions(vanillapdf PRIVATE -DVANILLAPDF_HAVE_JPEG)
-    message(STATUS "JPEG library ${JPEG_VERSION} was found")
-else()
-    message(WARNING "Compiling without JPEG support. JPEG compression will become unavailable")
-endif()
+target_link_libraries(vanillapdf PRIVATE $<IF:$<TARGET_EXISTS:libjpeg-turbo::turbojpeg>,libjpeg-turbo::turbojpeg,libjpeg-turbo::turbojpeg-static>)
+target_compile_definitions(vanillapdf PRIVATE -DVANILLAPDF_HAVE_JPEG)
+message(STATUS "libjpeg-turbo was found")
 
 if (ZLIB_FOUND)
     target_include_directories(vanillapdf PRIVATE ${ZLIB_INCLUDE_DIRS})
@@ -789,7 +781,7 @@ if(WIN32)
     endif (OPENSSL_FOUND)
 
     # libjpeg dependent libraries
-    if (JPEG_FOUND)
+    if (TARGET libjpeg-turbo::turbojpeg OR TARGET libjpeg-turbo::turbojpeg-static)
 
         # Find dll runtime binary file
         find_file(LIBJPEG_RUNTIME
@@ -799,13 +791,13 @@ if(WIN32)
 
         if (NOT EXISTS ${LIBJPEG_RUNTIME})
             # message(FATAL_ERROR "JPEG support is enabled, but the LIBJPEG_RUNTIME does not exist")
-        endif(NOT EXISTS ${LIBJPEG_RUNTIME})
-        
+        endif()
+
         # message(STATUS "LIBJPEG runtime was found at ${LIBJPEG_RUNTIME}")
-        
+
         # Install dependency into output package
         # install(FILES ${LIBJPEG_RUNTIME} DESTINATION bin)
-    endif (JPEG_FOUND)
+    endif()
 
     # zlib dependent libraries
     if (ZLIB_FOUND)


### PR DESCRIPTION
## Summary
- link against JPEG via its imported target to ensure matching headers and libraries

## Testing
- `apt-get update` *(fails: The repository ... is not signed)*
- `cmake --preset default` *(fails: vcpkg install failed; CMake unable to find build program "Ninja")*

------
https://chatgpt.com/codex/tasks/task_e_68c67c9122fc832babacce81c8cf9f94