### PR TITLE
Fix vcpkg cache configuration in CI workflows

### DIFF
--- a/.github/workflows/sanity-check.yml
+++ b/.github/workflows/sanity-check.yml
@@ -46,7 +46,6 @@ concurrency:
 env:
   VCPKG_ROOT: external/vcpkg
   VCPKG_DISABLE_METRICS: 1 # vcpkg is by default sending build metrics, we do not need it here
-  VCPKG_BINARY_SOURCES: "clear;files,${{ github.workspace }}/external/vcpkg/bincache,readwrite"
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
@@ -96,14 +95,15 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Cache vcpkg installed
+      - name: Cache vcpkg
         uses: actions/cache@v4
         with:
           path: |
             build/${{ matrix.config.preset }}/vcpkg_installed
             external/vcpkg/downloads
-            external/vcpkg/bincache
-          key: vcpkg-${{ runner.os }}-${{ matrix.config.preset }}-${{ hashFiles('vcpkg.json', 'cmake/overlays/*.cmake') }}
+            external/vcpkg/buildtrees
+            external/vcpkg/packages
+          key: vcpkg-${{ runner.os }}-${{ matrix.config.preset }}-${{ hashFiles('vcpkg.json') }}
           restore-keys: |
             vcpkg-${{ runner.os }}-${{ matrix.config.preset }}-
             vcpkg-${{ runner.os }}-
@@ -148,14 +148,15 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Cache vcpkg installed
+      - name: Cache vcpkg
         uses: actions/cache@v4
         with:
           path: |
             build/${{ matrix.config.preset }}/vcpkg_installed
             external/vcpkg/downloads
-            external/vcpkg/bincache
-          key: vcpkg-${{ runner.os }}-${{ matrix.config.preset }}-${{ hashFiles('vcpkg.json', 'cmake/overlays/*.cmake') }}
+            external/vcpkg/buildtrees
+            external/vcpkg/packages
+          key: vcpkg-${{ runner.os }}-${{ matrix.config.preset }}-${{ hashFiles('vcpkg.json') }}
           restore-keys: |
             vcpkg-${{ runner.os }}-${{ matrix.config.preset }}-
             vcpkg-${{ runner.os }}-
@@ -198,14 +199,15 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Cache vcpkg installed
+      - name: Cache vcpkg
         uses: actions/cache@v4
         with:
           path: |
             build/${{ matrix.config.preset }}/vcpkg_installed
             external/vcpkg/downloads
-            external/vcpkg/bincache
-          key: vcpkg-${{ runner.os }}-${{ matrix.config.preset }}-${{ hashFiles('vcpkg.json', 'cmake/overlays/*.cmake') }}
+            external/vcpkg/buildtrees
+            external/vcpkg/packages
+          key: vcpkg-${{ runner.os }}-${{ matrix.config.preset }}-${{ hashFiles('vcpkg.json') }}
           restore-keys: |
             vcpkg-${{ runner.os }}-${{ matrix.config.preset }}-
             vcpkg-${{ runner.os }}-


### PR DESCRIPTION
## Summary
- Fixed vcpkg cache configuration issues causing constant dependency rebuilds
- Removed problematic VCPKG_BINARY_SOURCES pointing to non-existent bincache directory
- Added missing cache paths for buildtrees and packages directories
- Simplified cache key to improve cache hit rates

## Root Cause Analysis
The CI pipelines were rebuilding vcpkg dependencies on every run because:

1. **Missing cache directories**: The cache configuration included `external/vcpkg/bincache` which doesn't exist until vcpkg creates it
2. **Missing build artifacts**: Key directories like `buildtrees` and `packages` weren't being cached
3. **Overly specific cache keys**: Including `cmake/overlays/*.cmake` in the hash made cache keys change unnecessarily

## Changes Made
- Removed `VCPKG_BINARY_SOURCES` environment variable (was pointing to non-existent directory)
- Added `external/vcpkg/buildtrees` and `external/vcpkg/packages` to cache paths
- Simplified cache key to only hash `vcpkg.json` (removed overlay files that rarely change)
- Updated cache step name for clarity

## Test Plan
- [x] Verify YAML syntax is correct
- [x] Confirm all three platform jobs (Linux, Windows, macOS) are updated consistently
- [ ] Monitor CI runs to confirm vcpkg dependencies are now cached properly
- [ ] Verify cache hit rates improve in subsequent runs

This should significantly reduce CI build times by properly caching vcpkg artifacts across builds.

🤖 Generated with [Claude Code](https://claude.ai/code)