### PR TITLE
fix: Address sanitizer issues in signature verification and tests

### DIFF
--- a/src/vanillapdf.unittest/byte_range_test.cpp
+++ b/src/vanillapdf.unittest/byte_range_test.cpp
@@ -74,6 +74,8 @@ TEST(ByteRange, CreateFromData) {
     // Cleanup
     IntegerObject_Release(retrieved_offset);
     IntegerObject_Release(retrieved_length);
+    IntegerObject_Release(offset);
+    IntegerObject_Release(length);
     ByteRange_Release(range);
 }
 
@@ -106,6 +108,8 @@ TEST(ByteRangeCollection, CreateEmptyAndAppend) {
     EXPECT_EQ(size, 1);
 
     // Cleanup
+    IntegerObject_Release(offset);
+    IntegerObject_Release(length);
     ByteRange_Release(range);
     ByteRangeCollection_Release(collection);
 }
@@ -127,6 +131,8 @@ TEST(ByteRangeCollection, AppendMultipleAndRetrieve) {
         ByteRangeHandle* range = nullptr;
         ASSERT_EQ(ByteRange_CreateFromData(offset, length, &range), VANILLAPDF_ERROR_SUCCESS);
         ASSERT_EQ(ByteRangeCollection_Append(collection, range), VANILLAPDF_ERROR_SUCCESS);
+        IntegerObject_Release(offset);
+        IntegerObject_Release(length);
         ByteRange_Release(range);
     }
 
