### PR TITLE
feat: Add external PDF conformance validation with qpdf

### DIFF
--- a/.github/workflows/conformance-check.yml
+++ b/.github/workflows/conformance-check.yml
@@ -1,0 +1,175 @@
+name: Conformance check (qpdf)
+
+on:
+  workflow_dispatch:
+
+  pull_request:
+    branches: [ "main", "release/*" ]
+    paths:
+      - 'src/**'
+      - 'include/**'
+      - 'scripts/conformance_check.py'
+      - 'scripts/conformance_check.cfg'
+      - '.github/workflows/conformance-check.yml'
+
+  schedule:
+    - cron: '0 4 * * 1'  # Every Monday at 4 AM UTC
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  packages: read
+
+env:
+  VCPKG_ROOT: external/vcpkg
+  VCPKG_DISABLE_METRICS: 1
+
+jobs:
+
+  linux:
+    name: ubuntu.24.04-x64
+    runs-on: ubuntu-24.04
+    container:
+      image: ghcr.io/vanillapdf/vanillapdf-ubuntu-amd64:24.04
+      options: --platform=linux/amd64
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      # Share vcpkg cache with sanity-check and nightly-check (same config)
+      - name: Cache vcpkg
+        uses: actions/cache@v5
+        with:
+          path: |
+            build/linux-x64-gcc/vcpkg_installed
+            external/vcpkg/downloads
+            external/vcpkg/buildtrees
+            external/vcpkg/packages
+          key: vcpkg-${{ runner.os }}-ubuntu.24.04-x64-linux-x64-gcc-${{ hashFiles('vcpkg.json.in') }}
+          restore-keys: |
+            vcpkg-${{ runner.os }}-ubuntu.24.04-x64-linux-x64-gcc-
+
+      - name: Install qpdf
+        run: apt-get update && apt-get install -y qpdf
+
+      - name: Bootstrap vcpkg
+        run: ./external/vcpkg/bootstrap-vcpkg.sh
+
+      - name: Configure
+        run: cmake --preset linux-x64-gcc -DCMAKE_BUILD_TYPE=Release -DVANILLAPDF_ENABLE_TESTS=OFF -DVANILLAPDF_ENABLE_BENCHMARK=OFF
+
+      - name: Build vanillapdf.tools
+        run: cmake --build --preset linux-x64-gcc --target vanillapdf.tools
+
+      - name: Install vanillapdf.tools
+        run: cmake --install build/linux-x64-gcc --prefix install
+
+      - name: Run conformance check
+        run: |
+          python3 scripts/conformance_check.py \
+            --tools-binary install/bin/vanillapdf.tools \
+            --source-dir . \
+            --config scripts/conformance_check.cfg \
+            --verbose
+
+
+  windows:
+    name: win.2025-x64
+    runs-on: windows-2025
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      # Share vcpkg cache with sanity-check and nightly-check (same config)
+      - name: Cache vcpkg
+        uses: actions/cache@v5
+        with:
+          path: |
+            build/windows-x64-msvc-17/vcpkg_installed
+            external/vcpkg/downloads
+            external/vcpkg/buildtrees
+            external/vcpkg/packages
+          key: vcpkg-${{ runner.os }}-win.2025-x64-windows-x64-msvc-17-${{ hashFiles('vcpkg.json.in') }}
+          restore-keys: |
+            vcpkg-${{ runner.os }}-win.2025-x64-windows-x64-msvc-17-
+
+      - name: Install qpdf
+        run: choco install qpdf -y
+
+      - name: Bootstrap vcpkg
+        run: ${{ github.workspace }}\external\vcpkg\bootstrap-vcpkg.bat
+
+      - name: Configure
+        run: cmake --preset windows-x64-msvc-17 -DVANILLAPDF_ENABLE_TESTS=OFF -DVANILLAPDF_ENABLE_BENCHMARK=OFF
+
+      - name: Build vanillapdf.tools
+        run: cmake --build --preset windows-x64-msvc-17 --config Release --target vanillapdf.tools
+
+      - name: Install vanillapdf.tools
+        run: cmake --install build/windows-x64-msvc-17 --prefix install --config Release
+
+      - name: Run conformance check
+        run: |
+          $env:PATH = "build\windows-x64-msvc-17\vcpkg_installed\x64-windows\bin;$env:PATH"
+          python scripts/conformance_check.py --tools-binary install/bin/vanillapdf.tools.exe --source-dir . --config scripts/conformance_check.cfg --verbose
+
+
+  macos:
+    name: osx.15-arm64
+    runs-on: macos-15
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      # Share vcpkg cache with sanity-check and nightly-check (same config)
+      - name: Cache vcpkg
+        uses: actions/cache@v5
+        with:
+          path: |
+            build/macos-arm64/vcpkg_installed
+            external/vcpkg/downloads
+            external/vcpkg/buildtrees
+            external/vcpkg/packages
+          key: vcpkg-${{ runner.os }}-osx.15-arm64-macos-arm64-${{ hashFiles('vcpkg.json.in') }}
+          restore-keys: |
+            vcpkg-${{ runner.os }}-osx.15-arm64-macos-arm64-
+
+      - name: Install build tools and qpdf
+        run: brew install --quiet autoconf automake autoconf-archive qpdf
+
+      # TODO: Remove this workaround - see GitHub issue #125
+      - name: Fix JPEG library conflicts (macOS) - TEMPORARY WORKAROUND
+        run: |
+          echo "=== Unlinking conflicting JPEG packages ==="
+          brew unlink jpeg 2>/dev/null || echo "jpeg not linked or not found"
+          brew unlink jpeg-turbo 2>/dev/null || echo "jpeg-turbo not linked or not found"
+          brew unlink libjpeg 2>/dev/null || echo "libjpeg not linked or not found"
+
+      - name: Bootstrap vcpkg
+        run: ./external/vcpkg/bootstrap-vcpkg.sh
+
+      - name: Configure
+        run: cmake --preset macos-arm64 -DCMAKE_BUILD_TYPE=Release -DVANILLAPDF_ENABLE_TESTS=OFF -DVANILLAPDF_ENABLE_BENCHMARK=OFF
+
+      - name: Build vanillapdf.tools
+        run: cmake --build --preset macos-arm64 --target vanillapdf.tools
+
+      - name: Install vanillapdf.tools
+        run: cmake --install build/macos-arm64 --prefix install
+
+      - name: Run conformance check
+        run: |
+          python3 scripts/conformance_check.py \
+            --tools-binary install/bin/vanillapdf.tools \
+            --source-dir . \
+            --config scripts/conformance_check.cfg \
+            --verbose

