### PR TITLE
feat: Add Visual Studio 2026 (MSVC 18) CMake presets

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,6 +95,9 @@ Common presets include:
 - `windows-x64-msvc-17` / `windows-x86-msvc-17` - Windows with Visual Studio 2022 (dynamic CRT)
 - `windows-x64-msvc-17-static` / `windows-x86-msvc-17-static` - Windows with Visual Studio 2022 (static CRT)
 - `windows-x64-msvc-17-static-md` / `windows-x86-msvc-17-static-md` - Windows with Visual Studio 2022 (static libs, dynamic CRT)
+- `windows-x64-msvc-18` / `windows-x86-msvc-18` - Windows with Visual Studio 2026 (dynamic CRT)
+- `windows-x64-msvc-18-static` / `windows-x86-msvc-18-static` - Windows with Visual Studio 2026 (static CRT)
+- `windows-x64-msvc-18-static-md` / `windows-x86-msvc-18-static-md` - Windows with Visual Studio 2026 (static libs, dynamic CRT)
 - `linux-x64-gcc` / `linux-arm64-gcc` - Linux with GCC
 - `linux-x64-clang` / `linux-arm64-clang` - Linux with Clang
 - `linux-x64-musl` / `linux-arm64-musl` / `linux-arm-musl` - Linux with musl libc
@@ -109,16 +112,16 @@ cmake --build --preset windows-x64-msvc-17
 
 #### Windows Build Notes
 
-Windows presets use Visual Studio 2022 generator and automatically configure:
+Windows presets use Visual Studio generators and automatically configure:
 - CRT linking based on preset variant:
-  - Standard presets (`windows-x*-msvc-17`): Dynamic CRT (default)
-  - Static presets (`windows-x*-msvc-17-static`): Static CRT (`VANILLAPDF_USE_STATIC_CRT=ON`)
-  - Static-MD presets (`windows-x*-msvc-17-static-md`): Static libs + dynamic CRT
+  - Standard presets (`windows-x*-msvc-17`, `windows-x*-msvc-18`): Dynamic CRT (default)
+  - Static presets (`windows-x*-msvc-17-static`, `windows-x*-msvc-18-static`): Static CRT (`VANILLAPDF_USE_STATIC_CRT=ON`)
+  - Static-MD presets (`windows-x*-msvc-17-static-md`, `windows-x*-msvc-18-static-md`): Static libs + dynamic CRT
 - Platform-specific vcpkg triplets:
   - `x64-windows` (standard presets, dynamic CRT)
   - `x64-windows-static` (static presets, static CRT)
   - `x64-windows-static-md` (static-md presets, static libs + dynamic CRT)
-- Visual Studio 2022 generator only (no Ninja variants available)
+- Visual Studio 2022 (msvc-17) and Visual Studio 2026 (msvc-18) generators available
 
 ### vcpkg Dependencies
 

--- a/cmake/presets/windows.json
+++ b/cmake/presets/windows.json
@@ -96,6 +96,99 @@
                 "VCPKG_TARGET_TRIPLET": "arm64-windows-static-md",
                 "PLATFORM_IDENTIFIER": "win-arm64"
             }
