### PR TITLE
fix: Include PDB files in Windows NuGet runtime packages

### DIFF
--- a/nuget/vanillapdf.runtime.csproj.in
+++ b/nuget/vanillapdf.runtime.csproj.in
@@ -20,10 +20,11 @@
   <ItemGroup>
     <None Include="vanillapdf_net.targets" Pack="true" PackagePath="buildTransitive/vanillapdf.runtime.@PLATFORM_IDENTIFIER@.targets" />
 
-    <!-- MSVC-style layout -->
+    <!-- MSVC-style layout (Windows) -->
     <None Include="../build/*/src/vanillapdf/Release/libvanillapdf.dll" Pack="true" PackagePath="runtimes/@PLATFORM_IDENTIFIER@/native/libvanillapdf.dll" />
+    <None Include="../build/*/src/vanillapdf/Release/libvanillapdf.pdb" Pack="true" PackagePath="runtimes/@PLATFORM_IDENTIFIER@/native/libvanillapdf.pdb" />
 
-    <!-- Ninja/unix-style layout -->
+    <!-- Ninja/unix-style layout (Linux/macOS) -->
     <None Include="../build/*/src/vanillapdf/libvanillapdf.so" Pack="true" PackagePath="runtimes/@PLATFORM_IDENTIFIER@/native/libvanillapdf.so" />
     <None Include="../build/*/src/vanillapdf/libvanillapdf.dylib" Pack="true" PackagePath="runtimes/@PLATFORM_IDENTIFIER@/native/libvanillapdf.dylib" />
     


### PR DESCRIPTION
## Summary
- Add PDB symbol files alongside DLL files in Windows NuGet runtime packages
- Enables source-level debugging for consumers of the vanillapdf NuGet package
- Updated comment clarification for MSVC and Ninja build layouts

## Test plan
- [ ] Build Windows NuGet package and verify PDB is included in `runtimes/<platform>/native/`
- [ ] Verify snupkg symbol package is generated correctly

Closes #178

🤖 Generated with [Claude Code](https://claude.com/claude-code)