### PR TITLE
fix: Replace custom source manager with jpeg_mem_src for robust DCT decode

### DIFF
--- a/src/vanillapdf.unittest/filter_test.cpp
+++ b/src/vanillapdf.unittest/filter_test.cpp
@@ -1,6 +1,8 @@
 #include "unittest.h"
 
 #include <cstring>
+#include <string_view>
+#include <vector>
 
 namespace filters {
 
@@ -168,6 +170,50 @@ TEST(DCTDecodeFilter, Decode) {
 
     ASSERT_EQ(DCTDecodeFilter_Release(filter_handle), VANILLAPDF_ERROR_SUCCESS);
 }
+
+struct DCTMalformedCase {
+    std::string_view name;
+    std::vector<uint8_t> data;
+};
+
+class DCTDecodeMalformedTest : public ::testing::TestWithParam<DCTMalformedCase> {};
+
+TEST_P(DCTDecodeMalformedTest, RejectsInvalidInput) {
+    const auto& param = GetParam();
+
+    BufferHandle* input_data_buffer = nullptr;
+    BufferHandle* decoded_data_buffer = nullptr;
+    DCTDecodeFilterHandle* filter_handle = nullptr;
+
+    ASSERT_EQ(DCTDecodeFilter_Create(&filter_handle), VANILLAPDF_ERROR_SUCCESS);
+    auto data_ptr = param.data.empty() ? "" : reinterpret_cast<string_type>(param.data.data());
+    ASSERT_EQ(Buffer_CreateFromData(data_ptr,
+        static_cast<size_type>(param.data.size()), &input_data_buffer), VANILLAPDF_ERROR_SUCCESS);
+
+    EXPECT_NE(DCTDecodeFilter_Decode(filter_handle, input_data_buffer, &decoded_data_buffer), VANILLAPDF_ERROR_SUCCESS);
+    EXPECT_EQ(decoded_data_buffer, nullptr);
+
+    // Cleanup
+    ASSERT_EQ(Buffer_Release(input_data_buffer), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(DCTDecodeFilter_Release(filter_handle), VANILLAPDF_ERROR_SUCCESS);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    DCTDecodeFilter,
+    DCTDecodeMalformedTest,
+    ::testing::Values(
+        DCTMalformedCase{ "Empty", {} },
+        DCTMalformedCase{ "SingleByte", { 0xFF } },
+        DCTMalformedCase{ "SOIOnly", { 0xFF, 0xD8 } },
+        DCTMalformedCase{ "TruncatedHeader", { 0xFF, 0xD8, 0xFF, 0xE0, 0x00 } },
+        DCTMalformedCase{ "NotJPEG", { 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07 } },
+        DCTMalformedCase{ "OversizedMarkerLength", { 0xFF, 0xD8, 0xFF, 0xDC, 0xDC, 0xDC, 0xDC, 0xDC, 0xDC, 0xDC, 0xDC, 0xDC, 0xDC, 0xD9 } },
+        DCTMalformedCase{ "SkipPastBuffer", { 0xFF, 0xD8, 0xFF, 0xFF, 0xDC, 0xFF, 0xD8, 0xFF, 0xC9 } }
+    ),
+    [](const ::testing::TestParamInfo<DCTMalformedCase>& info) {
+        return std::string(info.param.name);
+    }
+);
 
 TEST(JPXDecodeFilter, Decode) {
 

--- a/src/vanillapdf/syntax/filters/dct_decode_filter.cpp
+++ b/src/vanillapdf/syntax/filters/dct_decode_filter.cpp
@@ -49,42 +49,6 @@ void output_message(j_common_ptr cinfo) {
     spdlog::warn("JPEG decompression reported message: {}", buffer);
 }
 
-void init_source(j_decompress_ptr cinfo) {
-    UNUSED(cinfo);
-}
-
-boolean fill_input_buffer(j_decompress_ptr cinfo) {
-    UNUSED(cinfo);
-
-    assert(!"This method is not handled");
-    spdlog::error("JPEG decompression failure. Please report this issue");
-
-    return TRUE;
-}
-
-void skip_input_data(j_decompress_ptr cinfo, long num_bytes) {
-
-    if (cinfo == nullptr) {
-        throw GeneralException("Invalid jpeg pointer");
-    }
-
-    if (cinfo->src == nullptr) {
-        throw GeneralException("Missing jpeg source manager");
-    }
-
-    cinfo->src->next_input_byte += num_bytes;
-    cinfo->src->bytes_in_buffer -= num_bytes;
-}
-
-void term_source(j_decompress_ptr cinfo) {
-    UNUSED(cinfo);
-}
-
-boolean resync_to_restart(j_decompress_ptr cinfo, int desired) {
-    spdlog::info("JPEG decompression resync restart, desired: {}", desired);
-    return jpeg_resync_to_restart(cinfo, desired);
-}
-
 void init_destination(j_compress_ptr cinfo) {
 
     if (cinfo == nullptr) {
@@ -318,22 +282,12 @@ BufferPtr DCTDecodeFilter::Decode(IInputStreamPtr src, types::stream_size length
 
     SCOPE_GUARD([&jpeg]() { jpeg_destroy_decompress(&jpeg); });
 
-    jpeg.src = static_cast<jpeg_source_mgr*>(
-        (jpeg.mem->alloc_small)
-        (reinterpret_cast<j_common_ptr>(&jpeg), JPOOL_PERMANENT, sizeof(jpeg_source_mgr))
-        );
-
-    jpeg.src->init_source = init_source;
-    jpeg.src->fill_input_buffer = fill_input_buffer;
-    jpeg.src->skip_input_data = skip_input_data;
-    jpeg.src->resync_to_restart = resync_to_restart;
-    jpeg.src->term_source = term_source;
-
     size_t length_converted = ValueConvertUtils::SafeConvert<size_t>(length);
     BufferPtr input = src->Read(length_converted);
 
-    jpeg.src->next_input_byte = reinterpret_cast<uint8_t *>(input->data());
-    jpeg.src->bytes_in_buffer = length_converted;
+    jpeg_mem_src(&jpeg,
+        reinterpret_cast<const unsigned char*>(input->data()),
+        static_cast<unsigned long>(length_converted));
 
     int header = jpeg_read_header(&jpeg, TRUE);
     if (header != JPEG_HEADER_OK) {


### PR DESCRIPTION
## Summary
- Backport of #331 to `release/2.2`
- Removes custom libjpeg source manager callbacks (`fill_input_buffer`, `skip_input_data`, `init_source`, `term_source`, `resync_to_restart`) that had out-of-bounds issues with malformed input found by fuzzing
- Replaces with standard `jpeg_mem_src` API which handles all edge cases internally
- Adds parameterized malformed input test suite (7 cases including fuzzer-discovered crash inputs)

## Test plan
- [x] Verify DCT decode tests pass on CI
- [x] Verify existing `DCTDecodeFilter.Decode` test still passes with valid JPEG input

🤖 Generated with [Claude Code](https://claude.com/claude-code)