### PR TITLE
fix: Add prepare to build-nuget needs and fix prerelease boolean

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,7 @@ jobs:
 
 
   build-nuget:
-    needs: verify
+    needs: [verify, prepare]
     uses: ./.github/workflows/build-nuget.yml
     with:
       build_suffix: ${{ needs.prepare.outputs.build_suffix }}
@@ -116,7 +116,8 @@ jobs:
     uses: ./.github/workflows/github-release.yml
     with:
       tag: ${{ needs.prepare.outputs.tag }}
-      prerelease: ${{ needs.prepare.outputs.prerelease }}
+      # Convert string output to boolean (job outputs are always strings)
+      prerelease: ${{ needs.prepare.outputs.prerelease == 'true' }}
     secrets: inherit
 
   vcpkg-pr:


### PR DESCRIPTION
## Summary
Two critical fixes for the release workflow:

### 1. Missing `prepare` dependency (ROOT CAUSE of 2.2.0 publish)
The `build-nuget` job was missing `prepare` in its `needs` array:
```yaml
build-nuget:
  needs: verify  # ❌ Can't access prepare.outputs
  with:
    build_suffix: ${{ needs.prepare.outputs.build_suffix }}  # Always empty!
```

In GitHub Actions, you can **only access outputs from jobs listed in your `needs` array**. This caused `build_suffix` to be empty, so `2.2.0-alpha.3` was published as `2.2.0`.

### 2. Prerelease boolean type conversion
Job outputs are always strings. The `github-release` workflow expects boolean for `prerelease`, causing "Unexpected value 'true'" error.

## Test plan
- [ ] Verify build_suffix is correctly passed to build-nuget
- [ ] Verify prerelease flag works without type errors
- [ ] Test with alpha.4 release

Closes #172

🤖 Generated with [Claude Code](https://claude.com/claude-code)