### PR TITLE
fix: Remove deprecated x-gha vcpkg binary caching

### DIFF
--- a/.github/workflows/examples-integration.yml
+++ b/.github/workflows/examples-integration.yml
@@ -36,12 +36,9 @@ concurrency:
 
 permissions:
   contents: read
-  actions: write
 
 env:
   VCPKG_DISABLE_METRICS: 1
-  # Enable binary caching to speed up dependency builds
-  VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
 
 jobs:
   setup:
@@ -204,13 +201,6 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y ninja-build
 
-      - name: Export GitHub Actions cache environment
-        uses: actions/github-script@v7
-        with:
-          script: |
-            core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
-            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
-
       - name: Bootstrap vcpkg
         run: ./external/vcpkg/bootstrap-vcpkg.sh
 
@@ -255,13 +245,6 @@ jobs:
       - name: Set up Visual Studio
         uses: microsoft/setup-msbuild@v2
 
-      - name: Export GitHub Actions cache environment
-        uses: actions/github-script@v7
-        with:
-          script: |
-            core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
-            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
-
       - name: Bootstrap vcpkg
         run: .\external\vcpkg\bootstrap-vcpkg.bat
 
@@ -301,13 +284,6 @@ jobs:
 
       - name: Install build tools
         run: brew install --quiet ninja autoconf automake autoconf-archive
-
-      - name: Export GitHub Actions cache environment
-        uses: actions/github-script@v7
-        with:
-          script: |
-            core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
-            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
 
       - name: Bootstrap vcpkg
         run: ./external/vcpkg/bootstrap-vcpkg.sh


### PR DESCRIPTION
## Summary
- Remove deprecated `x-gha` vcpkg binary caching backend from examples-integration workflow
- Remove `VCPKG_BINARY_SOURCES` environment variable
- Remove `actions: write` permission (no longer needed)
- Remove "Export GitHub Actions cache environment" steps from Linux, Windows, and macOS jobs

This fixes the warning that appeared in CI:
```
warning: Unknown binary provider 'x-gha' - The x-gha binary caching backend has been removed.
```

## Test plan
- [x] Verify examples-integration workflow runs without warnings
- [x] Verify vcpkg builds still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)