### PR TITLE
fix: Skip vcpkg PR and docs deployment for pre-releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,7 +111,7 @@ jobs:
       deploy: true
     secrets: inherit
   github-release:
-    needs: production-gate
+    needs: [production-gate, prepare]
     uses: ./.github/workflows/github-release.yml
     with:
       tag: ${{ needs.prepare.outputs.tag }}
@@ -120,6 +120,8 @@ jobs:
 
   vcpkg-pr:
     needs: [production-gate, prepare]
+    # Only create vcpkg PR for official releases, not pre-releases (alpha, beta, rc)
+    if: needs.prepare.outputs.prerelease == 'false'
     uses: ./.github/workflows/create-vcpkg-pr.yml
     with:
       tag: ${{ needs.prepare.outputs.tag }}


### PR DESCRIPTION
## Summary
- Skip `vcpkg-pr` job for alpha/beta/rc releases (vcpkg only accepts stable versions)
- Fix `github-release` job to properly declare `prepare` dependency for accessing outputs

Note: `github-pages` deployment is kept enabled for pre-releases to allow documentation verification.

## Test plan
- [ ] Verify alpha/beta releases skip vcpkg PR creation
- [ ] Verify stable releases still trigger all jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)