@@ -175,6 +181,8 @@ TEST(ByteRangeCollection, InsertAtBeginning) {
     ByteRangeHandle* range1 = nullptr;
     ASSERT_EQ(ByteRange_CreateFromData(offset1, length1, &range1), VANILLAPDF_ERROR_SUCCESS);
     ASSERT_EQ(ByteRangeCollection_Append(collection, range1), VANILLAPDF_ERROR_SUCCESS);
+    IntegerObject_Release(offset1);
+    IntegerObject_Release(length1);
     ByteRange_Release(range1);
 
     // Insert at beginning
@@ -187,6 +195,8 @@ TEST(ByteRangeCollection, InsertAtBeginning) {
     ByteRangeHandle* range2 = nullptr;
     ASSERT_EQ(ByteRange_CreateFromData(offset2, length2, &range2), VANILLAPDF_ERROR_SUCCESS);
     ASSERT_EQ(ByteRangeCollection_Insert(collection, 0, range2), VANILLAPDF_ERROR_SUCCESS);
+    IntegerObject_Release(offset2);
+    IntegerObject_Release(length2);
     ByteRange_Release(range2);
 
     // Verify size
@@ -224,6 +234,8 @@ TEST(ByteRangeCollection, InsertInMiddle) {
         ByteRangeHandle* range = nullptr;
         ASSERT_EQ(ByteRange_CreateFromData(offset, length, &range), VANILLAPDF_ERROR_SUCCESS);
         ASSERT_EQ(ByteRangeCollection_Append(collection, range), VANILLAPDF_ERROR_SUCCESS);
+        IntegerObject_Release(offset);
+        IntegerObject_Release(length);
         ByteRange_Release(range);
     }
 
@@ -237,6 +249,8 @@ TEST(ByteRangeCollection, InsertInMiddle) {
     ByteRangeHandle* range_mid = nullptr;
     ASSERT_EQ(ByteRange_CreateFromData(offset_mid, length_mid, &range_mid), VANILLAPDF_ERROR_SUCCESS);
     ASSERT_EQ(ByteRangeCollection_Insert(collection, 1, range_mid), VANILLAPDF_ERROR_SUCCESS);
+    IntegerObject_Release(offset_mid);
+    IntegerObject_Release(length_mid);
     ByteRange_Release(range_mid);
 
     // Verify size
@@ -274,6 +288,8 @@ TEST(ByteRangeCollection, RemoveFromCollection) {
         ByteRangeHandle* range = nullptr;
         ASSERT_EQ(ByteRange_CreateFromData(offset, length, &range), VANILLAPDF_ERROR_SUCCESS);
         ASSERT_EQ(ByteRangeCollection_Append(collection, range), VANILLAPDF_ERROR_SUCCESS);
+        IntegerObject_Release(offset);
+        IntegerObject_Release(length);
         ByteRange_Release(range);
     }
 
@@ -326,6 +342,8 @@ TEST(ByteRangeCollection, ClearCollection) {
         ByteRangeHandle* range = nullptr;
         ASSERT_EQ(ByteRange_CreateFromData(offset, length, &range), VANILLAPDF_ERROR_SUCCESS);
         ASSERT_EQ(ByteRangeCollection_Append(collection, range), VANILLAPDF_ERROR_SUCCESS);
+        IntegerObject_Release(offset);
+        IntegerObject_Release(length);
         ByteRange_Release(range);
     }
 

--- a/src/vanillapdf/utils/buffer.h
+++ b/src/vanillapdf/utils/buffer.h
@@ -56,6 +56,19 @@ public:
 
     size_t Hash() const;
     BufferPtr Clone(void) const { return make_deferred_container<Buffer>(begin(), end()); }
+
+    /**
+     * @brief Create a null-terminated buffer from a string view
+     *
+     * Use this when the buffer will be used as a C string (e.g., with printf).
+     * The returned buffer includes the null terminator in its size.
+     */
+    static BufferPtr CreateFromString(std::string_view str) {
+        auto buffer = make_deferred_container<Buffer>(str.begin(), str.end());
+        buffer->push_back('\0');
+        return buffer;
+    }
+
     std::string ToString(void) const { return std::string(begin(), end()); }
     std::string_view ToStringView(void) const { return std::string_view(data(), size()); }
     std::string ToHexString(void) const;

--- a/src/vanillapdf/utils/signature_verification_result.cpp
+++ b/src/vanillapdf/utils/signature_verification_result.cpp
@@ -61,7 +61,7 @@ void SignatureVerificationResult::SetMessage(BufferPtr message) {
 }
 
 void SignatureVerificationResult::SetMessage(std::string_view message) {
-    m_message = make_deferred_container<Buffer>(message.begin(), message.end());
+    m_message = Buffer::CreateFromString(message);
 }
 
 void SignatureVerificationResult::SetSignatureValid(bool valid) {
@@ -89,7 +89,7 @@ void SignatureVerificationResult::SetSignerCommonName(BufferPtr name) {
 }
 
 void SignatureVerificationResult::SetSignerCommonName(std::string_view name) {
-    m_signer_common_name = make_deferred_container<Buffer>(name.begin(), name.end());
+    m_signer_common_name = Buffer::CreateFromString(name);
 }
 
 } // vanillapdf


### PR DESCRIPTION
## Summary
Fix two issues reported by AddressSanitizer in CI run: https://github.com/vanillapdf/vanillapdf/actions/runs/19811024920/job/56753538429

## Issues Fixed

### 1. Heap-buffer-overflow in `SignatureVerificationResult::SetMessage`
- **Root cause:** Buffer created from `string_view` didn't include null terminator
- **Symptom:** When buffer was used with `printf` in `verify.c` (expecting C string), it read past the buffer end
- **Fix:** Added `Buffer::CreateFromString()` static helper that creates a null-terminated buffer
- Also fixed `SetSignerCommonName()` which had the same issue

### 2. Memory leak in `byte_range_test.cpp`
- **Root cause:** `IntegerObject` handles created for offset/length weren't released in test cleanup
- **Fix:** Added `IntegerObject_Release()` calls in all affected tests

## Changes
- `src/vanillapdf/utils/buffer.h` - Added `CreateFromString()` static method
- `src/vanillapdf/utils/signature_verification_result.cpp` - Use `CreateFromString()` for string_view setters
- `src/vanillapdf.unittest/byte_range_test.cpp` - Fix memory leaks in 7 tests

## Test plan
- [x] Build passes (MSVC 18)
- [x] All ByteRange tests pass
- [ ] Stack sanitizer CI should pass after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)