--- a/scripts/conformance_check.cfg
+++ b/scripts/conformance_check.cfg
@@ -1,0 +1,54 @@
+{
+    "Files": [
+        "test/example.pdf",
+        "test/sample.pdf",
+        "test/excerpts.pdf",
+        "test/19005-1_FAQ.PDF",
+        "test/Granizo.pdf",
+        "test/cv_juraj_matys.pdf",
+        "test/jpdfunit_aShortIntroduction.pdf",
+        "test/manual.pdf",
+        "test/pdfSample.pdf",
+        "test/Report.pdf",
+        "test/request_for_taxpayer.pdf",
+        "test/statistika-kriminalita-2019.pdf",
+
+        "test/custom/Granizo-signed.PDF",
+        "test/custom/sample_signed.pdf",
+        "test/custom/aspose_trial.pdf",
+        "test/custom/Scan2.pdf",
+
+        "test/custom/example_40-rc4.pdf",
+        "test/custom/example_128-rc4.pdf",
+        "test/custom/example_128-aes.pdf",
+        "test/custom/sample-encrypted-rc4-40-rev2.pdf",
+        "test/custom/sample-encrypted-aes-40-rev2.pdf",
+        "test/custom/sample-encrypted-rc4-128-rev3.pdf",
+        "test/custom/sample-encrypted-aes-128-rev3.pdf",
+
+        "test/pdf-association/pdf20examples/Simple-PDF-2.0-file.pdf",
+        "test/pdf-association/pdf20examples/PDF-2.0-via-incremental-save.pdf",
+        "test/pdf-association/pdf20examples/PDF-2.0-with-offset-start.pdf",
+        "test/pdf-association/pdf20examples/PDF-2.0-image-with-BPC.pdf",
+
+        "test/pdfjs/tracemonkey.pdf",
+        "test/pdfjs/freeculture.pdf",
+        "test/pdfjs/canvas.pdf",
+        "test/pdfjs/rotated.pdf",
+        "test/pdfjs/rotation.pdf",
+        "test/pdfjs/openoffice.pdf",
+        "test/pdfjs/pdfkit_compressed.pdf",
+        "test/pdfjs/cmykjpeg.pdf",
+        "test/pdfjs/devicen.pdf",
+        "test/pdfjs/calrgb.pdf"
+    ],
+    "Encryption": {
+        "example_40-rc4.pdf": { "owner_password": "testik" },
+        "example_128-rc4.pdf": { "owner_password": "testik" },
+        "example_128-aes.pdf": { "owner_password": "testik" },
+        "sample-encrypted-rc4-40-rev2.pdf": { "owner_password": "owner" },
+        "sample-encrypted-aes-40-rev2.pdf": { "owner_password": "owner" },
+        "sample-encrypted-rc4-128-rev3.pdf": { "owner_password": "owner" },
+        "sample-encrypted-aes-128-rev3.pdf": { "owner_password": "owner" }
+    }
+}

