### PR TITLE
feat: Add workflow_dispatch to vcpkg PR workflow

### DIFF
--- a/.github/workflows/create-vcpkg-pr.yml
+++ b/.github/workflows/create-vcpkg-pr.yml
@@ -7,6 +7,13 @@ on:
         required: true
         type: string
 
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag name (e.g. v2.2.0)"
+        required: true
+        type: string
+
 permissions:
   contents: read
 


### PR DESCRIPTION
## Summary
Add `workflow_dispatch` trigger to the vcpkg PR creation workflow, allowing manual triggering from the Actions tab.

Useful for:
- Creating PRs when the automated release workflow fails
- Re-running after fixes
- Testing the workflow

## Test plan
- [ ] Merge and trigger workflow with `v2.2.0` tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)