+        },
+        {
+            "name": "windows-x86-msvc-18-static",
+            "inherits": "default",
+            "generator": "Visual Studio 18 2026",
+            "architecture": "Win32",
+            "cacheVariables": {
+                "VCPKG_TARGET_TRIPLET": "x86-windows-static",
+                "PLATFORM_IDENTIFIER": "win-x86",
+                "VANILLAPDF_USE_STATIC_CRT": "ON"
+            }
+        },
+        {
+            "name": "windows-x64-msvc-18-static",
+            "inherits": "default",
+            "generator": "Visual Studio 18 2026",
+            "architecture": "x64",
+            "cacheVariables": {
+                "VCPKG_TARGET_TRIPLET": "x64-windows-static",
+                "PLATFORM_IDENTIFIER": "win-x64",
+                "VANILLAPDF_USE_STATIC_CRT": "ON"
+            }
+        },
+        {
+            "name": "windows-x86-msvc-18",
+            "inherits": "default",
+            "generator": "Visual Studio 18 2026",
+            "architecture": "Win32",
+            "cacheVariables": {
+                "VCPKG_TARGET_TRIPLET": "x86-windows",
+                "PLATFORM_IDENTIFIER": "win-x86"
+            }
+        },
+        {
+            "name": "windows-x64-msvc-18",
+            "inherits": "default",
+            "generator": "Visual Studio 18 2026",
+            "architecture": "x64",
+            "cacheVariables": {
+                "VCPKG_TARGET_TRIPLET": "x64-windows",
+                "PLATFORM_IDENTIFIER": "win-x64"
+            }
+        },
+        {
+            "name": "windows-arm64-msvc-18",
+            "inherits": "default",
+            "generator": "Visual Studio 18 2026",
+            "architecture": "arm64",
+            "cacheVariables": {
+                "VCPKG_TARGET_TRIPLET": "arm64-windows",
+                "PLATFORM_IDENTIFIER": "win-arm64"
+            }
+        },
+        {
+            "name": "windows-arm64-msvc-18-static",
+            "inherits": "default",
+            "generator": "Visual Studio 18 2026",
+            "architecture": "arm64",
+            "cacheVariables": {
+                "VCPKG_TARGET_TRIPLET": "arm64-windows-static",
+                "PLATFORM_IDENTIFIER": "win-arm64",
+                "VANILLAPDF_USE_STATIC_CRT": "ON"
+            }
+        },
+        {
+            "name": "windows-x86-msvc-18-static-md",
+            "inherits": "default",
+            "generator": "Visual Studio 18 2026",
+            "architecture": "Win32",
+            "cacheVariables": {
+                "VCPKG_TARGET_TRIPLET": "x86-windows-static-md",
+                "PLATFORM_IDENTIFIER": "win-x86"
+            }
+        },
+        {
+            "name": "windows-x64-msvc-18-static-md",
+            "inherits": "default",
+            "generator": "Visual Studio 18 2026",
+            "architecture": "x64",
+            "cacheVariables": {
+                "VCPKG_TARGET_TRIPLET": "x64-windows-static-md",
+                "PLATFORM_IDENTIFIER": "win-x64"
+            }
+        },
+        {
+            "name": "windows-arm64-msvc-18-static-md",
+            "inherits": "default",
+            "generator": "Visual Studio 18 2026",
+            "architecture": "arm64",
+            "cacheVariables": {
+                "VCPKG_TARGET_TRIPLET": "arm64-windows-static-md",
+                "PLATFORM_IDENTIFIER": "win-arm64"
+            }
         }
     ],
     "buildPresets": [
@@ -134,6 +227,42 @@
         {
             "name": "windows-arm64-msvc-17-static-md",
             "configurePreset": "windows-arm64-msvc-17-static-md"
+        },
+        {
+            "name": "windows-x86-msvc-18-static",
+            "configurePreset": "windows-x86-msvc-18-static"
+        },
+        {
+            "name": "windows-x64-msvc-18-static",
+            "configurePreset": "windows-x64-msvc-18-static"
+        },
+        {
+            "name": "windows-x86-msvc-18",
+            "configurePreset": "windows-x86-msvc-18"
+        },
+        {
+            "name": "windows-x64-msvc-18",
+            "configurePreset": "windows-x64-msvc-18"
+        },
+        {
+            "name": "windows-arm64-msvc-18",
+            "configurePreset": "windows-arm64-msvc-18"
+        },
+        {
+            "name": "windows-arm64-msvc-18-static",
+            "configurePreset": "windows-arm64-msvc-18-static"
+        },
+        {
+            "name": "windows-x86-msvc-18-static-md",
+            "configurePreset": "windows-x86-msvc-18-static-md"
+        },
+        {
+            "name": "windows-x64-msvc-18-static-md",
+            "configurePreset": "windows-x64-msvc-18-static-md"
+        },
+        {
+            "name": "windows-arm64-msvc-18-static-md",
+            "configurePreset": "windows-arm64-msvc-18-static-md"
         }
     ],
     "testPresets": [
@@ -172,6 +301,42 @@
         {
             "name": "windows-arm64-msvc-17-static-md",
             "configurePreset": "windows-arm64-msvc-17-static-md"
+        },
+        {
+            "name": "windows-x86-msvc-18-static",
+            "configurePreset": "windows-x86-msvc-18-static"
+        },
+        {
+            "name": "windows-x64-msvc-18-static",
+            "configurePreset": "windows-x64-msvc-18-static"
+        },
+        {
+            "name": "windows-x86-msvc-18",
+            "configurePreset": "windows-x86-msvc-18"
+        },
+        {
+            "name": "windows-x64-msvc-18",
+            "configurePreset": "windows-x64-msvc-18"
+        },
+        {
+            "name": "windows-arm64-msvc-18",
+            "configurePreset": "windows-arm64-msvc-18"
+        },
+        {
+            "name": "windows-arm64-msvc-18-static",
+            "configurePreset": "windows-arm64-msvc-18-static"
+        },
+        {
+            "name": "windows-x86-msvc-18-static-md",
+            "configurePreset": "windows-x86-msvc-18-static-md"
+        },
+        {
+            "name": "windows-x64-msvc-18-static-md",
+            "configurePreset": "windows-x64-msvc-18-static-md"
+        },
+        {
+            "name": "windows-arm64-msvc-18-static-md",
+            "configurePreset": "windows-arm64-msvc-18-static-md"
         }
     ]
 }

