### PR TITLE
docs: Trim context rules to reduce token usage

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -2,297 +2,66 @@
 
 ## Core Structure
 
-- **src/vanillapdf/** - Main library implementation (C++17)
-  - **syntax/** - Low-level PDF syntax parsing and objects
-  - **semantics/** - High-level PDF document semantics
-  - **contents/** - Content stream parsing and operations
-  - **utils/** - Utility classes and interfaces
-  - **implementation/** - C interface bridge layer
-- **src/vanillapdf.tools/** - CLI utility (C code)
-- **src/vanillapdf.test/** - Integration tests (C code, one test per PDF)
+- **src/vanillapdf/** - Main library (C++17): `syntax/`, `semantics/`, `contents/`, `utils/`, `implementation/` (C bridge)
+- **src/vanillapdf.tools/** - CLI utility (C)
+- **src/vanillapdf.test/** - Integration tests (C, one test per PDF)
 - **src/vanillapdf.unittest/** - Unit tests (GoogleTest, C++)
 - **src/vanillapdf.benchmark/** - Benchmarks (Google Benchmark, C++)
 
 ## Layered Architecture
 
-Three distinct layers, each with C++ internals and a C API surface:
+1. **Syntax Layer** (`syntax/`) - PDF objects, parsing, file structure
+2. **Semantics Layer** (`semantics/`) - Pages, annotations, forms, signatures
+3. **Contents Layer** (`contents/`) - Content stream parsing and operations
 
-1. **Syntax Layer** - Low-level PDF objects and file structure
-2. **Semantics Layer** - High-level document concepts (pages, annotations, forms)
-3. **Contents Layer** - Content stream parsing and operations
+## Object Model
 
-## Object Model - Class Hierarchy
+### Type Hierarchy (syntax/objects/)
 
-### PDF Object Hierarchy (syntax/objects/)
+`Object` (abstract, Versionable) → `ContainableObject` (abstract) with concrete types:
+- **Collections**: `MixedArrayObject`, `ArrayObject<T>`, `DictionaryObject` (thread-safe)
+- **Strings**: `LiteralStringObject`, `HexadecimalStringObject` (thread-safe)
+- **Numerics**: `IntegerObject`, `RealObject`
+- **Simple**: `BooleanObject`, `NameObject`, `NullObject` (singleton)
+- **References**: `IndirectReferenceObject` (lazy-resolving, thread-safe)
+- **Streams**: `StreamObject` (dict header + raw data, thread-safe, lazy decode)
 
-```
-Object (abstract) : Versionable, IWeakReferenceable<Object>
-├── ContainableObject (abstract marker - objects that go inside arrays/dicts)
-│   ├── MixedArrayObject (concrete, stores vector<ContainableObjectPtr>)
-│   │   └── ArrayObject<T> (template wrapper with type-safe access)
-│   ├── DictionaryObject (concrete, stores map<NameObjectPtr, ContainableObjectPtr>)
-│   │   └── Thread-safe: uses std::shared_ptr<std::recursive_mutex>
-│   ├── StringObjectBase (abstract)
-│   │   ├── LiteralStringObject (concrete, parenthesis-delimited)
-│   │   └── HexadecimalStringObject (concrete, angle-bracket-delimited)
-│   │   └── Both thread-safe with std::shared_ptr<std::recursive_mutex>
-│   ├── NumericObject (abstract, backed by NumericObjectBackend)
-│   │   ├── IntegerObject (concrete)
-│   │   └── RealObject (concrete)
-│   ├── BooleanObject (concrete)
-│   ├── NameObject (concrete)
-│   ├── NullObject (singleton, concrete)
-│   └── IndirectReferenceObject (concrete, lazy-resolving weak reference)
-│       └── Thread-safe with std::recursive_mutex
-└── StreamObject (concrete, DictionaryObject header + raw data)
-    └── Thread-safe with std::shared_ptr<std::recursive_mutex>
-    └── Lazy decoding: _body_raw → _body_decrypted → _body_decoded
-```
+Type enum: `Object::Type { Null, Array, Boolean, Dictionary, Integer, Name, Real, Stream, String, IndirectReference }`
 
-### Object Type Enum
+### Smart Pointers
 
-```cpp
-Object::Type { Null, Array, Boolean, Dictionary, Integer, Name, Real, Stream, String, IndirectReference }
-```
-
-### Key Object Methods
-
-- `GetObjectType()` - Returns Type enum
-- `ToPdf()`, `ToPdfStream()` - Serialize to PDF format
-- `IsIndirect()`, `GetXrefEntry()` - Cross-reference association
-- `IsDirty()`, `SetDirty()` - Change tracking
-- `GetOffset()`, `SetOffset()` - File position (bytes from start)
-- `Hash()`, `Equals()` - Equality and hashing
-- `Clone()` - Deep copy
-- `SetFile()`, `GetFile()` - File association (weak reference)
-- `SetOwner()`, `GetOwner()` - Parent-child ownership
+- **`Deferred<T>`** (`utils/deferred.h`): Ref-counted pointer via `IUnknown::AddRef()/Release()`. Create with `make_deferred<T>(...)`. Common typedefs: `ObjectPtr`, `StringObjectPtr`, `DictionaryObjectPtr`, `ArrayObjectPtr<T>`
+- **`WeakReference<T>`** (`utils/unknown_interface.h`): Prevents use-after-free via `std::atomic<bool>` counter. Check `IsActive()`, promote with `GetReference()`
+- **`IUnknown`**: Base class with `std::atomic<uint32_t>` ref counter; `Release()` deletes at 0
 
 ### Object Lifecycle
 
-1. **Creation**: Via constructors, parser, or `make_deferred<T>(...)`
-2. **File Association**: `SetFile(WeakReference<File>)` links to owning PDF
-3. **Xref Registration**: `SetXrefEntry()` registers in cross-reference table
-4. **Ownership**: `SetOwner()` establishes parent-child relationships
-5. **Mutation**: Changes call `IncrementVersion()` to mark object dirty
-6. **Serialization**: `ToPdfStream()` outputs to PDF format
-7. **Cleanup**: `Release()` via reference counting
-
-## Smart Pointer System
-
-### Deferred<T> (utils/deferred.h) - Primary Smart Pointer
-
-Reference-counted pointer that integrates with `IUnknown::AddRef()/Release()`:
-
-```cpp
-// Creation
-ObjectPtr obj = make_deferred<IntegerObject>(42);
-
-// Copy (increments ref count)
-ObjectPtr copy = obj;
-
-// Move (steals ownership, zeros source)
-ObjectPtr moved = std::move(obj);
-
-// Dereference
-int value = (*obj)->GetValue();
-
-// Raw pointer with incremented refcount (for C API returns)
-Object* ptr = obj.AddRefGet();
-
-// Automatic weak reference conversion
-WeakReference<Object> weak = obj;
-```
-
-**Common Typedefs**:
-- `ObjectPtr` = `Deferred<Object>`
-- `StringObjectPtr` = `Deferred<StringObjectBase>`
-- `DictionaryObjectPtr` = `Deferred<DictionaryObject>`
-- `ArrayObjectPtr<T>` = `Deferred<ArrayObject<T>>`
-
-### WeakReference<T> (utils/unknown_interface.h)
-
-Prevents use-after-free via shared counter:
-
-```cpp
-WeakReference<Object> weak = obj.GetWeakReference();
-if (weak.IsActive()) {
-    ObjectPtr strong = weak.GetReference(); // Throws if disposed
-}
-```
-
-Storage: `{T* m_ptr, shared_ptr<WeakReferenceCounter> m_counter}` where counter uses `std::atomic<bool>`.
-
-## IUnknown Reference Counting
-
-All objects inherit from `IUnknown`:
-
-```cpp
-class IUnknown {
-    std::atomic<uint32_t> m_ref_counter;
-public:
-    void AddRef();    // Atomic increment
-    void Release();   // Atomic decrement; delete when 0
-};
-```
+Creation → `SetFile()` → `SetXrefEntry()` → `SetOwner()` → mutations call `IncrementVersion()` → `ToPdfStream()` → `Release()`
 
 ## Parser Architecture (syntax/parsers/)
 
-```
-Tokenizer (base - character-by-character token reading with offset cache)
-├── ParserBase (extends Tokenizer - converts tokens to Object instances)
-│   └── Parser (full PDF parsing - xrefs, indirect objects, streams)
-└── ReverseTokenizer (reads backwards from end of file)
-    └── ReverseParser (finds xref offset from EOF)
-```
-
-### Tokenizer
-
-- Reads tokens from input stream character-by-character
-- Caching: `std::map<stream_offset, CacheItem>` avoids re-reads
-- Key methods: `ReadToken()`, `PeekToken()`, `ReadTokenWithType()`
-- Private readers: `ReadComment()`, `ReadHexadecimalString()`, `ReadLiteralString()`, `ReadName()`, `ReadUnknown()`
-
-### ParserBase
-
-- Stores `WeakReference<File>` for object context
-- `ReadDirectObject()` dispatches to type-specific readers
-- `ReadArray()`, `ReadDictionary()`, `ReadDictionaryStream()`
-- Templated: `ReadDirectObjectWithType<T>()`
-
-### Parser (implements IParser)
-
-- `ReadXref()` - Reads from offset or current position
-- `ReadIndirectObject()` - Reads `obj gen obj ... endobj`
-- `ReadObjectStreamEntries()` - Parses object streams (PDF 1.5+)
-- `ReadHeader()` - Extracts `%PDF-X.Y` version
-- `FindAllObjects()` - Builds complete xref chain
-- Private: `ReadXrefTable()`, `ReadXrefStream()`, `ParseXrefStream()`
-
-### ReverseParser
-
-- Finds xref offset from end of file (reverse scanning)
-- Key method: `ReadLastXrefOffset()`
-- Used in `File::Initialize()` to locate trailer
+`Tokenizer` → `ParserBase` → `Parser` (full PDF: xrefs, indirect objects, streams)
+`ReverseTokenizer` → `ReverseParser` (finds xref offset from EOF)
 
 ## Content Stream Processing (contents/)
 
-### Instruction Hierarchy
-
-```
-InstructionBase (abstract - token or operation)
-├── PDFObject (wraps syntax::Object)
-└── OperationBase (abstract - PDF operation, 88 types)
-    ├── GenericOperation (parameterized)
-    └── 88 specific operations (LineWidth, SaveGraphicsState, TextFont, TextShow, etc.)
-
-BaseInstructionCollection (container of InstructionBase)
-└── STL-compatible: begin(), end(), at(), push_back()
-```
-
-### Operation Types (OperationBase::Type enum, 88 values)
-
-Categories: Graphics state (5), Path construction (10), Path painting (8), Text operations (16), Color operations (8), Inline images, Marked content, XObject, Shading, etc.
-
-### ContentStreamParser
-
-- Input: Stream content (compressed/decompressed)
-- Output: `BaseInstructionCollection` of mixed objects and operations
-- Handles CID→Unicode mapping for text via character maps
-- Handles inline images (BI...ID...EI structure)
+`InstructionBase` → `PDFObject` (wraps syntax Object) or `OperationBase` (88 operation types)
+`ContentStreamParser` produces `BaseInstructionCollection` from stream content.
 
 ## Semantic Layer (semantics/objects/)
 
-### Base Class: HighLevelObject<T>
+All inherit `HighLevelObject<T>` wrapping a syntax object (typically `DictionaryObjectPtr`).
 
-```cpp
-template <typename T>
-class HighLevelObject : public virtual IUnknown {
-protected:
-    T _obj;  // Wrapped syntax object (typically DictionaryObjectPtr)
-};
-```
-
-### Key Semantic Classes
-
-- **Document** - Top-level. Static factories: `Open()`, `Create()`. Methods: `Save()`, `SaveIncremental()`, `Sign()`, `AddEncryption()`, `RemoveEncryption()`, `AppendDocument()`
-- **Catalog** - Root of document structure. Contains Pages, Names, AcroForm
-- **PageObject** / **PageTree** - Hierarchical page structure
-- **InteractiveForm** / **FormField** - AcroForm objects and field definitions
-- **DigitalSignature** - Signature dictionary with contact info, reason, certificate
-- **Annotations** - Page annotations (links, comments, etc.)
-- **Destinations** - Named destinations for links/jumps
-- **NameDictionary** / **NameTree** - Hierarchical name storage
-- **CharacterMap** - CID font character mappings
-
-### Extension Pattern
-
-```cpp
-class DigitalSignatureExtensions {
-public:
-    static SignatureVerificationResultPtr Verify(
-        DigitalSignaturePtr signature, DocumentPtr document,
-        TrustedCertificateStorePtr trusted_store,
-        SignatureVerificationSettingsPtr settings
-    );
-};
-```
+Key classes: `Document` (Open/Create/Save/Sign), `Catalog`, `PageObject`/`PageTree`, `InteractiveForm`/`FormField`, `DigitalSignature`, `Annotations`, `Destinations`, `NameDictionary`/`NameTree`, `CharacterMap`
 
 ## Exception Hierarchy (utils/exceptions.h)
 
-```cpp
-ExceptionBase : std::exception
-├── Type enum (uint32_t):
-│   Success = 0, InvalidParameter, NotSupported, UserCancelled,
-│   ZlibDataError, InvalidLicense, LicenseRequired, InsufficientSpace,
-│   Conversion = 0x00010000, FileDisposed, FileNotInitialized,
-│   ObjectMissing, ParseException, InvalidPassword, DuplicateKey,
-│   OptionalEntryMissing = 0x10000000, SemanticContext,
-│   General = 0xFFFFFFFF
-```
+`ExceptionBase : std::exception` with `Type` enum mapping 1:1 to C API error codes via `CATCH_VANILLAPDF_EXCEPTIONS`. Key types: `InvalidParameter`, `NotSupported`, `ParseException`, `ObjectMissing`, `InvalidPassword`, `OptionalEntryMissing`, `General`
 
-Maps 1:1 to C API error codes via `CATCH_VANILLAPDF_EXCEPTIONS` macro.
+## Dirty Tracking
 
-## Dirty Tracking (Versionable)
-
-Objects use poll-based version counters instead of push-based observers:
-
-- **Versionable base class**: `std::atomic<uint32_t> m_version` + `bool m_initialized`
-- Each object increments its own version on mutation via `IncrementVersion()`
-- **Leaf objects**: `IsDirty() = m_version > 0`
-- **Containers** (MixedArrayObject, DictionaryObject, StreamObject): `IsDirty()` checks own version + iterates children
-- **NumericObject/NameObject/StringObjects**: Check own version + backend/buffer version
-- **XrefUsedEntryBase**: Checks own version + referenced object's `IsDirty()`
-- **Xref tables**: Track structural changes only (Add/Remove entries)
-- `IObservable<T>` template preserved for `IFileWriterObservable` (file writer events)
-
-## Thread Safety
-
-**Thread-safe components** (use `std::recursive_mutex` or atomics):
-- `IUnknown::m_ref_counter` - `std::atomic<uint32_t>`
-- `WeakReferenceCounter::m_active` - `std::atomic<bool>`
-- `DictionaryObject` - `std::shared_ptr<std::recursive_mutex> m_access_lock`
-- `StreamObject` - `std::shared_ptr<std::recursive_mutex> _access_lock`
-- `StringObjectBase` (both variants) - `std::shared_ptr<std::recursive_mutex> _access_lock`
-- `IndirectReferenceObject` - `std::recursive_mutex m_access_lock`
-- Streams: `ExclusiveInputLock()` / `ExclusiveInputUnlock()`
-
-**Not thread-safe** (single-threaded model assumed):
-- Most objects don't use locks
-- Content stream parsing and file reading not fully protected
-- Locks are "infrastructure for future" per code comments
+Poll-based `Versionable` with `std::atomic<uint32_t> m_version`. Leaf: dirty if version > 0. Containers: check own version + iterate children.
 
 ## Feature Dependencies
 
-Optional, controlled by `VANILLAPDF_HAVE_*` compile definitions:
-- OpenSSL (`VANILLAPDF_HAVE_OPENSSL`): Encryption/decryption and digital signing
-- libjpeg-turbo (`VANILLAPDF_HAVE_JPEG`): JPEG image support
-- openjpeg (`VANILLAPDF_HAVE_OPENJPEG`): JPEG 2000 support
-- zlib (`VANILLAPDF_HAVE_ZLIB`): PDF object compression
-- spdlog: Logging framework
-- nlohmann-json: Configuration parsing
-
-## Development Tools
-
-- `.natvis` files: Visual Studio debugger visualizations (`public.natvis`, `vanillapdf.natvis`)
-- `precompiled.h` includes: `deferred.h`, `constants.h`, `exceptions.h`, `log.h`, `util.h`, `object_utils.h`, `objects.h`
-- Debug memory tracking on MSVC: `_CRTDBG_MAP_ALLOC` with `pdf_new` macro
+Optional via `VANILLAPDF_HAVE_*`: OpenSSL (encryption/signing), libjpeg-turbo, openjpeg, zlib, spdlog, nlohmann-json

--- a/.claude/rules/build-system.md
+++ b/.claude/rules/build-system.md
@@ -6,89 +6,25 @@
 - Use Debug only for targeted tests: `ctest --preset <preset> --build-config Debug -R "TestPattern" --output-on-failure`
 - Use **Release** (`--build-config Release`) for full test suite runs.
 
-## CMake Presets (Recommended)
+## CMake Presets
 
-List available presets:
-```bash
-cmake --list-presets
-```
+Presets organized by platform in `cmake/presets/{windows,linux,macos,android}.json`. Each includes configure, build, and test configurations. List with `cmake --list-presets`.
 
-### Presets Structure
-
-Presets are organized by platform in separate files:
-- `cmake/presets/windows.json` - Visual Studio and Ninja generators
-- `cmake/presets/linux.json` - GCC and Clang compilers
-- `cmake/presets/macos.json` - AppleClang for x64 and ARM64
-- `cmake/presets/android.json` - NDK toolchain for all Android ABIs
-
-Each preset includes configure, build, and test configurations.
-
-Common presets include:
-- `windows-x64-msvc-17` / `windows-x86-msvc-17` - Windows with Visual Studio 2022 (dynamic CRT)
-- `windows-x64-msvc-17-static` / `windows-x86-msvc-17-static` - Windows with Visual Studio 2022 (static CRT)
-- `windows-x64-msvc-17-static-md` / `windows-x86-msvc-17-static-md` - Windows with Visual Studio 2022 (static libs, dynamic CRT)
-- `windows-x64-msvc-18` / `windows-x86-msvc-18` - Windows with Visual Studio 2026 (dynamic CRT)
-- `windows-x64-msvc-18-static` / `windows-x86-msvc-18-static` - Windows with Visual Studio 2026 (static CRT)
-- `windows-x64-msvc-18-static-md` / `windows-x86-msvc-18-static-md` - Windows with Visual Studio 2026 (static libs, dynamic CRT)
-- `linux-x64-gcc` / `linux-arm64-gcc` - Linux with GCC
-- `linux-x64-clang` / `linux-arm64-clang` - Linux with Clang
-- `linux-x64-musl` / `linux-arm64-musl` / `linux-arm-musl` - Linux with musl libc
-- `macos-x64` / `macos-arm64` - macOS builds
-- `android-*` - Android builds (arm64, armv7, x86, x86_64)
-
-Build with a preset:
-```bash
-cmake --preset windows-x64-msvc-17
-cmake --build --preset windows-x64-msvc-17
-```
-
-### Windows Build Notes
-
-Windows presets use Visual Studio generators and automatically configure:
-- CRT linking based on preset variant:
-  - Standard presets (`windows-x*-msvc-17`, `windows-x*-msvc-18`): Dynamic CRT (default)
-  - Static presets (`windows-x*-msvc-17-static`, `windows-x*-msvc-18-static`): Static CRT (`VANILLAPDF_USE_STATIC_CRT=ON`)
-  - Static-MD presets (`windows-x*-msvc-17-static-md`, `windows-x*-msvc-18-static-md`): Static libs + dynamic CRT
-- Platform-specific vcpkg triplets:
-  - `x64-windows` (standard presets, dynamic CRT)
-  - `x64-windows-static` (static presets, static CRT)
-  - `x64-windows-static-md` (static-md presets, static libs + dynamic CRT)
-- Visual Studio 2022 (msvc-17) and Visual Studio 2026 (msvc-18) generators available
+Common patterns: `windows-x64-msvc-17`, `windows-x64-msvc-17-static` (static CRT), `windows-x64-msvc-17-static-md` (static libs + dynamic CRT). Same variants for `msvc-18` (VS 2026). Linux: `linux-x64-gcc`, `linux-x64-clang`, `linux-x64-musl`. macOS: `macos-x64`, `macos-arm64`.
 
 ## Build Targets
 
-| Target | Type | Language | Depends On | Enabled By |
-|--------|------|----------|------------|------------|
-| `vanillapdf` | STATIC or SHARED lib | C++17 | vcpkg deps | Always |
-| `vanillapdf.tools` | Executable | C | vanillapdf | Always |
-| `vanillapdf.unittest` | Executable | C++ | vanillapdf, GTest | `VANILLAPDF_ENABLE_TESTS=ON` |
-| `vanillapdf.test` | Executable | C | vanillapdf, Python3 | `VANILLAPDF_ENABLE_TESTS=ON` |
-| `vanillapdf.benchmark` | Executable | C++ | vanillapdf, benchmark | `VANILLAPDF_ENABLE_BENCHMARK=ON` |
+| Target | Type | Language | Enabled By |
+|--------|------|----------|------------|
+| `vanillapdf` | STATIC/SHARED lib | C++17 | Always |
+| `vanillapdf.tools` | Executable | C | Always |
+| `vanillapdf.unittest` | Executable | C++ | `VANILLAPDF_ENABLE_TESTS=ON` |
+| `vanillapdf.test` | Executable | C | `VANILLAPDF_ENABLE_TESTS=ON` |
+| `vanillapdf.benchmark` | Executable | C++ | `VANILLAPDF_ENABLE_BENCHMARK=ON` |
 
-Alias: `vanillapdf::vanillapdf` for CMake consumption via `find_package(vanillapdf CONFIG)`.
+## Adding New Source Files
 
-## Source File Organization
-
-Source files use **explicit lists** (NOT `file(GLOB)`). All declared in `src/vanillapdf/CMakeLists.txt`:
-
-```cmake
-VANILLAPDF_SYNTAX_SOURCES          # syntax/objects/, parsers/, files/, filters/, exceptions/
-VANILLAPDF_SEMANTICS_SOURCES       # semantics/objects/, extensions/, utils/
-VANILLAPDF_CONTENTS_SOURCES        # contents/
-VANILLAPDF_UTILS_SOURCES           # utils/, streams/
-VANILLAPDF_C_IMPLEMENTATION_*      # implementation/ bridge layer (utils/syntax/semantics/contents)
-```
-
-Public headers listed in `include/files.cmake`:
-```cmake
-VANILLAPDF_INCLUDE_HEADERS           # 6 core headers (c_export, c_handles, c_types, etc.)
-VANILLAPDF_INCLUDE_UTILS_HEADERS     # 13 headers
-VANILLAPDF_INCLUDE_SYNTAX_HEADERS    # 18 headers
-VANILLAPDF_INCLUDE_SEMANTICS_HEADERS # 24 headers
-VANILLAPDF_INCLUDE_CONTENTS_HEADERS  # 6 headers
-```
-
-### Adding New Source Files
+Source files use **explicit lists** (NOT `file(GLOB)`):
 
 | Task | Where to Edit |
 |------|---------------|
@@ -98,134 +34,28 @@ VANILLAPDF_INCLUDE_CONTENTS_HEADERS  # 6 headers
 | Add unit test file | `src/vanillapdf.unittest/CMakeLists.txt` → `VANILLAPDF_UNITTEST_SOURCES` |
 | Add integration test | Place `.pdf` in `test/` directory (auto-discovered via `file(GLOB_RECURSE)`) |
 
-## CMake Configuration Options
+## Key CMake Options
 
-### Feature Enable/Disable
+Features (all default ON): `VANILLAPDF_ENABLE_{ENCRYPTION,JPEG,JPEG2000,ZLIB}` → defines `VANILLAPDF_HAVE_*`
 
-```cmake
-VANILLAPDF_ENABLE_ENCRYPTION    # ON/OFF (default ON) → VANILLAPDF_HAVE_OPENSSL
-VANILLAPDF_ENABLE_JPEG          # ON/OFF (default ON) → VANILLAPDF_HAVE_JPEG
-VANILLAPDF_ENABLE_JPEG2000      # ON/OFF (default ON) → VANILLAPDF_HAVE_OPENJPEG
-VANILLAPDF_ENABLE_ZLIB          # ON/OFF (default ON) → VANILLAPDF_HAVE_ZLIB
-```
+Build options: `VANILLAPDF_INTERNAL_VCPKG` (ON), `VANILLAPDF_ENABLE_TESTS` (ON), `VANILLAPDF_ENABLE_BENCHMARK` (ON), `VANILLAPDF_USE_STATIC_CRT` (OFF), `BUILD_SHARED_LIBS` (ON), `VANILLAPDF_ENABLE_COVERAGE`, `VANILLAPDF_ENABLE_STACK_SANITIZER`
 
-Pattern in CMakeLists.txt:
-```cmake
-if (VANILLAPDF_ENABLE_ENCRYPTION AND OPENSSL_FOUND)
-    target_link_libraries(vanillapdf PRIVATE OpenSSL::Crypto)
-    target_compile_definitions(vanillapdf PRIVATE -DVANILLAPDF_HAVE_OPENSSL)
-endif ()
-```
+External deps (all OFF): `VANILLAPDF_EXTERNAL_{OPENSSL,JPEG,OPENJPEG,ZLIB,SPDLOG,NLOHMANN_JSON}` — use system instead of vcpkg.
 
-### Build Options
+## vcpkg
 
-- `VANILLAPDF_INTERNAL_VCPKG=ON/OFF` (default ON) - Use internal vcpkg
-- `VANILLAPDF_ENABLE_PACKAGING=ON/OFF` (auto-detected) - CPack packaging
-- `VANILLAPDF_ENABLE_TESTS=ON/OFF` (default ON) - Build tests
-- `VANILLAPDF_ENABLE_BENCHMARK=ON/OFF` (default ON) - Build benchmarks
-- `VANILLAPDF_SKIP_CMAKE_CONFIG_INSTALL=ON/OFF` (default OFF)
-- `VANILLAPDF_USE_STATIC_CRT=ON/OFF` (default OFF) - Static MSVC runtime
-- `BUILD_SHARED_LIBS=ON/OFF` (default ON) - Shared vs static library
-- `VANILLAPDF_ENABLE_COVERAGE=ON` - Code coverage (GCC/Clang)
-- `VANILLAPDF_FORCE_32_BIT=ON` - Force 32-bit binary
-- `VANILLAPDF_ENABLE_STACK_SANITIZER=ON` - Address sanitizer
-
-### External Dependency Options (all default OFF)
-
-`VANILLAPDF_EXTERNAL_{OPENSSL,JPEG,OPENJPEG,ZLIB,SPDLOG,NLOHMANN_JSON}` - Use system instead of vcpkg.
-
-### Symbol Export (Shared Library)
-
-Defined in CMakeLists.txt when `BUILD_SHARED_LIBS=ON`:
-- `VANILLAPDF_EXPORTS` (PRIVATE) - Library exports symbols
-- `VANILLAPDF_CONFIGURATION_DLL` (PUBLIC) - Consumers import symbols
-
-## Precompiled Header
-
-File: `src/vanillapdf/precompiled.h` - Includes:
-- `c_platform.h` (platform detection)
-- Debug memory tracking on MSVC (`_CRTDBG_MAP_ALLOC`, `pdf_new` macro)
-- `utils/deferred.h`, `utils/constants.h`, `utils/exceptions.h`, `utils/log.h`, `utils/util.h`
-- `syntax/utils/object_utils.h`, `syntax/objects/objects.h`
-
-Setup: `target_precompile_headers(vanillapdf PRIVATE precompiled.h)`
-
-## vcpkg Dependencies
-
-Initialize submodules first:
-```bash
-git submodule sync --recursive && git submodule update --init --recursive
-```
-
-### vcpkg.json Manifest
-
-Generated from `vcpkg.json.in` at configure time by `cmake/vcpkg_manifest.cmake`.
-
-**Always included**: spdlog, nlohmann-json
-
-**Feature-based** (enabled by CMake options):
-- `encryption` → openssl
-- `jpeg` → libjpeg-turbo
-- `jpeg2000` → openjpeg
-- `zlib` → zlib
-- `tests` → gtest
-- `benchmarks` → benchmark
-
-## Conan Dependencies
-
-Recipe in `conan/conanfile.py`. Build:
-```bash
-pip install "conan>=2,<3"
-conan profile detect
-conan create conan/ --version=2.3.0 --build=missing
-```
-
-## Version Management
-
-Set in `cmake/version.cmake`. CI can override via `VANILLAPDF_VERSION_{MAJOR,MINOR,PATCH}_OVERRIDE`. Build suffix: `-nightly.main` for pre-release.
+vcpkg.json generated from `vcpkg.json.in` at configure time by `cmake/vcpkg_manifest.cmake`. Always included: spdlog, nlohmann-json. Feature-based: encryption→openssl, jpeg→libjpeg-turbo, jpeg2000→openjpeg, zlib→zlib, tests→gtest, benchmarks→benchmark.
 
 ## CMake Module Files
 
 | File | Purpose |
 |------|---------|
-| `cmake/compiler_flags.cmake` | Warning levels and flag settings |
+| `cmake/compiler_flags.cmake` | Warning levels and flags |
 | `cmake/compiler_checks.cmake` | C++17 feature detection |
-| `cmake/coverage.cmake` | Code coverage configuration |
-| `cmake/sanitizers.cmake` | Address sanitizer setup |
-| `cmake/vcpkg_manifest.cmake` | vcpkg.json template generation |
-| `cmake/vcpkg_init.cmake` | vcpkg initialization and feature management |
-| `cmake/version.cmake` | Version number definitions |
-| `cmake/packaging.cmake` | CPack and distribution packaging |
-| `cmake/vanillapdf_install.cmake` | Installation target definitions |
-| `cmake/generate_test_certificates.cmake` | Test certificate generation |
-
-## CLI Tools
-
-```bash
-./vanillapdf-tools sign -s input.pdf -d signed.pdf -k private_key.p12 -p password
-./vanillapdf-tools verify -f signed.pdf --skip-certificate-validation
-./vanillapdf-tools --help
-```
-
-## Integration Testing
-
-### FetchContent (`examples/fetchcontent-integration/`)
-
-```bash
-cd examples/fetchcontent-integration
-cmake --preset windows-x64-debug  # or linux-x64-debug, macos-arm64-debug
-cmake --build --preset windows-x64-debug
-ctest --preset windows-x64-debug --output-on-failure
-```
-
-Platform strategies: Windows (internal vcpkg), Linux (apt packages), macOS (Homebrew).
-
-### Conan (`examples/conan-integration/`)
-
-```bash
-conan create conan/ --version=2.3.0 --build=missing
-cd examples/conan-integration
-conan install . --build=missing
-cmake --preset linux-x64-debug && cmake --build --preset linux-x64-debug
-ctest --preset linux-x64-debug --output-on-failure
-```
+| `cmake/coverage.cmake` | Code coverage |
+| `cmake/sanitizers.cmake` | Address sanitizer |
+| `cmake/vcpkg_manifest.cmake` | vcpkg.json generation |
+| `cmake/vcpkg_init.cmake` | vcpkg initialization |
+| `cmake/version.cmake` | Version numbers (CI overrides via `VANILLAPDF_VERSION_*_OVERRIDE`) |
+| `cmake/packaging.cmake` | CPack packaging |
+| `cmake/vanillapdf_install.cmake` | Install targets |

--- a/.claude/rules/ci-cd.md
+++ b/.claude/rules/ci-cd.md
@@ -3,73 +3,30 @@
 ## GitHub Actions Workflows
 
 - `nightly-check.yml` - Full platform matrix testing (Linux, Windows, macOS, Android)
-- `coverage.yml` - Code coverage analysis with Codecov integration
-- `stack-sanitizer.yml` - Address sanitizer testing for memory safety
-- `codeql.yml` - Security analysis with GitHub CodeQL
+- `coverage.yml` - Code coverage with Codecov
+- `stack-sanitizer.yml` - Address sanitizer testing
+- `codeql.yml` - Security analysis
 - `build-nuget.yml` / `build-deb-package.yml` / `build-brew-package.yml` - Package building
 - `github-pages.yml` - Documentation deployment
-- `update-vcpkg.yml` - Automated monthly vcpkg updates (uses vanillapdf-bot)
-- `create-vcpkg-pr.yml` - Manual vcpkg update workflow (uses vanillapdf-bot)
-- `update-homebrew.yml` - Homebrew formula PR workflow (uses vanillapdf-bot)
-- `create-conan-pr.yml` - Conan Center Index PR workflow (uses vanillapdf-bot)
-- `release.yml` - Release automation workflow (uses vanillapdf-bot)
-- `backport.yml` - Automatic backporting of merged PRs to release branches
+- `update-vcpkg.yml` / `create-vcpkg-pr.yml` - vcpkg updates (vanillapdf-bot)
+- `update-homebrew.yml` - Homebrew formula PRs (vanillapdf-bot)
+- `create-conan-pr.yml` - Conan Center PRs (vanillapdf-bot)
+- `release.yml` - Release automation (vanillapdf-bot)
+- `backport.yml` - Auto-backport merged PRs to release branches
 
 ## Build Matrix
 
-Builds are tested on:
-- Windows: 2022, 2025 (x86/x64, MSVC 17)
-- Linux: Ubuntu 22.04/24.04, Rocky 8/9, Fedora 41/42 (x64/ARM64)
-- macOS: 13 (x64), 14/15 (ARM64)
-- Android: arm64, armv7, x86, x86_64
+Windows 2022/2025 (x86/x64), Linux Ubuntu 22.04/24.04, Rocky 8/9, Fedora 41/42 (x64/ARM64), macOS 13 (x64), 14/15 (ARM64), Android (arm64, armv7, x86, x86_64)
 
 ## Release Process
 
-**Branch Structure:**
-- `main` - Development branch (default)
-- `release/X.Y` - Release branches for major.minor versions
-- Tags: `vX.Y.Z` format on release branches
+- `main` → development, `release/X.Y` → release branches, tags `vX.Y.Z`
+- Major/Minor: create `release/X.Y` from `main`. Patch: work on existing `release/X.Y`
 
-**Workflow:**
-- Major/Minor: Create `release/X.Y` from `main`
-- Patch: Work on existing `release/X.Y`
-- Hotfixes: Branch from release branch if needed
+## Backporting
 
-## Homebrew Formula
+Add label `backport release/X.Y` to a PR before merging. The workflow cherry-picks and creates a backport PR automatically. If cherry-pick fails, manually create the backport.
 
-The Homebrew formula is maintained in `homebrew/vanillapdf.rb` and submitted to `Homebrew/homebrew-core` during releases.
+## Homebrew
 
-**Development:**
-- Formula source: `homebrew/vanillapdf.rb`
-- Integration test: `examples/homebrew-integration/`
-- Test locally: `brew install --build-from-source --HEAD ./homebrew/vanillapdf.rb`
-
-**Release workflow:**
-- `update-homebrew.yml` creates PRs to `Homebrew/homebrew-core` after production gate
-- Requires fork: `vanillapdf/homebrew-core`
-- Updates URL and SHA256 automatically from release tag
-
-## Backporting PRs to Release Branches
-
-To backport a merged PR to a release branch:
-
-1. Add a label `backport release/X.Y` to the PR (e.g., `backport release/2.2`)
-2. When the PR is merged, the backport workflow automatically:
-   - Cherry-picks the commit to the target branch
-   - Creates a new PR with title `[Backport release/X.Y] <original title>`
-   - Adds `backported release/X.Y` label to the new PR
-3. If cherry-pick fails (conflicts), manually create a backport PR
-
-Available labels:
-- `backport release/2.2` - Request backport to release/2.2 branch
-- `backport release/2.1` - Request backport to release/2.1 branch
-- `backported release/2.2` - PR was backported to release/2.2
-- `backported release/2.1` - PR was backported to release/2.1
-
-For new release branches, create labels following the patterns `backport <branch>` and `backported <branch>`.
-
-**Automated Workflows Using vanillapdf-bot:**
-- All vcpkg-related automation
-- Release processes and package updates
-- Monthly maintenance tasks
-- Any workflow that creates commits or PRs automatically
+Formula in `homebrew/vanillapdf.rb`. Test: `brew install --build-from-source --HEAD ./homebrew/vanillapdf.rb`. Releases auto-PR to `Homebrew/homebrew-core` via `update-homebrew.yml`.


### PR DESCRIPTION
## Summary
- Condense `architecture.md` (299→68 lines), `build-system.md` (232→62 lines), and `ci-cd.md` (76→33 lines)
- Remove code examples, duplicate content across files, and verbose listings
- Preserve all essential information (class names, type enums, file locations, option names)
- Estimated savings: ~4k tokens from memory file footprint

## Test plan
- [x] Verify no essential information was lost by reviewing trimmed files
- [ ] Confirm token usage reduction via `/context` in a new session

🤖 Generated with [Claude Code](https://claude.com/claude-code)