### PR TITLE
docs: Add Claude Code skills and coding style rules

### DIFF
--- a/.claude/rules/coding-style.md
+++ b/.claude/rules/coding-style.md
@@ -1,0 +1,27 @@
+# Coding Style
+
+Detailed coding style preferences for C++ code in this project. This file is continuously updated as new patterns are established.
+
+## Variable Initialization
+
+- Prefer `= value` over brace initialization `{value}` for scalar, atomic, and member variables
+  - Good: `std::atomic<int64_t> counter = 0;` / `int m_count = 0;`
+  - Avoid: `std::atomic<int64_t> counter{0};` / `int m_count{0};`
+
+## Increment and Decrement
+
+- Avoid standalone `var--`, `var++`, `++var`, `--var` as a full statement on its own line; use compound assignment `var -= 1` or `var += 1` instead
+  - Good: `s_active_object_count -= 1;` / `s_total_objects_created += 1;`
+  - Avoid: `s_active_object_count--;` / `s_total_objects_created++;`
+- Inline prefix `++var` / `--var` within expressions is fine (e.g., `auto current = ++s_active_object_count;`, `if (--m_ref_counter == 0)`)
+
+## Control Flow
+
+- When two consecutive single-line `if` statements can be combined with `||`, prefer the combined form
+  - Good: `return (A) || (B);`
+  - Avoid: `if (A) return true; return B;`
+
+## Visual Cohesion
+
+- Do not insert structurally different code into a group of similarly-looking lines without separating it with a blank line and a comment
+- Uniform blocks (e.g., a series of assignments, a series of `if`/`return` checks) should stay visually cohesive

--- a/.claude/rules/lessons/build-and-testing.md
+++ b/.claude/rules/lessons/build-and-testing.md
@@ -1,0 +1,3 @@
+# Build and Testing Lessons
+
+- Full test suite (`ctest`) takes ~40 minutes in Debug. Run the unit test executable directly for quick verification (~600ms): `build/windows-x64-msvc-17/src/vanillapdf.unittest/Debug/vanillapdf.unittest.exe`

--- a/.claude/rules/lessons/exceptions.md
+++ b/.claude/rules/lessons/exceptions.md
@@ -1,0 +1,7 @@
+# Exception Usage Lessons
+
+- `NotSupportedException` is only for legitimately valid input where functionality is not implemented (e.g., "compiled without OpenSSL", "TIFF predictor not supported"). Do not use it for unknown/unexpected values.
+- Unknown values read from PDF files → `ParseException`
+- Invalid user-supplied values or internal invariants → `InvalidParameterException`
+- Files in `semantics/` need `#include "syntax/exceptions/syntax_exceptions.h"` and the `syntax::` prefix to use `ParseException`, unless `using namespace syntax;` is in scope.
+- `InvalidParameterException` and other base exception classes from `utils/exceptions.h` are available everywhere via `precompiled.h` — no extra include needed.

--- a/.claude/rules/lessons/tooling.md
+++ b/.claude/rules/lessons/tooling.md
@@ -1,0 +1,3 @@
+# Tooling Lessons
+
+- The Edit tool requires a prior Read call on the same file in the same conversation. Grep results do not count as reading. Always Read before Edit.