--- a/doc/src/input/install.dox
+++ b/doc/src/input/install.dox
@@ -60,7 +60,7 @@ A complete working example with cross-platform testing is available in the
 Download from <https://cmake.org/download/>
 
 <b>Supported Compilers:</b>
-- **Windows:** Visual Studio 2022 (MSVC 17.x)
+- **Windows:** Visual Studio 2022 (MSVC 17.x) or Visual Studio 2026 (MSVC 18.x)
 - **Linux:** GCC 8.1+ or Clang 10+ (x64, ARM64, ARM)
 - **macOS:** AppleClang 15+ (Xcode 15)
 - **Android:** NDK toolchain (arm64-v8a, armeabi-v7a, x86, x86_64)
@@ -94,6 +94,12 @@ Available configure presets:
   "windows-x64-msvc-17"
   "windows-x86-msvc-17-static-md"
   "windows-x64-msvc-17-static-md"
+  "windows-x86-msvc-18-static"
+  "windows-x64-msvc-18-static"
+  "windows-x86-msvc-18"
+  "windows-x64-msvc-18"
+  "windows-x86-msvc-18-static-md"
+  "windows-x64-msvc-18-static-md"
   "default"
   "linux-x64-gcc"
   "linux-arm64-gcc"
@@ -114,6 +120,9 @@ Common presets include:
 - `windows-x64-msvc-17` / `windows-x86-msvc-17` - Windows with Visual Studio 2022 (dynamic CRT)
 - `windows-x64-msvc-17-static` / `windows-x86-msvc-17-static` - Windows with Visual Studio 2022 (static CRT)
 - `windows-x64-msvc-17-static-md` / `windows-x86-msvc-17-static-md` - Windows with Visual Studio 2022 (static libs, dynamic CRT)
+- `windows-x64-msvc-18` / `windows-x86-msvc-18` - Windows with Visual Studio 2026 (dynamic CRT)
+- `windows-x64-msvc-18-static` / `windows-x86-msvc-18-static` - Windows with Visual Studio 2026 (static CRT)
+- `windows-x64-msvc-18-static-md` / `windows-x86-msvc-18-static-md` - Windows with Visual Studio 2026 (static libs, dynamic CRT)
 - `linux-x64-gcc` / `linux-arm64-gcc` - Linux with GCC
 - `linux-x64-clang` / `linux-arm64-clang` - Linux with Clang
 - `macos-x64` / `macos-arm64` - macOS builds
@@ -130,7 +139,7 @@ ctest --preset windows-x64-msvc-17
 \endcode
 
 **Windows Build Notes:**
-- Uses Visual Studio 2022 generator
+- Uses Visual Studio 2022 (msvc-17) or Visual Studio 2026 (msvc-18) generator
 - CRT linking depends on preset: `-static` variants use static CRT (`VANILLAPDF_USE_STATIC_CRT=ON`)
 - Uses optimized vcpkg triplets (e.g., `x64-windows-static-md` for static libs + dynamic CRT)
 
@@ -278,7 +287,7 @@ cmake --preset <your-preset>
 *Platform-specific dependency issues:*
 - **Linux**: Install system packages: `sudo apt-get install libssl-dev libjpeg-turbo8-dev zlib1g-dev libopenjp2-7-dev`
 - **macOS**: Install via Homebrew: `brew install openssl@3 jpeg-turbo zlib openjpeg`
-- **Windows**: Use vcpkg presets or ensure Visual Studio 2022 is properly installed
+- **Windows**: Use vcpkg presets or ensure Visual Studio 2022 or 2026 is properly installed
 
 \section install_packages Building packages
 


### PR DESCRIPTION
## Summary

- Add CMake presets for Visual Studio 2026 (MSVC 18) supporting all Windows architectures (x86, x64, arm64)
- Include all CRT linking variants: dynamic CRT, static CRT, and static-md (static libs + dynamic CRT)
- Update documentation (CLAUDE.md, install.dox) to reflect VS2026 support

## New Presets

| Architecture | Dynamic CRT | Static CRT | Static-MD |
|-------------|-------------|------------|-----------|
| x86 | `windows-x86-msvc-18` | `windows-x86-msvc-18-static` | `windows-x86-msvc-18-static-md` |
| x64 | `windows-x64-msvc-18` | `windows-x64-msvc-18-static` | `windows-x64-msvc-18-static-md` |
| arm64 | `windows-arm64-msvc-18` | `windows-arm64-msvc-18-static` | `windows-arm64-msvc-18-static-md` |

## Test plan

- [x] Configure with `cmake --preset windows-x64-msvc-18`
- [x] Build with `cmake --build --preset windows-x64-msvc-18`
- [x] Run tests with `ctest --preset windows-x64-msvc-18 --build-config Debug`

🤖 Generated with [Claude Code](https://claude.com/claude-code)