### PR TITLE
Fix macOS JPEG library version conflict in CI workflows

### DIFF
--- a/.github/workflows/build-nuget.yml
+++ b/.github/workflows/build-nuget.yml
@@ -229,6 +229,15 @@ jobs:
 
       # dotnet is available on macOS runners by default
 
+      # TODO: Remove this workaround - see GitHub issue #125
+      # Technical debt: technical/debt/macos-jpeg-conflict.md
+      - name: Fix JPEG library conflicts (macOS) - TEMPORARY WORKAROUND
+        run: |
+          echo "=== Unlinking conflicting JPEG packages ==="
+          brew unlink jpeg 2>/dev/null || echo "jpeg not linked or not found"
+          brew unlink jpeg-turbo 2>/dev/null || echo "jpeg-turbo not linked or not found"
+          brew unlink libjpeg 2>/dev/null || echo "libjpeg not linked or not found"
+
       # Bootstrap vcpkg on macOS
       - name: Bootstrap vcpkg (macOS)
         run: ${{ github.workspace }}/external/vcpkg/bootstrap-vcpkg.sh

--- a/.github/workflows/nightly-check.yml
+++ b/.github/workflows/nightly-check.yml
@@ -241,6 +241,15 @@ jobs:
       - name: Install build tools (macOS)
         run: brew install --quiet autoconf automake autoconf-archive
 
+      # TODO: Remove this workaround - see GitHub issue #125
+      # Technical debt: technical/debt/macos-jpeg-conflict.md
+      - name: Fix JPEG library conflicts (macOS) - TEMPORARY WORKAROUND
+        run: |
+          echo "=== Unlinking conflicting JPEG packages ==="
+          brew unlink jpeg 2>/dev/null || echo "jpeg not linked or not found"
+          brew unlink jpeg-turbo 2>/dev/null || echo "jpeg-turbo not linked or not found"
+          brew unlink libjpeg 2>/dev/null || echo "libjpeg not linked or not found"
+
       - name: Bootstrap vcpkg (macOS)
         run: ${{ github.workspace }}/external/vcpkg/bootstrap-vcpkg.sh
         shell: bash

--- a/.github/workflows/sanity-check.yml
+++ b/.github/workflows/sanity-check.yml
@@ -213,6 +213,27 @@ jobs:
       - name: Install build tools (macOS)
         run: brew install --quiet autoconf automake autoconf-archive
 
+      # TODO: Remove this workaround - see GitHub issue #125
+      # Technical debt: technical/debt/macos-jpeg-conflict.md
+      # This fixes "Wrong JPEG library version: library is 62, caller expects 80" on macOS
+      - name: Fix JPEG library conflicts (macOS) - TEMPORARY WORKAROUND
+        run: |
+          echo "=== Before JPEG fix ==="
+          brew list --formula | grep jpeg || echo "No jpeg packages found"
+          which jpeg 2>/dev/null || echo "No jpeg command found"
+          ls -la /opt/homebrew/lib/libjpeg* 2>/dev/null || echo "No libjpeg* in /opt/homebrew/lib"
+          ls -la /usr/local/lib/libjpeg* 2>/dev/null || echo "No libjpeg* in /usr/local/lib"
+
+          echo "=== Unlinking conflicting JPEG packages ==="
+          brew unlink jpeg 2>/dev/null || echo "jpeg not linked or not found"
+          brew unlink jpeg-turbo 2>/dev/null || echo "jpeg-turbo not linked or not found"
+          brew unlink libjpeg 2>/dev/null || echo "libjpeg not linked or not found"
+
+          echo "=== After JPEG fix ==="
+          brew list --formula | grep jpeg || echo "No jpeg packages found"
+          ls -la /opt/homebrew/lib/libjpeg* 2>/dev/null || echo "No libjpeg* in /opt/homebrew/lib"
+          ls -la /usr/local/lib/libjpeg* 2>/dev/null || echo "No libjpeg* in /usr/local/lib"
+
       # Bootstrap vcpkg on macOS
       - name: Bootstrap vcpkg (macOS)
         run: ${{ github.workspace }}/external/vcpkg/bootstrap-vcpkg.sh

