### PR TITLE
fix: Add environment to publish-nuget job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,6 +92,7 @@ jobs:
   publish-nuget:
     runs-on: ubuntu-latest
     needs: production-gate
+    environment: production
     steps:
       - name: Download NuGet packages
         uses: actions/download-artifact@v6


### PR DESCRIPTION
## Summary
The `publish-nuget` job was missing `environment: production`, which prevented it from accessing:
- `vars.NUGET_SOURCE` - the NuGet feed URL
- `secrets.NUGET_API_KEY` - the API key for publishing

This caused the error:
```
--source "" \
--api-key "" \
error: Source parameter was not specified.
```

## Test plan
- [ ] Verify publish-nuget job can access production environment variables
- [ ] Verify NuGet packages are published successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)