### PR TITLE
fix: Convert prerelease output to boolean type

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,7 +116,8 @@ jobs:
     uses: ./.github/workflows/github-release.yml
     with:
       tag: ${{ needs.prepare.outputs.tag }}
-      prerelease: ${{ needs.prepare.outputs.prerelease }}
+      # Convert string output to boolean (job outputs are always strings)
+      prerelease: ${{ needs.prepare.outputs.prerelease == 'true' }}
     secrets: inherit
 
   vcpkg-pr:


### PR DESCRIPTION
## Summary
Job outputs are always strings in GitHub Actions. The `github-release` workflow expects a boolean type for the `prerelease` input, causing the error:

```
Unexpected value 'true'
```

Fixed by converting the string to boolean: `${{ needs.prepare.outputs.prerelease == 'true' }}`

## Test plan
- [ ] Verify release workflow parses without errors
- [ ] Verify prerelease flag is correctly passed to github-release job

🤖 Generated with [Claude Code](https://claude.com/claude-code)