### PR TITLE
ci: Standardize vcpkg cache configuration across all workflows

### DIFF
--- a/.github/workflows/build-nuget.yml
+++ b/.github/workflows/build-nuget.yml
@@ -88,6 +88,8 @@ jobs:
           path: |
             build/${{ matrix.config.preset }}/vcpkg_installed
             external/vcpkg/downloads
+            external/vcpkg/buildtrees
+            external/vcpkg/packages
             external/vcpkg/bincache
           key: vcpkg-${{ runner.os }}-${{ matrix.config.preset }}-${{ hashFiles('vcpkg.json', 'cmake/overlays/*.cmake') }}
           restore-keys: |
@@ -154,6 +156,8 @@ jobs:
           path: |
             build/${{ matrix.config.preset }}/vcpkg_installed
             external/vcpkg/downloads
+            external/vcpkg/buildtrees
+            external/vcpkg/packages
             external/vcpkg/bincache
           key: vcpkg-${{ runner.os }}-${{ matrix.config.preset }}-${{ hashFiles('vcpkg.json', 'cmake/overlays/*.cmake') }}
           restore-keys: |
@@ -221,6 +225,8 @@ jobs:
           path: |
             build/${{ matrix.config.preset }}/vcpkg_installed
             external/vcpkg/downloads
+            external/vcpkg/buildtrees
+            external/vcpkg/packages
             external/vcpkg/bincache
           key: vcpkg-${{ runner.os }}-${{ matrix.config.preset }}-${{ hashFiles('vcpkg.json', 'cmake/overlays/*.cmake') }}
           restore-keys: |

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -84,6 +84,8 @@ jobs:
         path: |
           build/**/vcpkg_installed
           external/vcpkg/downloads
+          external/vcpkg/buildtrees
+          external/vcpkg/packages
           external/vcpkg/bincache
         key: codeql-vcpkg-${{ runner.os }}-${{ hashFiles('vcpkg.json', 'cmake/overlays/*.cmake') }}
         restore-keys: |

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -52,6 +52,24 @@ jobs:
       - name: Install tools
         run: sudo apt-get install -y lcov gcovr
 
+      - name: Cache vcpkg
+        uses: actions/cache@v4
+        with:
+          path: |
+            build/linux-x64-gcc/vcpkg_installed
+            external/vcpkg/downloads
+            external/vcpkg/buildtrees
+            external/vcpkg/packages
+          key: vcpkg-${{ runner.os }}-linux-x64-gcc-coverage-${{ hashFiles('vcpkg.json', 'cmake/overlays/*.cmake') }}
+          restore-keys: |
+            vcpkg-${{ runner.os }}-linux-x64-gcc-coverage-
+            vcpkg-${{ runner.os }}-linux-x64-gcc-
+            vcpkg-${{ runner.os }}-
+
+      - name: Bootstrap vcpkg
+        run: ./external/vcpkg/bootstrap-vcpkg.sh
+        shell: bash
+
       - name: Configure CMake with coverage
         run: cmake --preset linux-x64-gcc -DVANILLAPDF_ENABLE_COVERAGE=ON -DCMAKE_BUILD_TYPE=Debug
 

--- a/.github/workflows/nightly-check.yml
+++ b/.github/workflows/nightly-check.yml
@@ -139,6 +139,8 @@ jobs:
           path: |
             build/${{ matrix.config.preset }}/vcpkg_installed
             external/vcpkg/downloads
+            external/vcpkg/buildtrees
+            external/vcpkg/packages
             external/vcpkg/bincache
           key: vcpkg-${{ runner.os }}-${{ matrix.config.preset }}-${{ hashFiles('vcpkg.json', 'cmake/overlays/*.cmake') }}
           restore-keys: |
@@ -188,6 +190,8 @@ jobs:
           path: |
             build/${{ matrix.config.preset }}/vcpkg_installed
             external/vcpkg/downloads
+            external/vcpkg/buildtrees
+            external/vcpkg/packages
             external/vcpkg/bincache
           key: vcpkg-${{ runner.os }}-${{ matrix.config.preset }}-${{ hashFiles('vcpkg.json', 'cmake/overlays/*.cmake') }}
           restore-keys: |
