### PR TITLE
fix: Escalate hdiutil detach to -force on macOS CI

### DIFF
--- a/scripts/hdiutil_retry.sh
+++ b/scripts/hdiutil_retry.sh
@@ -4,13 +4,39 @@
 # Based on workaround from: https://github.com/HEXRD/hexrdgui/pull/1768
 # Related: https://gitlab.kitware.com/cmake/cmake/-/issues/25671
 
+COMMAND="$1"
+
+# For detach, escalate to -force after gentle attempts fail
+if [ "$COMMAND" = "detach" ]; then
+    for i in {1..5}; do
+        if /usr/bin/hdiutil "$@"; then
+            exit 0
+        fi
+        echo "hdiutil detach failed, attempt $i/10" >&2
+        sleep 3
+    done
+
+    # Escalate to force detach
+    for i in {6..10}; do
+        if /usr/bin/hdiutil "$@" -force; then
+            exit 0
+        fi
+        echo "hdiutil detach -force failed, attempt $i/10" >&2
+        sleep 3
+    done
+
+    echo "hdiutil detach failed after 10 attempts" >&2
+    exit 1
+fi
+
+# For all other commands (create, attach, etc.) retry normally
 for i in {1..10}; do
     if /usr/bin/hdiutil "$@"; then
         exit 0
     fi
-    echo "hdiutil $1 failed, attempt $i/10" >&2
+    echo "hdiutil $COMMAND failed, attempt $i/10" >&2
     sleep 2
 done
 
-echo "hdiutil $1 failed after 10 attempts" >&2
+echo "hdiutil $COMMAND failed after 10 attempts" >&2
 exit 1


### PR DESCRIPTION
## Summary

- Fix intermittent CPack DragNDrop packaging failure on macOS CI caused by XProtect/Spotlight holding file handles on the mounted volume
- Split `hdiutil detach` retry logic: 5 gentle attempts (3s sleep), then escalate to `detach -force` for remaining 5 attempts
- Other hdiutil commands (create, attach) keep original retry behavior

## Test plan

- [x] Verify macOS packaging job passes on CI (macos-13 x64 runner)

🤖 Generated with [Claude Code](https://claude.com/claude-code)