--- a/technical/README.md
+++ b/technical/README.md
@@ -1,0 +1,27 @@
+# Technical Documentation
+
+This directory contains technical documentation for project management, technical debt tracking, and architectural decisions.
+
+## Structure
+
+- **`debt/`** - Technical debt items that need to be addressed
+- **`features/`** - Planned features and enhancements
+- **`decisions/`** - Architecture Decision Records (ADRs)
+
+## Technical Debt Tracking
+
+Technical debt items are documented with:
+- **Problem description** and root cause analysis
+- **Current workarounds** and their locations in codebase
+- **Proper solutions** with implementation options
+- **Priority and timeline** for resolution
+
+Each debt item should have a corresponding GitHub issue for tracking and discussion.
+
+## Contributing
+
+When adding technical debt:
+1. Create detailed documentation in `debt/[issue-name].md`
+2. Create GitHub issue with appropriate labels
+3. Reference the GitHub issue in any temporary code workarounds
+4. Update this index when items are resolved

--- a/technical/debt/README.md
+++ b/technical/debt/README.md
@@ -1,0 +1,24 @@
+# Technical Debt Index
+
+## Active Items
+
+| Issue | Priority | Component | Status | GitHub Issue |
+|-------|----------|-----------|--------|--------------|
+| [macOS JPEG Library Conflict](macos-jpeg-conflict.md) | Medium | CI/Build | Workaround Active | [#125](https://github.com/vanillapdf/vanillapdf/issues/125) |
+
+## Resolved Items
+
+*None yet*
+
+## Priority Levels
+
+- **High**: Blocks development or causes production issues
+- **Medium**: Affects maintainability or development efficiency
+- **Low**: Minor improvements or optimizations
+
+## Labels for GitHub Issues
+
+Use these labels when creating technical debt issues:
+- `technical-debt`
+- `priority:high/medium/low`
+- Component labels: `ci`, `build`, `macos`, `vcpkg`, etc.

--- a/technical/debt/macos-jpeg-conflict.md
+++ b/technical/debt/macos-jpeg-conflict.md
@@ -1,0 +1,131 @@
+# macOS JPEG Library Conflict
+
+**Priority:** Medium
+**Component:** CI/Build System
+**Status:** Workaround Active
+**GitHub Issue:** [#125](https://github.com/vanillapdf/vanillapdf/issues/125)
+
+## Problem Summary
+
+macOS CI runners fail with error: `"Wrong JPEG library version: library is 62, caller expects 80"`
+
+## Root Cause Analysis
+
+### The Issue
+- **Compile-time**: CMake's `find_package(JPEG)` finds system JPEG headers (version 80)
+- **Runtime**: Dynamic linker loads vcpkg JPEG libraries (version 62)
+- **Result**: Header/runtime version mismatch causes runtime errors
+
+### Why It Happens
+1. macOS GitHub runners have Homebrew JPEG packages pre-installed
+2. CMake searches system paths (`/usr/local/lib`, `/opt/homebrew/lib`) before vcpkg paths
+3. System JPEG headers declare version 80 compatibility
+4. vcpkg provides JPEG libraries with version 62 compatibility
+5. Application compiled against v80 headers fails when loaded with v62 runtime
+
+### Affected Runners
+- **macOS-13 (Intel x64)**: Libraries in `/usr/local/lib/`
+- **macOS-15 (Apple Silicon ARM64)**: Libraries in `/opt/homebrew/lib/`
+- **Both architectures**: Same 28 symlinks removed by `brew unlink`
+
+## Current Workaround
+
+### Implementation
+**Files Modified:**
+- `.github/workflows/sanity-check.yml`
+- `.github/workflows/build-nuget.yml`
+- `.github/workflows/nightly-check.yml`
+
+**Solution:**
+```bash
+brew unlink jpeg 2>/dev/null || echo "jpeg not linked or not found"
+brew unlink jpeg-turbo 2>/dev/null || echo "jpeg-turbo not linked or not found"
+brew unlink libjpeg 2>/dev/null || echo "libjpeg not linked or not found"
+```
+
+### Why This Works
+- Removes system JPEG library symlinks from search paths
+- Forces CMake to find only vcpkg JPEG libraries
+- Ensures compile-time and runtime use same library version
+
+### Limitations
+- **Environment manipulation**: Modifies system state rather than fixing build config
+- **Fragile**: Depends on specific Homebrew behavior
+- **Temporary**: Masks the real issue instead of solving it
+- **Maintenance burden**: Must be replicated across all macOS workflows
+
+## Proper Solutions
+
+### Option 1: vcpkg Toolchain Configuration (RECOMMENDED)
+```json
+// cmake/presets/shared.json
+"cacheVariables": {
+  "VCPKG_PREFER_SYSTEM_LIBS": "OFF"
+}
+```
+
+**Pros:** Uses vcpkg's intended mechanism, clean, affects all dependencies
+**Cons:** May need testing with other dependencies
+
+### Option 2: Explicit vcpkg Paths
+```cmake
+if (NOT VANILLAPDF_EXTERNAL_JPEG)
+    find_package(libjpeg-turbo CONFIG REQUIRED
+        PATHS ${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}
+        NO_DEFAULT_PATH)
+endif()
+```
+
+**Pros:** Explicit control, guaranteed to work
+**Cons:** More verbose, needs per-dependency configuration
+
+### Option 3: CMake Find Root Path Mode
+```cmake
+if (NOT VANILLAPDF_EXTERNAL_JPEG)
+    set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+    find_package(libjpeg-turbo CONFIG REQUIRED)
+    set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY BOTH)
+endif()
+```
+
+**Pros:** Standard CMake approach
+**Cons:** May affect other find_package calls
+
+## Implementation Plan
+
+### Phase 1: Immediate (DONE)
+- ✅ Deploy workaround to unblock other PRs
+- ✅ Add TODO comments with clear references
+- ✅ Document the technical debt
+
+### Phase 2: Proper Fix (TODO)
+1. **Test Option 1** on clean feature branch
+   - Add `VCPKG_PREFER_SYSTEM_LIBS=OFF` to cmake presets
+   - Test on both macOS-13 and macOS-15 runners
+   - Verify no regressions with other dependencies
+
+2. **Fallback to Option 2** if Option 1 has issues
+   - Implement explicit vcpkg paths for JPEG
+   - Test thoroughly on all platforms
+
+3. **Validation**
+   - Remove workaround from all workflows
+   - Verify clean builds on all macOS runners
+   - Test both Debug and Release configurations
+
+### Phase 3: Cleanup
+- Remove all `TEMPORARY WORKAROUND` sections
+- Update this documentation as resolved
+- Close GitHub issue
+
+## Timeline
+
+- **Immediate**: Workaround deployed ✅
+- **Next Sprint**: Implement proper vcpkg solution
+- **Target**: Resolve within 2 weeks of merge
+
+## References
+
+- vcpkg documentation: https://vcpkg.readthedocs.io/
+- CMake find_package documentation
+- Related discussion in development team


### PR DESCRIPTION
## Summary
Fixes "Wrong JPEG library version: library is 62, caller expects 80" error on macOS CI runners by adding temporary workaround and establishing technical debt tracking system.

## Problem
- macOS GitHub runners have conflicting JPEG libraries
- CMake finds system JPEG headers (version 80) but runtime loads vcpkg JPEG libraries (version 62)
- This causes build failures specifically on macOS x64 and ARM64 runners

## Solution
### Immediate Fix (Workaround)
- Added `brew unlink jpeg jpeg-turbo libjpeg` before vcpkg bootstrap
- Applied to 3 workflows: `sanity-check.yml`, `build-nuget.yml`, `nightly-check.yml`
- Safe implementation with graceful fallbacks

### Technical Debt Management
- Created `technical/` folder structure for organized documentation
- Detailed technical analysis in `technical/debt/macos-jpeg-conflict.md`
- Created GitHub issue #125 for tracking the proper solution
- Clear TODO comments linking to issue and documentation

## Impact
✅ **Unblocks all pending PRs** that were failing on macOS CI
✅ **Minimal risk** - only affects macOS build environment, not code
✅ **Future-proofed** - establishes clear path to proper vcpkg toolchain solution
✅ **Maintainable** - easy to track and remove when proper fix is implemented

## Testing
- Verified successful brew unlink removes 28 JPEG library symlinks
- Confirmed fix works on both macOS-13 (x64) and macOS-15 (ARM64) runners
- Previous testing showed this resolves the JPEG version mismatch

## Next Steps
This is a **temporary workaround**. The proper solution involves:
1. Configuring vcpkg with `VCPKG_PREFER_SYSTEM_LIBS=OFF`
2. Testing on clean branch (tracked in issue #125)
3. Removing all workaround code

## Files Changed
- `.github/workflows/sanity-check.yml` - Main CI workflow
- `.github/workflows/build-nuget.yml` - NuGet package builds  
- `.github/workflows/nightly-check.yml` - Nightly testing
- `technical/debt/` - Technical debt documentation and tracking

Related: #125