### PR TITLE
fix: Add missing prerelease and dry_run gates in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -231,7 +231,8 @@ jobs:
 
   github-pages:
     needs: [production-gate, prepare]
-    if: needs.prepare.outputs.dry_run == 'false'
+    # Only deploy documentation for official releases, not pre-releases (alpha, beta, rc)
+    if: needs.prepare.outputs.prerelease == 'false' && needs.prepare.outputs.dry_run == 'false'
     uses: ./.github/workflows/github-pages.yml
     with:
       deploy: true
@@ -258,7 +259,7 @@ jobs:
   homebrew-pr:
     needs: [production-gate, prepare]
     # Only create Homebrew PR for official releases, not pre-releases (alpha, beta, rc)
-    if: needs.prepare.outputs.prerelease == 'false'
+    if: needs.prepare.outputs.prerelease == 'false' && needs.prepare.outputs.dry_run == 'false'
     uses: ./.github/workflows/update-homebrew.yml
     with:
       tag: ${{ needs.prepare.outputs.tag }}


### PR DESCRIPTION
## Summary

- **github-pages**: Was missing the `prerelease == 'false'` check, causing alpha/beta/rc tags to deploy documentation to GitHub Pages
- **homebrew-pr**: Was missing the `dry_run == 'false'` check, allowing production dry-runs to create real Homebrew PRs

Both jobs now require `prerelease == 'false' && dry_run == 'false'`, consistent with `vcpkg-pr`, `conan-pr`, and `update-port`.

## Test plan

- [x] Run release workflow dry-run with a simulated alpha tag (e.g. `v2.3.0-alpha.1`) and verify github-pages and homebrew-pr are skipped
- [ ] Run release workflow dry-run with a simulated production tag (e.g. `v2.3.0`) and verify all jobs execute

🤖 Generated with [Claude Code](https://claude.com/claude-code)