### PR TITLE
ci: Add concurrency settings to prevent stuck pipelines

### DIFF
--- a/.github/workflows/build-brew-package.yml
+++ b/.github/workflows/build-brew-package.yml
@@ -20,6 +20,10 @@ on:
   schedule:
     - cron: '0 3 * * 1'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/build-deb-package.yml
+++ b/.github/workflows/build-deb-package.yml
@@ -20,6 +20,10 @@ on:
   schedule:
     - cron: '0 3 * * 1'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/build-nuget.yml
+++ b/.github/workflows/build-nuget.yml
@@ -49,6 +49,10 @@ on:
       - 'cmake/**'
       - 'vcpkg.json.in'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read  # Needed for future GitHub release or content access
   packages: read  # Needed for publishing NuGet packages within organization

--- a/.github/workflows/nightly-check.yml
+++ b/.github/workflows/nightly-check.yml
@@ -26,6 +26,10 @@ on:
   schedule:
     - cron: '0 2 * * 1'  # Every on Monday at 2 AM UTC
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 # Enable only minimum required permissions
 permissions:
   contents: read    # Download the repository source code


### PR DESCRIPTION
## Summary

- Add concurrency groups with `cancel-in-progress: true` to 4 workflows that were missing them
- Prevents duplicate/stuck runs when multiple commits are pushed rapidly to the same branch

**Workflows updated:**
- `nightly-check.yml` - Large matrix build (Linux, Windows, macOS)
- `build-deb-package.yml` - Debian package builds
- `build-brew-package.yml` - Homebrew package builds
- `build-nuget.yml` - NuGet package builds

## Test plan

- [x] Verify workflows still trigger correctly on push/PR
- [ ] Confirm older runs are cancelled when new commits are pushed

🤖 Generated with [Claude Code](https://claude.com/claude-code)