--- a/.claude/skills/session-retrospective/SKILL.md
+++ b/.claude/skills/session-retrospective/SKILL.md
@@ -1,0 +1,46 @@
+---
+description: Capture lessons learned from the current session to improve future accuracy and speed
+auto-invoke: true
+---
+
+# Session Retrospective
+
+## When to auto-invoke
+
+Trigger this skill when any of the following happen during conversation:
+- The user corrects a mistake ("that's wrong", "I don't like this", "this is incorrect")
+- A tool call fails and requires a different approach
+- Something takes multiple attempts that should have taken one
+- The user shares non-obvious codebase knowledge or preferences
+- The conversation is wrapping up (user says "thanks", "that's all", commits final work)
+
+## What to capture
+
+For each lesson, record:
+- **What happened**: Brief description of the mistake or discovery
+- **Why it matters**: Impact on speed or correctness
+- **Rule**: The actionable takeaway
+
+## Where to write
+
+### Actionable rules → `.claude/rules/lessons/<topic>.md`
+
+Topic-based files under `.claude/rules/lessons/`. Each file stays small and focused. Current files:
+- `build-and-testing.md` — Build commands, test execution shortcuts
+- `exceptions.md` — Exception type usage and include patterns
+- `tooling.md` — Claude Code tool quirks and workarounds
+
+Create new topic files as needed (e.g., `git.md`, `api.md`, `codebase.md`). Format: bullet points, one rule per line, concise.
+
+Only add a rule if it would prevent a real mistake from recurring. Do not add obvious or generic advice.
+
+### Detailed notes → memory files
+
+Write verbose context, session-specific details, and exploratory notes to files under the auto memory directory. Use topic-based files (e.g., `debugging.md`, `codebase-knowledge.md`). Link from `MEMORY.md` if adding a new file.
+
+## When invoked manually
+
+When the user runs `/session-retrospective`, review the full conversation and:
+1. Identify all corrections, failed attempts, and rediscovered knowledge
+2. Update the appropriate files under `.claude/rules/lessons/` and memory files
+3. Summarize what was added or changed

--- a/.claude/skills/update-coding-style/SKILL.md
+++ b/.claude/skills/update-coding-style/SKILL.md
@@ -1,0 +1,20 @@
+---
+description: Update the project coding style guide when a style preference is expressed or discovered
+auto-invoke: true
+---
+
+# Update Coding Style
+
+When any of the following happen during conversation:
+- The user expresses a coding style preference ("I don't like X", "use Y instead", "this looks weird")
+- The user corrects a style choice in code you wrote
+- You notice a consistent pattern in the codebase that isn't yet documented
+
+Then update `.claude/rules/coding-style.md` with the new preference, using the same format as existing entries (section heading, bullet points with Good/Avoid examples).
+
+When invoked manually with `/update-coding-style`, perform a full scan:
+1. Read `.claude/rules/coding-style.md` to see what is already documented
+2. Sample recent commits and files under `src/vanillapdf/` to identify recurring patterns in: naming, formatting, control flow, error handling, comments, includes
+3. Add any new consistently-used patterns not yet documented
+4. Remove or update any rules that contradict current practice
+5. Summarize what was added or changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,9 +85,7 @@ For vcpkg port development, work in `ports/vanillapdf/` (not `external/vcpkg/por
 - Uses precompiled headers (`precompiled.h`)
 - Visual Studio .natvis files for debugging support
 - Follow existing patterns in similar classes
-- Do not insert structurally different code into a group of similarly-looking lines without separating it with a blank line and a comment. Uniform blocks (e.g., a series of assignments) should stay visually cohesive.
-- Prefer `= value` assignment over `{value}` brace initialization for member variables (e.g., `int m_count = 0;` not `int m_count{0};`)
-- When two consecutive single-line `if` statements can be combined with `||`, prefer the combined form: `return (A) || (B);` instead of `if (A) return true; return B;`
+- See `.claude/rules/coding-style.md` for detailed coding style preferences
 
 ### Contribution Guidelines
 


### PR DESCRIPTION
## Summary

- Add `.claude/rules/coding-style.md` consolidating all coding style preferences (variable initialization, increment/decrement, control flow, visual cohesion)
- Add `.claude/skills/update-coding-style/` — auto-invokes when style preferences are expressed, updates the coding style file
- Add `.claude/skills/session-retrospective/` — auto-invokes to capture lessons learned (mistakes, corrections, codebase knowledge) into topic-based files
- Add `.claude/rules/lessons/` directory with initial notes on build/testing, exceptions, and tooling
- Move inline style rules from `CLAUDE.md` to the dedicated coding style file

## Test plan

- [x] No code changes — documentation and Claude Code configuration only
- [ ] Verify skills auto-invoke correctly in future sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)