### PR TITLE
feat: Add automated backporting workflow

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -22,8 +22,8 @@ jobs:
           # Supports any branch name after "backport "
           label_pattern: '^backport (?<target>[^ ]+)$'
 
-          # Add label to created backport PR for tracking
-          pull_labels: backported
+          # Add label to created backport PR for tracking (includes target branch)
+          pull_labels: backported ${target_branch}
 
           # For squash-merged PRs, cherry-pick the squashed commit
           # For merge commits, cherry-pick the merge commit

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -419,14 +419,16 @@ To backport a merged PR to a release branch:
 2. When the PR is merged, the backport workflow automatically:
    - Cherry-picks the commit to the target branch
    - Creates a new PR with title `[Backport release/X.Y] <original title>`
-   - Adds the `backported` label to the new PR
+   - Adds `backported release/X.Y` label to the new PR
 3. If cherry-pick fails (conflicts), manually create a backport PR
 
-Available backport labels:
-- `backport release/2.2` - Backport to release/2.2 branch
-- `backport release/2.1` - Backport to release/2.1 branch
+Available labels:
+- `backport release/2.2` - Request backport to release/2.2 branch
+- `backport release/2.1` - Request backport to release/2.1 branch
+- `backported release/2.2` - PR was backported to release/2.2
+- `backported release/2.1` - PR was backported to release/2.1
 
-For new release branches, create a label following the pattern `backport <branch-name>`.
+For new release branches, create labels following the patterns `backport <branch>` and `backported <branch>`.
 
 **Automated Workflows Using vanillapdf-bot:**
 - All vcpkg-related automation


### PR DESCRIPTION
## Summary
Add a GitHub Actions workflow that automatically backports merged PRs to release branches when labeled appropriately.

## How It Works
1. Add label `backport release/X.Y` to a PR before or after merging
2. When the PR is merged, the workflow automatically:
   - Cherry-picks the commit to the target release branch
   - Creates a new PR titled `[Backport release/X.Y] <original title>`
   - Adds the `backported` label to the new PR
3. If cherry-pick fails due to conflicts, the workflow reports the failure and you can manually create a backport PR

## Labels Created
- `backport release/2.2` - Backport to release/2.2 branch
- `backport release/2.1` - Backport to release/2.1 branch  
- `backported` - Applied to PRs created by the backport action

## Implementation
Uses [korthout/backport-action](https://github.com/korthout/backport-action) v3 which is well-maintained and handles edge cases like conflicts gracefully.

## Test plan
- [x] Labels created in repository
- [ ] Merge a test PR with `backport release/2.2` label to verify workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)