### PR TITLE
fix: Use BOT_TOKEN consistently in backport workflow

### DIFF
--- a/.github/scripts/backport.sh
+++ b/.github/scripts/backport.sh
@@ -83,7 +83,7 @@ post_success_comment() {
     gh pr comment "$PR_NUMBER" --body "✅ Backport to \`$target\` created: $pr_url"
 }
 
-# Post failure comment with manual instructions
+# Post failure comment with manual instructions (cherry-pick conflicts)
 post_failure_comment() {
     local target="$1"
     local branch_name="$2"
@@ -97,6 +97,26 @@ git fetch origin $target
 git checkout -b $branch_name origin/$target
 git cherry-pick -x $MERGE_COMMIT
 # Resolve conflicts, then:
+git push origin $branch_name
+gh pr create --base $target --head $branch_name
+\`\`\`"
+
+    gh pr comment "$PR_NUMBER" --body "$failure_msg"
+}
+
+# Post push/PR creation failure comment
+post_push_failure_comment() {
+    local target="$1"
+    local branch_name="$2"
+
+    local failure_msg="❌ Backport to \`$target\` failed during push or PR creation.
+
+Please check the workflow logs and try manually:
+
+\`\`\`bash
+git fetch origin $target
+git checkout -b $branch_name origin/$target
+git cherry-pick -x $MERGE_COMMIT
 git push origin $branch_name
 gh pr create --base $target --head $branch_name
 \`\`\`"
@@ -128,12 +148,15 @@ process_target() {
 
     # Create backport branch and cherry-pick
     if create_backport_branch "$target" "$branch_name"; then
-        # Cherry-pick succeeded, create PR
+        # Cherry-pick succeeded, try to create PR
         local pr_url
-        pr_url=$(create_backport_pr "$target" "$branch_name")
-
-        echo "Created backport PR: $pr_url"
-        post_success_comment "$target" "$pr_url"
+        if pr_url=$(create_backport_pr "$target" "$branch_name"); then
+            echo "Created backport PR: $pr_url"
+            post_success_comment "$target" "$pr_url"
+        else
+            echo "::error::Push or PR creation failed for $target"
+            post_push_failure_comment "$target" "$branch_name"
+        fi
     else
         # Cherry-pick failed
         git cherry-pick --abort 2>/dev/null || true

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -42,20 +42,13 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ secrets.BOT_TOKEN }}
 
       - name: Configure Git
         if: steps.get-targets.outputs.has_targets == 'true'
         run: |
           git config --global user.name "vanillapdf-bot"
           git config --global user.email "info@vanillapdf.com"
-
-      - name: Set authenticated origin for push
-        if: steps.get-targets.outputs.has_targets == 'true'
-        env:
-          BOT_TOKEN: ${{ secrets.BOT_TOKEN }}
-          REPO: ${{ github.repository }}
-        run: |
-          git remote set-url origin "https://x-access-token:${BOT_TOKEN}@github.com/${REPO}.git"
 
       - name: Run backport script
         if: steps.get-targets.outputs.has_targets == 'true'
@@ -110,7 +103,7 @@ jobs:
       - name: Update labels on original PR
         if: steps.extract-info.outputs.has_info == 'true'
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.BOT_TOKEN }}
           ORIGINAL_PR: ${{ steps.extract-info.outputs.original_pr }}
           TARGET_BRANCH: ${{ steps.extract-info.outputs.target_branch }}
         run: |


### PR DESCRIPTION
## Summary
- Use BOT_TOKEN for all operations in the backport workflow
- Remove redundant 'Set authenticated origin' step (checkout with token handles this)
- Fix error propagation when push/PR creation fails
- Add separate error message for push/PR creation failures

## Problem
The backport workflow was failing with permission denied on push because mixing GITHUB_TOKEN (from checkout) and BOT_TOKEN (for remote URL) caused credential conflicts.

## Solution
Use BOT_TOKEN consistently:
- Checkout with `token: ${{ secrets.BOT_TOKEN }}`
- All gh CLI operations use BOT_TOKEN
- Removed the manual "Set authenticated origin" step

🤖 Generated with [Claude Code](https://claude.com/claude-code)