### PR TITLE
fix: Make encryption, jpeg, jpeg2000 mandatory in vcpkg port

### DIFF
--- a/ports/vanillapdf/portfile.cmake
+++ b/ports/vanillapdf/portfile.cmake
@@ -9,9 +9,6 @@ vcpkg_from_github(
 vcpkg_check_features(
     OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
-        encryption   VANILLAPDF_ENABLE_ENCRYPTION
-        jpeg         VANILLAPDF_ENABLE_JPEG
-        jpeg2000     VANILLAPDF_ENABLE_JPEG2000
         tests        VANILLAPDF_ENABLE_TESTS
         benchmarks   VANILLAPDF_ENABLE_BENCHMARK
 )
@@ -20,8 +17,6 @@ vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
       -DVANILLAPDF_INTERNAL_VCPKG=OFF
-      -DVANILLAPDF_ENABLE_TESTS=OFF
-      -DVANILLAPDF_ENABLE_BENCHMARK=OFF
       ${FEATURE_OPTIONS}
 )
 

--- a/ports/vanillapdf/vcpkg.json
+++ b/ports/vanillapdf/vcpkg.json
@@ -16,22 +16,12 @@
         },
         "zlib",
         "spdlog",
-        "nlohmann-json"
+        "nlohmann-json",
+        "openssl",
+        "libjpeg-turbo",
+        "openjpeg"
     ],
-    "default-features": [ "encryption", "jpeg", "jpeg2000" ],
     "features": {
-        "encryption": {
-            "description": "Enable encryption and decryption of secure PDF documents",
-            "dependencies": [ "openssl" ]
-        },
-        "jpeg": {
-            "description": "Decode JPEG images into bitmaps",
-            "dependencies": [ "libjpeg-turbo" ]
-        },
-        "jpeg2000": {
-            "description": "Support JPEG‑2000 images through the OpenJPEG codec",
-            "dependencies": [ "openjpeg" ]
-        },
         "tests": {
             "description": "Enable unit and integration tests",
             "dependencies": [


### PR DESCRIPTION
## Summary
Make encryption, JPEG, and JPEG2000 dependencies mandatory in the vcpkg port instead of optional features.

## Problem
Some feature configurations are not fully supported - disabling jpeg2000 or encryption causes build failures or test issues.

## Solution
- Move `openssl`, `libjpeg-turbo`, `openjpeg` from optional features to mandatory dependencies
- Remove `encryption`, `jpeg`, `jpeg2000` features from vcpkg.json
- Keep `tests` and `benchmarks` as optional features
- Remove redundant `-DVANILLAPDF_ENABLE_TESTS=OFF` and `-DVANILLAPDF_ENABLE_BENCHMARK=OFF` (CMake defaults them to OFF)

🤖 Generated with [Claude Code](https://claude.com/claude-code)