### PR TITLE
fix: Add GH_REPO env var for update-labels job

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -104,6 +104,7 @@ jobs:
         if: steps.extract-info.outputs.has_info == 'true'
         env:
           GH_TOKEN: ${{ secrets.BOT_TOKEN }}
+          GH_REPO: ${{ github.repository }}
           ORIGINAL_PR: ${{ steps.extract-info.outputs.original_pr }}
           TARGET_BRANCH: ${{ steps.extract-info.outputs.target_branch }}
         run: |


### PR DESCRIPTION
## Summary
Add `GH_REPO` environment variable to the update-labels job so gh CLI knows which repository to use.

## Problem
The update-labels job failed with:
```
failed to run git: fatal: not a git repository (or any of the parent directories): .git
```

The `gh pr edit` and `gh pr comment` commands need repository context.

## Solution
Add `GH_REPO: ${{ github.repository }}` to the environment variables. This tells gh CLI which repo to use without needing a checkout step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)