### PR TITLE
fix: Remove error suppression from backport label update

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -113,7 +113,7 @@ jobs:
           # Remove 'backport <branch>' label and add 'backported <branch>' label
           gh pr edit "$ORIGINAL_PR" \
             --remove-label "backport $TARGET_BRANCH" \
-            --add-label "backported $TARGET_BRANCH" || true
+            --add-label "backported $TARGET_BRANCH"
 
           # Post comment on original PR
           BACKPORT_PR="${{ github.event.pull_request.number }}"


### PR DESCRIPTION
## Summary
Remove `|| true` from the label update command so errors are visible and can be investigated.

## Problem
The `|| true` was masking permission errors like missing `read:org` scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)