### PR TITLE
chore: Update copyright year to 2026

### DIFF
--- a/doc/src/input/index.dox
+++ b/doc/src/input/index.dox
@@ -12,6 +12,6 @@ Next be sure to take a look at \ref page_overview, which contains all the necess
 
 In case of any questions, do not hesitate to [contact us](mailto:info@vanillapdf.com).
 
-Copyright &copy; 2025 by [Vanilla.PDF Labs](mailto:info@vanillapdf.com)
+Copyright &copy; 2026 by [Vanilla.PDF Labs](mailto:info@vanillapdf.com)
 
 */

--- a/nuget/vanillapdf.csproj.in
+++ b/nuget/vanillapdf.csproj.in
@@ -10,7 +10,7 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageProjectUrl>https://github.com/vanillapdf/vanillapdf</PackageProjectUrl>
     <Description>Vanilla.PDF is a cross-platform SDK for creating and modifying PDF documents</Description>
-    <Copyright>Copyright 2018-2025 Vanilla.PDF Labs s.r.o.</Copyright>
+    <Copyright>Copyright 2018-2026 Vanilla.PDF Labs s.r.o.</Copyright>
     <PackageTags>pdf parsing sign native</PackageTags>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <IncludeBuildOutput>false</IncludeBuildOutput>

--- a/nuget/vanillapdf.runtime.csproj.in
+++ b/nuget/vanillapdf.runtime.csproj.in
@@ -10,7 +10,7 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageProjectUrl>https://github.com/vanillapdf/vanillapdf</PackageProjectUrl>
     <Description>Vanilla.PDF is a cross-platform SDK for creating and modifying PDF documents</Description>
-    <Copyright>Copyright 2018-2025 Vanilla.PDF Labs s.r.o.</Copyright>
+    <Copyright>Copyright 2018-2026 Vanilla.PDF Labs s.r.o.</Copyright>
     <PackageTags>pdf parsing sign native</PackageTags>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <IncludeBuildOutput>false</IncludeBuildOutput>


### PR DESCRIPTION
## Summary
- Update copyright year from 2025 to 2026 in NuGet package metadata and documentation

## Files updated
- `nuget/vanillapdf.csproj.in`
- `nuget/vanillapdf.runtime.csproj.in`
- `doc/src/input/index.dox`

🤖 Generated with [Claude Code](https://claude.com/claude-code)