### PR TITLE
fix: Improve update-vcpkg workflow reliability

### DIFF
--- a/.github/workflows/update-vcpkg.yml
+++ b/.github/workflows/update-vcpkg.yml
@@ -25,8 +25,8 @@ on:
         type: boolean
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read  # checkout only; bot token will do writes
+  pull-requests: read
 
 jobs:
   update-vcpkg:
@@ -44,13 +44,19 @@ jobs:
           git config --global user.name "vanillapdf-bot"
           git config --global user.email "info@vanillapdf.com"
 
+      - name: Set authenticated origin for push
+        env:
+          BOT_TOKEN: ${{ secrets.BOT_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          git remote set-url origin "https://x-access-token:${BOT_TOKEN}@github.com/${REPO}.git"
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: '3.14'
 
       - name: Run vcpkg update script
-        id: update
         env:
           GH_TOKEN: ${{ secrets.BOT_TOKEN }}
         run: |
@@ -65,21 +71,12 @@ jobs:
             FLAGS="$FLAGS --no-pr"
           fi
 
-          python scripts/update_vcpkg.py $FLAGS 2>&1 | tee update_output.txt
-
-          # Check if update was performed
-          if grep -q "Successfully updated vcpkg" update_output.txt; then
-            echo "updated=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "updated=false" >> "$GITHUB_OUTPUT"
-          fi
+          python scripts/update_vcpkg.py $FLAGS
 
       - name: Summary
         run: |
           if [[ "${{ inputs.dry-run }}" == "true" ]]; then
             echo "ℹ️ Dry run completed - no changes made"
-          elif [[ "${{ steps.update.outputs.updated }}" == "true" ]]; then
-            echo "✅ vcpkg update PR created successfully"
           else
-            echo "ℹ️ No vcpkg update needed - already on latest version"
+            echo "✅ vcpkg update workflow completed successfully"
           fi

--- a/scripts/update_vcpkg.py
+++ b/scripts/update_vcpkg.py
@@ -128,11 +128,11 @@ class VcpkgUpdater:
         print(f"Successfully updated vcpkg.json.in baseline to {commit_hash}")
 
     def create_update_branch(self, version: str) -> str:
-        """Create a new branch for the vcpkg update."""
+        """Create or reset branch for the vcpkg update (idempotent)."""
         branch_name = f"automated/update-vcpkg-{version}"
         print(f"Creating branch: {branch_name}")
 
-        self.run_command(['git', 'checkout', '-b', branch_name])
+        self.run_command(['git', 'checkout', '-B', branch_name])
         return branch_name
 
     def commit_changes(self, current_version: str, new_version: str) -> None:


### PR DESCRIPTION
## Summary
- Reduce permissions to read-only (bot token handles writes)
- Use local git remote set-url instead of global config
- Make branch creation idempotent with `-B` flag
- Simplify script execution (remove file piping)
- Properly propagate script exit code

## Test plan
- [x] Run workflow manually with dry-run enabled
- [ ] Verify workflow fails properly when script errors occur

🤖 Generated with [Claude Code](https://claude.com/claude-code)