### PR TITLE
Update vcpkg to latest tag 2025.08.27

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -41,5 +41,5 @@
             ]
         }
     },
-    "builtin-baseline": "dd3097e305afa53f7b4312371f62058d2e665320"
+    "builtin-baseline": "120deac3062162151622ca4860575a33844ba10b"
 }


### PR DESCRIPTION
## Summary
- Updated vcpkg submodule from version 2025.07.25 to 2025.08.27
- Updated builtin-baseline in vcpkg.json to match the new commit hash
- Ensures project uses the latest vcpkg dependency versions and bug fixes

## Test plan
- [x] Verify project builds successfully with updated vcpkg
- [x] Run tests to ensure no regressions with new dependency versions
- [x] Check that all vcpkg features still work correctly

🤖 Generated with [Claude Code](https://claude.ai/code)