### PR TITLE
fix: Place native libraries in runtimes folder instead of root

### DIFF
--- a/.github/workflows/build-nuget.yml
+++ b/.github/workflows/build-nuget.yml
@@ -76,7 +76,7 @@ jobs:
           submodules: recursive
       - uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: 10.0.x
 
       - name: Install ICU dependencies
         if: runner.os == 'Linux'
@@ -148,7 +148,7 @@ jobs:
           submodules: recursive
       - uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: 10.0.x
 
       - name: Cache vcpkg
         uses: actions/cache@v4
@@ -217,7 +217,7 @@ jobs:
           submodules: recursive
       - uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: 10.0.x
 
       - name: Cache vcpkg
         uses: actions/cache@v4
@@ -293,7 +293,7 @@ jobs:
 
       - uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: 10.0.x
 
       - name: Generate NuGet project files
         run: cmake -DVANILLAPDF_VERSION_BUILD_SUFFIX="${{ inputs.build_suffix }}" -P cmake/nuget.cmake

--- a/nuget/vanillapdf_net.targets.in
+++ b/nuget/vanillapdf_net.targets.in
@@ -1,14 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
+  <!-- Include native library and place it in the correct runtime folder (not root) -->
   <ItemGroup>
-    <!-- include the native DLL and mark it for publish -->
-    <None Include="$(MSBuildThisFileDirectory)..\runtimes\@PLATFORM_IDENTIFIER@\native\*.*">
-      <!-- ensure it gets copied on publish -->
+    <ContentWithTargetPath Include="$(MSBuildThisFileDirectory)..\runtimes\@PLATFORM_IDENTIFIER@\native\*.*">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
-      <!-- exactly where under publish/ it should land -->
       <TargetPath>runtimes/@PLATFORM_IDENTIFIER@/native/%(Filename)%(Extension)</TargetPath>
-    </None>
+    </ContentWithTargetPath>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary

- Fix NuGet package targets to place native libraries in `runtimes/<RID>/native/` instead of the publish root directory
- Update .NET SDK version from 8.0.x to 10.0.x in build-nuget workflow

## Changes

### NuGet targets (`nuget/vanillapdf_net.targets.in`)
- Changed from `<None>` to `<ContentWithTargetPath>` item type
- Added `<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>` for build output
- Kept `<CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>` for publish
- `<TargetPath>` ensures files go to `runtimes/<RID>/native/` subdirectory

### Workflow (`.github/workflows/build-nuget.yml`)
- Updated `dotnet-version` from `8.0.x` to `10.0.x`

## Test plan

- [x] Verify pipeline passes on all platforms (Linux, Windows, macOS)
- [x] Verify NuGet package contains native libraries in correct location
- [x] Verify published application has DLLs in `runtimes/<RID>/native/` not root

🤖 Generated with [Claude Code](https://claude.com/claude-code)