--- a/scripts/conformance_check.py
+++ b/scripts/conformance_check.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+"""
+External PDF conformance validation using qpdf.
+
+Re-saves each test PDF through vanillapdf.tools and validates the output
+with ``qpdf --check``.  Uses a dedicated config file (conformance_check.cfg)
+with an explicit allowlist of files to test.
+
+Usage:
+    python scripts/conformance_check.py \
+        --tools-binary build/.../vanillapdf.tools[.exe] \
+        --source-dir . \
+        --config scripts/conformance_check.cfg
+"""
+
+import argparse
+import io
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import unicodedata
+
+
+def normalize_string(s):
+    """Match the normalisation used by run_test.py."""
+    normalized = unicodedata.normalize("NFC", s)
+    encoded = normalized.encode("utf8")
+    return encoded.decode("latin-1")
+
+
+def load_config(config_path):
+    with io.open(config_path, encoding="utf8") as fh:
+        return json.load(fh)
+
+
+def password_for(filename, encryption_data):
+    """Return a password string for *filename*, or None."""
+    entry = encryption_data.get(filename)
+    if entry is None:
+        return None
+    for key in ("owner_password", "user_password"):
+        if key in entry:
+            return normalize_string(entry[key])
+    return None
+
+
+def _collect_output(result):
+    """Safely concatenate stdout and stderr, handling None."""
+    parts = []
+    if result.stdout:
+        parts.append(result.stdout)
+    if result.stderr:
+        parts.append(result.stderr)
+    return "\n".join(parts)
+
+
+def run_resave(tools_binary, src, dst, password=None, timeout=120):
+    """Run ``vanillapdf.tools resave`` and return (returncode, output)."""
+    cmd = [tools_binary, "resave", "-s", src, "-d", dst]
+    if password is not None:
+        cmd += ["-p", password]
+    result = subprocess.run(
+        cmd, capture_output=True, encoding="utf-8", errors="replace",
+        timeout=timeout,
+    )
+    return result.returncode, _collect_output(result)
+
+
+def run_qpdf_check(qpdf_binary, pdf_path, password=None, timeout=60):
+    """Run ``qpdf --check`` and return (returncode, combined output)."""
+    cmd = [qpdf_binary, "--check", pdf_path]
+    if password is not None:
+        cmd += ["--password=" + password]
+    result = subprocess.run(
+        cmd, capture_output=True, encoding="utf-8", errors="replace",
+        timeout=timeout,
+    )
+    return result.returncode, _collect_output(result)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Validate vanillapdf round-trip output with qpdf"
+    )
+    parser.add_argument(
+        "--tools-binary",
+        required=True,
+        help="Path to the vanillapdf.tools executable",
+    )
+    parser.add_argument(
+        "--source-dir",
+        required=True,
+        help="Repository root (file paths in config are relative to this)",
+    )
+    parser.add_argument(
+        "--config",
+        required=True,
+        help="Path to conformance_check.cfg",
+    )
+    parser.add_argument(
+        "--qpdf",
+        default="qpdf",
+        help="Path to the qpdf binary (default: qpdf)",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default=None,
+        help="Directory for resaved PDFs (default: auto-created temp dir)",
+    )
+    parser.add_argument(
+        "--keep-output",
+        action="store_true",
+        help="Do not delete the output directory on exit",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Print details for every file, not just failures",
+    )
+    args = parser.parse_args()
+
+    # Verify prerequisites
+    if not os.path.isfile(args.tools_binary):
+        print(f"ERROR: tools binary not found: {args.tools_binary}")
+        return 1
+    if not os.path.isdir(args.source_dir):
+        print(f"ERROR: source directory not found: {args.source_dir}")
+        return 1
+    if not os.path.isfile(args.config):
+        print(f"ERROR: config file not found: {args.config}")
+        return 1
+
+    # Verify qpdf is available
+    try:
+        subprocess.run(
+            [args.qpdf, "--version"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except FileNotFoundError:
+        print(f"ERROR: qpdf not found at: {args.qpdf}")
+        return 1
+
+    config = load_config(args.config)
+    file_list = config.get("Files", [])
+    encryption_data = config.get("Encryption", {})
+
+    if not file_list:
+        print("No files listed in config")
+        return 1
+
+    # Prepare output directory
+    tmp_created = False
+    output_dir = args.output_dir
+    if output_dir is None:
+        output_dir = tempfile.mkdtemp(prefix="vanillapdf_conformance_")
+        tmp_created = True
+    else:
+        os.makedirs(output_dir, exist_ok=True)
+
+    total = 0
+    passed = 0
+    failed = 0
+    missing = 0
+    resave_failures = []
+    qpdf_failures = []
+
+    for rel_path in file_list:
+        pdf_path = os.path.join(args.source_dir, rel_path)
+        filename = os.path.basename(pdf_path)
+        total += 1
+
+        if not os.path.isfile(pdf_path):
+            missing += 1
+            print(f"  MISS  {rel_path} (file not found)")
+            continue
+
+        password = password_for(filename, encryption_data)
+
+        # Build output path preserving relative structure
+        out_path = os.path.join(output_dir, rel_path)
+        os.makedirs(os.path.dirname(out_path), exist_ok=True)
+
+        # Step 1: resave
+        rc, output = run_resave(
+            args.tools_binary, pdf_path, out_path, password=password
+        )
+        if rc != 0:
+            failed += 1
+            resave_failures.append((rel_path, output.strip()))
+            print(f"  FAIL  {rel_path} (resave returned {rc})")
+            if args.verbose and output.strip():
+                for line in output.strip().splitlines():
+                    print(f"        {line}")
+            continue
+
+        # Step 2: qpdf --check
+        rc, output = run_qpdf_check(args.qpdf, out_path, password=password)
+        if rc != 0:
+            # qpdf exit code 3 = warnings only (not errors)
+            if rc == 3:
+                passed += 1
+                if args.verbose:
+                    print(f"  WARN  {rel_path} (qpdf warnings)")
+            else:
+                failed += 1
+                qpdf_failures.append((rel_path, output.strip()))
+                print(f"  FAIL  {rel_path} (qpdf --check returned {rc})")
+                if args.verbose and output.strip():
+                    for line in output.strip().splitlines():
+                        print(f"        {line}")
+                continue
+        else:
+            passed += 1
+
+        if args.verbose:
+            print(f"  PASS  {rel_path}")
+
+    # Summary
+    print()
+    print("=" * 60)
+    print(f"Conformance check summary")
+    print(f"  Total:   {total}")
+    print(f"  Passed:  {passed}")
+    print(f"  Failed:  {failed}")
+    if missing > 0:
+        print(f"  Missing: {missing}")
+    print("=" * 60)
+
+    if resave_failures:
+        print()
+        print(f"Resave failures ({len(resave_failures)}):")
+        for name, msg in resave_failures:
+            print(f"  - {name}")
+            if msg:
+                for line in msg.splitlines()[:3]:
+                    print(f"    {line}")
+
+    if qpdf_failures:
+        print()
+        print(f"qpdf failures ({len(qpdf_failures)}):")
+        for name, msg in qpdf_failures:
+            print(f"  - {name}")
+            if msg:
+                for line in msg.splitlines()[:3]:
+                    print(f"    {line}")
+
+    # Cleanup
+    if tmp_created and not args.keep_output:
+        shutil.rmtree(output_dir, ignore_errors=True)
+
+    return 1 if (failed > 0 or missing > 0) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/vanillapdf.tools/CMakeLists.txt
+++ b/src/vanillapdf.tools/CMakeLists.txt
@@ -16,6 +16,7 @@ set(VANILLAPDF_TOOLS_SOURCES
     filter.c
     merge.c
     read.c
+    resave.c
     sign.c
     sign_custom.c
     verify.c

--- a/src/vanillapdf.tools/main.c
+++ b/src/vanillapdf.tools/main.c
@@ -25,6 +25,7 @@ void print_help() {
     printf("  encrypt         Encrypt a PDF document\n");
     printf("  decrypt         Decrypt a PDF document\n");
     printf("  read            Read a PDF using memory IO strategy\n");
+    printf("  resave          Re-save a PDF document\n");
     printf("  write_custom    Write PDF with custom handler\n");
     printf("\nOptions:\n");
     printf("  --help, -h      Show this help message\n");
@@ -91,6 +92,10 @@ int main(int argc, char *argv[]) {
 
     if (0 == strcmp(argv[1], "read")) {
         return process_read(argc - 2, &argv[2]);
+    }
+
+    if (0 == strcmp(argv[1], "resave")) {
+        return process_resave(argc - 2, &argv[2]);
     }
 
     if (0 == strcmp(argv[1], "write_custom")) {

--- a/src/vanillapdf.tools/resave.c
+++ b/src/vanillapdf.tools/resave.c
@@ -1,0 +1,62 @@
+#include "tools.h"
+
+void print_resave_help() {
+    printf("Usage: resave -s [source file] -d [destination file] -p [password]");
+}
+
+int process_resave(int argc, char *argv[]) {
+    FileHandle* source_file = NULL;
+    DocumentHandle* source_document = NULL;
+
+    string_type password = NULL;
+    string_type source_file_path = NULL;
+    string_type destination_file_path = NULL;
+
+    integer_type i = 0;
+
+    for (i = 0; i < argc; ++i) {
+
+        // password
+        if (strcmp(argv[i], "-p") == 0 && (i + 1 < argc)) {
+            password = argv[i + 1];
+            i++;
+
+            // source file path
+        } else if (strcmp(argv[i], "-s") == 0 && (i + 1 < argc)) {
+            source_file_path = argv[i + 1];
+            i++;
+
+            // destination file path
+        } else if (strcmp(argv[i], "-d") == 0 && (i + 1 < argc)) {
+            destination_file_path = argv[i + 1];
+            i++;
+        } else {
+            print_resave_help();
+            return VANILLAPDF_TOOLS_ERROR_INVALID_PARAMETERS;
+        }
+    }
+
+    if (source_file_path == NULL) {
+        print_resave_help();
+        return VANILLAPDF_TOOLS_ERROR_INVALID_PARAMETERS;
+    }
+
+    if (destination_file_path == NULL) {
+        print_resave_help();
+        return VANILLAPDF_TOOLS_ERROR_INVALID_PARAMETERS;
+    }
+
+    RETURN_ERROR_IF_NOT_SUCCESS(File_Open(source_file_path, &source_file));
+    RETURN_ERROR_IF_NOT_SUCCESS(Document_OpenFile(source_file, &source_document));
+
+    if (password != NULL) {
+        RETURN_ERROR_IF_NOT_SUCCESS(File_SetEncryptionPassword(source_file, password));
+    }
+
+    RETURN_ERROR_IF_NOT_SUCCESS(Document_Save(source_document, destination_file_path));
+
+    RETURN_ERROR_IF_NOT_SUCCESS(Document_Release(source_document));
+    RETURN_ERROR_IF_NOT_SUCCESS(File_Release(source_file));
+
+    return VANILLAPDF_TOOLS_ERROR_SUCCESS;
+}

--- a/src/vanillapdf.tools/tools.h
+++ b/src/vanillapdf.tools/tools.h
@@ -27,6 +27,7 @@ int process_encrypt(int argc, char* argv[]);
 int process_decrypt(int argc, char *argv[]);
 int process_write_custom(int argc, char *argv[]);
 int process_read(int argc, char *argv[]);
+int process_resave(int argc, char *argv[]);
 int process_verify(int argc, char *argv[]);
 
 // Some parameters to functions are unused


### PR DESCRIPTION
## Summary

- Add `resave` command to `vanillapdf.tools` — opens a PDF and saves it to a new file, exercising the full parse-then-serialize roundtrip
- Add `scripts/conformance_check.py` — standalone Python script that re-saves curated test PDFs and validates output with `qpdf --check`
- Add `scripts/conformance_check.cfg` — allowlist of 37 test files covering plain, encrypted, signed, PDF 2.0, and compressed PDFs
- Add `.github/workflows/conformance-check.yml` — CI workflow on Linux, Windows, and macOS (weekly + PR triggers)

## Test plan

- [x] Built `vanillapdf.tools` in Release locally
- [x] Verified `resave` command works (open → save roundtrip)
- [x] Ran `conformance_check.py` locally — 37/37 passed, 0 failed
- [x] CI passes on all three platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)