@@ -232,6 +236,8 @@ jobs:
           path: |
             build/${{ matrix.config.preset }}/vcpkg_installed
             external/vcpkg/downloads
+            external/vcpkg/buildtrees
+            external/vcpkg/packages
             external/vcpkg/bincache
           key: vcpkg-${{ runner.os }}-${{ matrix.config.preset }}-${{ hashFiles('vcpkg.json', 'cmake/overlays/*.cmake') }}
           restore-keys: |

--- a/.github/workflows/sanity-check.yml
+++ b/.github/workflows/sanity-check.yml
@@ -103,7 +103,7 @@ jobs:
             external/vcpkg/downloads
             external/vcpkg/buildtrees
             external/vcpkg/packages
-          key: vcpkg-${{ runner.os }}-${{ matrix.config.preset }}-${{ hashFiles('vcpkg.json') }}
+          key: vcpkg-${{ runner.os }}-${{ matrix.config.preset }}-${{ hashFiles('vcpkg.json', 'cmake/overlays/*.cmake') }}
           restore-keys: |
             vcpkg-${{ runner.os }}-${{ matrix.config.preset }}-
             vcpkg-${{ runner.os }}-
@@ -156,7 +156,7 @@ jobs:
             external/vcpkg/downloads
             external/vcpkg/buildtrees
             external/vcpkg/packages
-          key: vcpkg-${{ runner.os }}-${{ matrix.config.preset }}-${{ hashFiles('vcpkg.json') }}
+          key: vcpkg-${{ runner.os }}-${{ matrix.config.preset }}-${{ hashFiles('vcpkg.json', 'cmake/overlays/*.cmake') }}
           restore-keys: |
             vcpkg-${{ runner.os }}-${{ matrix.config.preset }}-
             vcpkg-${{ runner.os }}-
@@ -207,7 +207,7 @@ jobs:
             external/vcpkg/downloads
             external/vcpkg/buildtrees
             external/vcpkg/packages
-          key: vcpkg-${{ runner.os }}-${{ matrix.config.preset }}-${{ hashFiles('vcpkg.json') }}
+          key: vcpkg-${{ runner.os }}-${{ matrix.config.preset }}-${{ hashFiles('vcpkg.json', 'cmake/overlays/*.cmake') }}
           restore-keys: |
             vcpkg-${{ runner.os }}-${{ matrix.config.preset }}-
             vcpkg-${{ runner.os }}-

--- a/.github/workflows/stack-sanitizer.yml
+++ b/.github/workflows/stack-sanitizer.yml
@@ -40,6 +40,8 @@ jobs:
           path: |
             build/${{ env.BUILD_PRESET }}/vcpkg_installed
             external/vcpkg/downloads
+            external/vcpkg/buildtrees
+            external/vcpkg/packages
             external/vcpkg/bincache
           key: vcpkg-${{ runner.os }}-${{ env.BUILD_PRESET }}-sanitizer-${{ hashFiles('vcpkg.json', 'cmake/overlays/*.cmake') }}
           restore-keys: |


### PR DESCRIPTION
## Summary
- Standardize vcpkg cache configuration across all CI workflows following the recent sanity-check improvements
- Add complete vcpkg cache paths (buildtrees, packages) to all workflows that were missing them
- Ensure consistent cache key patterns including both vcpkg.json and cmake/overlays/*.cmake
- Add specialized cache keys for coverage and sanitizer builds to prevent cache conflicts

## Changes Made
- **coverage.yml**: Added vcpkg caching with coverage-specific cache key
- **nightly-check.yml**: Added missing buildtrees and packages cache paths  
- **stack-sanitizer.yml**: Added missing buildtrees and packages cache paths
- **sanity-check.yml**: Added cmake/overlays/*.cmake to cache key
- **build-nuget.yml**: Added missing buildtrees and packages cache paths
- **codeql.yml**: Added missing buildtrees and packages cache paths

## Test plan
- [ ] Verify workflows run successfully with improved caching
- [ ] Check that cache hit rates improve for vcpkg dependencies
- [ ] Ensure no cache conflicts between different build configurations

🤖 Generated with [Claude Code](https://claude.ai/code)