### PR TITLE
fix: Link stdc++fs for std::filesystem on GCC < 9

### DIFF
--- a/src/vanillapdf.unittest/CMakeLists.txt
+++ b/src/vanillapdf.unittest/CMakeLists.txt
@@ -105,6 +105,11 @@ set(VANILLAPDF_UNITTEST_LIBS
     GTest::gtest
 )
 
+# GCC < 9 requires explicit -lstdc++fs for std::filesystem (e.g. Rocky 8)
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 9.0)
+    list(APPEND VANILLAPDF_UNITTEST_LIBS stdc++fs)
+endif()
+
 target_link_libraries(vanillapdf.unittest PRIVATE ${VANILLAPDF_UNITTEST_LIBS})
 
 # In case we have the dynamic link configuration add specific definitions


### PR DESCRIPTION
## Summary

- Link `-lstdc++fs` when building `vanillapdf.unittest` with GCC < 9
- Fixes linker errors for `std::filesystem::temp_directory_path` and `std::filesystem::remove` on Rocky 8 (GCC 8.5)
- GCC 9+ bundles filesystem support into libstdc++ automatically, so the flag is only added conditionally

## Test plan

- [x] CI passes on Rocky 8 (rocky.8-x64, rocky.8-arm64)
- [x] No impact on GCC 9+, Clang, or MSVC builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)