### PR TITLE
fix: Add checkout step and correct parameter names in backport workflow

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -15,6 +15,9 @@ jobs:
     # Only run when PR is merged (not just closed)
     if: github.event.pull_request.merged == true
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: Backport
         uses: korthout/backport-action@v3
         with:
@@ -23,7 +26,7 @@ jobs:
           label_pattern: '^backport (?<target>[^ ]+)$'
 
           # Add label to created backport PR for tracking (includes target branch)
-          pull_labels: backported ${target_branch}
+          add_labels: backported ${target_branch}
 
           # For squash-merged PRs, cherry-pick the squashed commit
           # For merge commits, cherry-pick the merge commit
@@ -33,7 +36,7 @@ jobs:
           pull_title: '[Backport ${target_branch}] ${pull_title}'
 
           # Body format for backport PRs
-          pull_body: |
+          pull_description: |
             Backport of #${pull_number} to `${target_branch}`.
 
             ---


### PR DESCRIPTION
## Summary
- Add missing `actions/checkout@v4` step before running backport action
- Fix parameter names: `pull_labels` → `add_labels`, `pull_body` → `pull_description`

## Root Cause
The backport workflow was failing with:
```
fatal: not a git repository (or any of the parent directories): .git
```
And warnings about invalid inputs.

## Test plan
- [ ] Merge this PR
- [ ] Re-run backport on PR #177 by removing and re-adding the `backport release/2.2` label

🤖 Generated with [Claude Code](https://claude.com/claude-code)