### PR TITLE
perf: Standardize vcpkg cache keys, remove nightly caching

### DIFF
--- a/.github/workflows/build-nuget.yml
+++ b/.github/workflows/build-nuget.yml
@@ -72,14 +72,14 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - name: linux-x64
+          - name: rocky.9-x64
             os: ubuntu-24.04
             image: ghcr.io/vanillapdf/vanillapdf-rockylinux-amd64:9
             platform: linux/amd64
             preset: linux-x64-gcc
             build_type: Release
 
-          - name: linux-arm64
+          - name: rocky.9-arm64
             os: ubuntu-24.04-arm
             image: ghcr.io/vanillapdf/vanillapdf-rockylinux-arm64v8:9
             platform: linux/arm64
@@ -108,9 +108,8 @@ jobs:
           path: |
             external/vcpkg/downloads
             external/vcpkg/bincache
-          key: vcpkg-${{ runner.os }}-${{ matrix.config.name }}-${{ matrix.config.preset }}-${{ hashFiles('vcpkg.json.in') }}
+          key: vcpkg-${{ runner.os }}-${{ matrix.config.name }}-${{ hashFiles('vcpkg.json.in') }}
           restore-keys: |
-            vcpkg-${{ runner.os }}-${{ matrix.config.name }}-${{ matrix.config.preset }}-
             vcpkg-${{ runner.os }}-${{ matrix.config.name }}-
 
       # Bootstrap vcpkg on Linux
@@ -181,9 +180,8 @@ jobs:
           path: |
             external/vcpkg/downloads
             external/vcpkg/bincache
-          key: vcpkg-${{ runner.os }}-${{ matrix.config.name }}-${{ matrix.config.preset }}-${{ hashFiles('vcpkg.json.in') }}
+          key: vcpkg-${{ runner.os }}-${{ matrix.config.name }}-${{ hashFiles('vcpkg.json.in') }}
           restore-keys: |
-            vcpkg-${{ runner.os }}-${{ matrix.config.name }}-${{ matrix.config.preset }}-
             vcpkg-${{ runner.os }}-${{ matrix.config.name }}-
 
       # Bootstrap vcpkg on Windows
@@ -237,7 +235,7 @@ jobs:
             preset: macos-x64
             build_type: Release
 
-          - name: osx-arm64
+          - name: osx.15-arm64
             runner: macos-15
             preset: macos-arm64
             build_type: Release
@@ -256,9 +254,8 @@ jobs:
           path: |
             external/vcpkg/downloads
             external/vcpkg/bincache
-          key: vcpkg-${{ runner.os }}-${{ matrix.config.name }}-${{ matrix.config.preset }}-${{ hashFiles('vcpkg.json.in') }}
+          key: vcpkg-${{ runner.os }}-${{ matrix.config.name }}-${{ hashFiles('vcpkg.json.in') }}
           restore-keys: |
-            vcpkg-${{ runner.os }}-${{ matrix.config.name }}-${{ matrix.config.preset }}-
             vcpkg-${{ runner.os }}-${{ matrix.config.name }}-
 
       # dotnet is available on macOS runners by default

--- a/.github/workflows/build-nuget.yml
+++ b/.github/workflows/build-nuget.yml
@@ -152,17 +152,17 @@ jobs:
 
   build-windows:
     name: ${{ matrix.config.name }}
-    runs-on: windows-latest
+    runs-on: windows-2025
 
     strategy:
       fail-fast: false
       matrix:
         config:
-          - name: win-x86
+          - name: win.2025-x86-static
             preset: windows-x86-msvc-17-static
             build_type: Release
 
-          - name: win-x64
+          - name: win.2025-x64-static
             preset: windows-x64-msvc-17-static
             build_type: Release
 

--- a/.github/workflows/build-nuget.yml
+++ b/.github/workflows/build-nuget.yml
@@ -106,7 +106,6 @@ jobs:
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306  # v5.0.3
         with:
           path: |
-            build/${{ matrix.config.preset }}/vcpkg_installed
             external/vcpkg/downloads
             external/vcpkg/bincache
           key: vcpkg-${{ runner.os }}-${{ matrix.config.name }}-${{ matrix.config.preset }}-${{ hashFiles('vcpkg.json.in') }}
@@ -180,7 +179,6 @@ jobs:
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306  # v5.0.3
         with:
           path: |
-            build/${{ matrix.config.preset }}/vcpkg_installed
             external/vcpkg/downloads
             external/vcpkg/bincache
           key: vcpkg-${{ runner.os }}-${{ matrix.config.name }}-${{ matrix.config.preset }}-${{ hashFiles('vcpkg.json.in') }}
@@ -256,7 +254,6 @@ jobs:
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306  # v5.0.3
         with:
           path: |
-            build/${{ matrix.config.preset }}/vcpkg_installed
             external/vcpkg/downloads
             external/vcpkg/bincache
           key: vcpkg-${{ runner.os }}-${{ matrix.config.name }}-${{ matrix.config.preset }}-${{ hashFiles('vcpkg.json.in') }}

--- a/.github/workflows/build-nuget.yml
+++ b/.github/workflows/build-nuget.yml
@@ -108,8 +108,6 @@ jobs:
           path: |
             build/${{ matrix.config.preset }}/vcpkg_installed
             external/vcpkg/downloads
-            external/vcpkg/buildtrees
-            external/vcpkg/packages
             external/vcpkg/bincache
           key: vcpkg-${{ runner.os }}-${{ matrix.config.name }}-${{ matrix.config.preset }}-${{ hashFiles('vcpkg.json.in') }}
           restore-keys: |
@@ -184,8 +182,6 @@ jobs:
           path: |
             build/${{ matrix.config.preset }}/vcpkg_installed
             external/vcpkg/downloads
-            external/vcpkg/buildtrees
-            external/vcpkg/packages
             external/vcpkg/bincache
           key: vcpkg-${{ runner.os }}-${{ matrix.config.name }}-${{ matrix.config.preset }}-${{ hashFiles('vcpkg.json.in') }}
           restore-keys: |
@@ -262,8 +258,6 @@ jobs:
           path: |
             build/${{ matrix.config.preset }}/vcpkg_installed
             external/vcpkg/downloads
-            external/vcpkg/buildtrees
-            external/vcpkg/packages
             external/vcpkg/bincache
           key: vcpkg-${{ runner.os }}-${{ matrix.config.name }}-${{ matrix.config.preset }}-${{ hashFiles('vcpkg.json.in') }}
           restore-keys: |

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -86,8 +86,6 @@ jobs:
         path: |
           build/**/vcpkg_installed
           external/vcpkg/downloads
-          external/vcpkg/buildtrees
-          external/vcpkg/packages
           external/vcpkg/bincache
         key: codeql-vcpkg-${{ runner.os }}-${{ hashFiles('vcpkg.json.in') }}
         restore-keys: |

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -84,7 +84,6 @@ jobs:
       uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306  # v5.0.3
       with:
         path: |
-          build/**/vcpkg_installed
           external/vcpkg/downloads
           external/vcpkg/bincache
         key: codeql-vcpkg-${{ runner.os }}-${{ hashFiles('vcpkg.json.in') }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -44,7 +44,7 @@ jobs:
     #   - https://gh.io/supported-runners-and-hardware-resources
     #   - https://gh.io/using-larger-runners (GitHub.com only)
     # Consider using larger runners or machines with greater resources for possible analysis time improvements.
-    runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
+    runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-24.04' }}
     permissions:
       # required for all workflows
       security-events: write
@@ -86,9 +86,9 @@ jobs:
         path: |
           external/vcpkg/downloads
           external/vcpkg/bincache
-        key: codeql-vcpkg-${{ runner.os }}-${{ hashFiles('vcpkg.json.in') }}
+        key: vcpkg-${{ runner.os }}-ubuntu-24.04-x64-gcc-${{ hashFiles('vcpkg.json.in') }}
         restore-keys: |
-          codeql-vcpkg-${{ runner.os }}-
+          vcpkg-${{ runner.os }}-ubuntu-24.04-x64-gcc-
 
     - name: Bootstrap vcpkg
       run: ./external/vcpkg/bootstrap-vcpkg.sh

--- a/.github/workflows/conformance-check.yml
+++ b/.github/workflows/conformance-check.yml
@@ -26,6 +26,7 @@ permissions:
 env:
   VCPKG_ROOT: external/vcpkg
   VCPKG_DISABLE_METRICS: 1
+  VCPKG_BINARY_SOURCES: "clear;files,${{ github.workspace }}/external/vcpkg/bincache,readwrite"
 
 jobs:
 
@@ -48,8 +49,7 @@ jobs:
           path: |
             build/linux-x64-gcc/vcpkg_installed
             external/vcpkg/downloads
-            external/vcpkg/buildtrees
-            external/vcpkg/packages
+            external/vcpkg/bincache
           key: vcpkg-${{ runner.os }}-ubuntu.24.04-x64-linux-x64-gcc-${{ hashFiles('vcpkg.json.in') }}
           restore-keys: |
             vcpkg-${{ runner.os }}-ubuntu.24.04-x64-linux-x64-gcc-
@@ -94,8 +94,7 @@ jobs:
           path: |
             build/windows-x64-msvc-17/vcpkg_installed
             external/vcpkg/downloads
-            external/vcpkg/buildtrees
-            external/vcpkg/packages
+            external/vcpkg/bincache
           key: vcpkg-${{ runner.os }}-win.2025-x64-windows-x64-msvc-17-${{ hashFiles('vcpkg.json.in') }}
           restore-keys: |
             vcpkg-${{ runner.os }}-win.2025-x64-windows-x64-msvc-17-
@@ -137,8 +136,7 @@ jobs:
           path: |
             build/macos-arm64/vcpkg_installed
             external/vcpkg/downloads
-            external/vcpkg/buildtrees
-            external/vcpkg/packages
+            external/vcpkg/bincache
           key: vcpkg-${{ runner.os }}-osx.15-arm64-macos-arm64-${{ hashFiles('vcpkg.json.in') }}
           restore-keys: |
             vcpkg-${{ runner.os }}-osx.15-arm64-macos-arm64-

--- a/.github/workflows/conformance-check.yml
+++ b/.github/workflows/conformance-check.yml
@@ -78,7 +78,7 @@ jobs:
 
 
   windows:
-    name: win.2025-x64
+    name: win.2025-x64-static
     runs-on: windows-2025
 
     steps:
@@ -86,16 +86,16 @@ jobs:
         with:
           submodules: recursive
 
-      # Share vcpkg cache with sanity-check and nightly-check (same config)
+      # Share vcpkg cache with sanity-check and build-nuget (same config)
       - name: Cache vcpkg
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306  # v5.0.3
         with:
           path: |
             external/vcpkg/downloads
             external/vcpkg/bincache
-          key: vcpkg-${{ runner.os }}-win.2025-x64-${{ hashFiles('vcpkg.json.in') }}
+          key: vcpkg-${{ runner.os }}-win.2025-x64-static-${{ hashFiles('vcpkg.json.in') }}
           restore-keys: |
-            vcpkg-${{ runner.os }}-win.2025-x64-
+            vcpkg-${{ runner.os }}-win.2025-x64-static-
 
       - name: Install qpdf
         run: choco install qpdf -y
@@ -104,18 +104,16 @@ jobs:
         run: ${{ github.workspace }}\external\vcpkg\bootstrap-vcpkg.bat
 
       - name: Configure
-        run: cmake --preset windows-x64-msvc-17 -DVANILLAPDF_ENABLE_TESTS=OFF -DVANILLAPDF_ENABLE_BENCHMARK=OFF
+        run: cmake --preset windows-x64-msvc-17-static -DVANILLAPDF_ENABLE_TESTS=OFF -DVANILLAPDF_ENABLE_BENCHMARK=OFF
 
       - name: Build vanillapdf.tools
-        run: cmake --build --preset windows-x64-msvc-17 --config Release --target vanillapdf.tools
+        run: cmake --build --preset windows-x64-msvc-17-static --config Release --target vanillapdf.tools
 
       - name: Install vanillapdf.tools
-        run: cmake --install build/windows-x64-msvc-17 --prefix install --config Release
+        run: cmake --install build/windows-x64-msvc-17-static --prefix install --config Release
 
       - name: Run conformance check
-        run: |
-          $env:PATH = "build\windows-x64-msvc-17\vcpkg_installed\x64-windows\bin;$env:PATH"
-          python scripts/conformance_check.py --tools-binary install/bin/vanillapdf.tools.exe --source-dir . --config scripts/conformance_check.cfg --verbose
+        run: python scripts/conformance_check.py --tools-binary install/bin/vanillapdf.tools.exe --source-dir . --config scripts/conformance_check.cfg --verbose
 
 
   macos:

--- a/.github/workflows/conformance-check.yml
+++ b/.github/workflows/conformance-check.yml
@@ -47,7 +47,6 @@ jobs:
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306  # v5.0.3
         with:
           path: |
-            build/linux-x64-gcc/vcpkg_installed
             external/vcpkg/downloads
             external/vcpkg/bincache
           key: vcpkg-${{ runner.os }}-ubuntu.24.04-x64-linux-x64-gcc-${{ hashFiles('vcpkg.json.in') }}
@@ -92,7 +91,6 @@ jobs:
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306  # v5.0.3
         with:
           path: |
-            build/windows-x64-msvc-17/vcpkg_installed
             external/vcpkg/downloads
             external/vcpkg/bincache
           key: vcpkg-${{ runner.os }}-win.2025-x64-windows-x64-msvc-17-${{ hashFiles('vcpkg.json.in') }}
@@ -134,7 +132,6 @@ jobs:
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306  # v5.0.3
         with:
           path: |
-            build/macos-arm64/vcpkg_installed
             external/vcpkg/downloads
             external/vcpkg/bincache
           key: vcpkg-${{ runner.os }}-osx.15-arm64-macos-arm64-${{ hashFiles('vcpkg.json.in') }}

--- a/.github/workflows/conformance-check.yml
+++ b/.github/workflows/conformance-check.yml
@@ -49,9 +49,9 @@ jobs:
           path: |
             external/vcpkg/downloads
             external/vcpkg/bincache
-          key: vcpkg-${{ runner.os }}-ubuntu.24.04-x64-linux-x64-gcc-${{ hashFiles('vcpkg.json.in') }}
+          key: vcpkg-${{ runner.os }}-ubuntu.24.04-x64-${{ hashFiles('vcpkg.json.in') }}
           restore-keys: |
-            vcpkg-${{ runner.os }}-ubuntu.24.04-x64-linux-x64-gcc-
+            vcpkg-${{ runner.os }}-ubuntu.24.04-x64-
 
       - name: Install qpdf
         run: apt-get update && apt-get install -y qpdf
@@ -93,9 +93,9 @@ jobs:
           path: |
             external/vcpkg/downloads
             external/vcpkg/bincache
-          key: vcpkg-${{ runner.os }}-win.2025-x64-windows-x64-msvc-17-${{ hashFiles('vcpkg.json.in') }}
+          key: vcpkg-${{ runner.os }}-win.2025-x64-${{ hashFiles('vcpkg.json.in') }}
           restore-keys: |
-            vcpkg-${{ runner.os }}-win.2025-x64-windows-x64-msvc-17-
+            vcpkg-${{ runner.os }}-win.2025-x64-
 
       - name: Install qpdf
         run: choco install qpdf -y
@@ -134,9 +134,9 @@ jobs:
           path: |
             external/vcpkg/downloads
             external/vcpkg/bincache
-          key: vcpkg-${{ runner.os }}-osx.15-arm64-macos-arm64-${{ hashFiles('vcpkg.json.in') }}
+          key: vcpkg-${{ runner.os }}-osx.15-arm64-${{ hashFiles('vcpkg.json.in') }}
           restore-keys: |
-            vcpkg-${{ runner.os }}-osx.15-arm64-macos-arm64-
+            vcpkg-${{ runner.os }}-osx.15-arm64-
 
       - name: Install build tools and qpdf
         run: brew install --quiet autoconf automake autoconf-archive qpdf

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -33,6 +33,10 @@ on:
 
 permissions: {}
 
+env:
+  VCPKG_DISABLE_METRICS: 1
+  VCPKG_BINARY_SOURCES: "clear;files,${{ github.workspace }}/external/vcpkg/bincache,readwrite"
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -59,8 +63,7 @@ jobs:
           path: |
             build/linux-x64-gcc/vcpkg_installed
             external/vcpkg/downloads
-            external/vcpkg/buildtrees
-            external/vcpkg/packages
+            external/vcpkg/bincache
           key: vcpkg-${{ runner.os }}-ubuntu-latest-linux-x64-gcc-coverage-${{ hashFiles('vcpkg.json.in') }}
           restore-keys: |
             vcpkg-${{ runner.os }}-ubuntu-latest-linux-x64-gcc-coverage-

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -43,7 +43,7 @@ concurrency:
 
 jobs:
   coverage:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: read        # Download the repository source code
       statuses: write       # Required for Codecov to post coverage status
@@ -63,11 +63,9 @@ jobs:
           path: |
             external/vcpkg/downloads
             external/vcpkg/bincache
-          key: vcpkg-${{ runner.os }}-ubuntu-latest-linux-x64-gcc-coverage-${{ hashFiles('vcpkg.json.in') }}
+          key: vcpkg-${{ runner.os }}-ubuntu-24.04-x64-gcc-${{ hashFiles('vcpkg.json.in') }}
           restore-keys: |
-            vcpkg-${{ runner.os }}-ubuntu-latest-linux-x64-gcc-coverage-
-            vcpkg-${{ runner.os }}-ubuntu-latest-linux-x64-gcc-
-            vcpkg-${{ runner.os }}-ubuntu-latest-
+            vcpkg-${{ runner.os }}-ubuntu-24.04-x64-gcc-
 
       - name: Bootstrap vcpkg
         run: ./external/vcpkg/bootstrap-vcpkg.sh

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -61,7 +61,6 @@ jobs:
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306  # v5.0.3
         with:
           path: |
-            build/linux-x64-gcc/vcpkg_installed
             external/vcpkg/downloads
             external/vcpkg/bincache
           key: vcpkg-${{ runner.os }}-ubuntu-latest-linux-x64-gcc-coverage-${{ hashFiles('vcpkg.json.in') }}

--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -30,7 +30,7 @@ env:
 
 jobs:
   fuzz:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     name: fuzz (${{ matrix.name }})
     strategy:
       fail-fast: false
@@ -77,10 +77,9 @@ jobs:
           path: |
             external/vcpkg/downloads
             external/vcpkg/bincache
-          key: vcpkg-${{ runner.os }}-ubuntu-latest-${{ env.BUILD_PRESET }}-fuzzing-${{ hashFiles('vcpkg.json.in') }}
+          key: vcpkg-${{ runner.os }}-ubuntu-24.04-x64-clang-${{ hashFiles('vcpkg.json.in') }}
           restore-keys: |
-            vcpkg-${{ runner.os }}-ubuntu-latest-${{ env.BUILD_PRESET }}-fuzzing-
-            vcpkg-${{ runner.os }}-ubuntu-latest-
+            vcpkg-${{ runner.os }}-ubuntu-24.04-x64-clang-
 
       - name: Bootstrap vcpkg
         run: ./external/vcpkg/bootstrap-vcpkg.sh

--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -75,7 +75,6 @@ jobs:
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306  # v5.0.3
         with:
           path: |
-            build/${{ env.BUILD_PRESET }}/vcpkg_installed
             external/vcpkg/downloads
             external/vcpkg/bincache
           key: vcpkg-${{ runner.os }}-ubuntu-latest-${{ env.BUILD_PRESET }}-fuzzing-${{ hashFiles('vcpkg.json.in') }}

--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -77,8 +77,6 @@ jobs:
           path: |
             build/${{ env.BUILD_PRESET }}/vcpkg_installed
             external/vcpkg/downloads
-            external/vcpkg/buildtrees
-            external/vcpkg/packages
             external/vcpkg/bincache
           key: vcpkg-${{ runner.os }}-ubuntu-latest-${{ env.BUILD_PRESET }}-fuzzing-${{ hashFiles('vcpkg.json.in') }}
           restore-keys: |

--- a/.github/workflows/nightly-check.yml
+++ b/.github/workflows/nightly-check.yml
@@ -165,13 +165,11 @@ jobs:
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306  # v5.0.3
         with:
           path: |
-            build/${{ matrix.config.preset }}/vcpkg_installed
             external/vcpkg/downloads
             external/vcpkg/bincache
-          key: vcpkg-${{ runner.os }}-${{ matrix.config.name }}-${{ matrix.config.preset }}-${{ hashFiles('vcpkg.json.in') }}
+          key: vcpkg-${{ runner.os }}-${{ matrix.config.preset }}-${{ hashFiles('vcpkg.json.in') }}
           restore-keys: |
-            vcpkg-${{ runner.os }}-${{ matrix.config.name }}-${{ matrix.config.preset }}-
-            vcpkg-${{ runner.os }}-${{ matrix.config.name }}-
+            vcpkg-${{ runner.os }}-${{ matrix.config.preset }}-
 
       - name: Bootstrap vcpkg (Linux)
         run: ./external/vcpkg/bootstrap-vcpkg.sh
@@ -265,13 +263,11 @@ jobs:
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306  # v5.0.3
         with:
           path: |
-            build/${{ matrix.config.preset }}/vcpkg_installed
             external/vcpkg/downloads
             external/vcpkg/bincache
-          key: vcpkg-${{ runner.os }}-${{ matrix.config.name }}-${{ matrix.config.preset }}-${{ hashFiles('vcpkg.json.in') }}
+          key: vcpkg-${{ runner.os }}-${{ matrix.config.preset }}-${{ hashFiles('vcpkg.json.in') }}
           restore-keys: |
-            vcpkg-${{ runner.os }}-${{ matrix.config.name }}-${{ matrix.config.preset }}-
-            vcpkg-${{ runner.os }}-${{ matrix.config.name }}-
+            vcpkg-${{ runner.os }}-${{ matrix.config.preset }}-
 
       - name: Install build tools (macOS)
         run: brew install --quiet autoconf automake autoconf-archive

--- a/.github/workflows/nightly-check.yml
+++ b/.github/workflows/nightly-check.yml
@@ -161,15 +161,9 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Cache vcpkg
-        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306  # v5.0.3
-        with:
-          path: |
-            external/vcpkg/downloads
-            external/vcpkg/bincache
-          key: vcpkg-${{ runner.os }}-${{ matrix.config.preset }}-${{ hashFiles('vcpkg.json.in') }}
-          restore-keys: |
-            vcpkg-${{ runner.os }}-${{ matrix.config.preset }}-
+      # Note: vcpkg caching disabled for Linux weekly scan to reduce cache storage usage.
+      # Different distros use different GCC versions, producing distinct ABI hashes that
+      # cannot share a cache entry. Caching all distros separately would exceed budget.
 
       - name: Bootstrap vcpkg (Linux)
         run: ./external/vcpkg/bootstrap-vcpkg.sh
@@ -259,15 +253,8 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Cache vcpkg
-        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306  # v5.0.3
-        with:
-          path: |
-            external/vcpkg/downloads
-            external/vcpkg/bincache
-          key: vcpkg-${{ runner.os }}-${{ matrix.config.preset }}-${{ hashFiles('vcpkg.json.in') }}
-          restore-keys: |
-            vcpkg-${{ runner.os }}-${{ matrix.config.preset }}-
+      # Note: vcpkg caching disabled for macOS weekly scan to reduce cache storage usage.
+      # macOS 14 and 15 have different compiler versions, so caches cannot be shared.
 
       - name: Install build tools (macOS)
         run: brew install --quiet autoconf automake autoconf-archive

--- a/.github/workflows/nightly-check.yml
+++ b/.github/workflows/nightly-check.yml
@@ -167,8 +167,6 @@ jobs:
           path: |
             build/${{ matrix.config.preset }}/vcpkg_installed
             external/vcpkg/downloads
-            external/vcpkg/buildtrees
-            external/vcpkg/packages
             external/vcpkg/bincache
           key: vcpkg-${{ runner.os }}-${{ matrix.config.name }}-${{ matrix.config.preset }}-${{ hashFiles('vcpkg.json.in') }}
           restore-keys: |
@@ -269,8 +267,6 @@ jobs:
           path: |
             build/${{ matrix.config.preset }}/vcpkg_installed
             external/vcpkg/downloads
-            external/vcpkg/buildtrees
-            external/vcpkg/packages
             external/vcpkg/bincache
           key: vcpkg-${{ runner.os }}-${{ matrix.config.name }}-${{ matrix.config.preset }}-${{ hashFiles('vcpkg.json.in') }}
           restore-keys: |

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           submodules: recursive
 
@@ -43,13 +43,11 @@ jobs:
           sudo apt-get install -y libssl-dev libjpeg-turbo8 libjpeg-turbo8-dev zlib1g-dev libopenjp2-7-dev libopenjp2-tools
 
       - name: Cache vcpkg
-        uses: actions/cache@v5
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306  # v5.0.3
         with:
           path: |
             build/${{ env.BUILD_PRESET }}/vcpkg_installed
             external/vcpkg/downloads
-            external/vcpkg/buildtrees
-            external/vcpkg/packages
             external/vcpkg/bincache
           key: vcpkg-${{ runner.os }}-${{ env.RUNNER_IMAGE }}-${{ env.BUILD_PRESET }}-sanitizers-${{ hashFiles('vcpkg.json.in') }}
           restore-keys: |
@@ -88,7 +86,7 @@ jobs:
             cmake_flag: VANILLAPDF_ENABLE_TSAN
 
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           submodules: recursive
 
@@ -98,13 +96,11 @@ jobs:
           sudo apt-get install -y libssl-dev libjpeg-turbo8 libjpeg-turbo8-dev zlib1g-dev libopenjp2-7-dev libopenjp2-tools
 
       - name: Restore vcpkg cache
-        uses: actions/cache/restore@v5
+        uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306  # v5.0.3
         with:
           path: |
             build/${{ env.BUILD_PRESET }}/vcpkg_installed
             external/vcpkg/downloads
-            external/vcpkg/buildtrees
-            external/vcpkg/packages
             external/vcpkg/bincache
           key: vcpkg-${{ runner.os }}-${{ env.RUNNER_IMAGE }}-${{ env.BUILD_PRESET }}-sanitizers-${{ hashFiles('vcpkg.json.in') }}
           restore-keys: |

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -46,7 +46,6 @@ jobs:
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306  # v5.0.3
         with:
           path: |
-            build/${{ env.BUILD_PRESET }}/vcpkg_installed
             external/vcpkg/downloads
             external/vcpkg/bincache
           key: vcpkg-${{ runner.os }}-${{ env.RUNNER_IMAGE }}-${{ env.BUILD_PRESET }}-sanitizers-${{ hashFiles('vcpkg.json.in') }}
@@ -99,7 +98,6 @@ jobs:
         uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306  # v5.0.3
         with:
           path: |
-            build/${{ env.BUILD_PRESET }}/vcpkg_installed
             external/vcpkg/downloads
             external/vcpkg/bincache
           key: vcpkg-${{ runner.os }}-${{ env.RUNNER_IMAGE }}-${{ env.BUILD_PRESET }}-sanitizers-${{ hashFiles('vcpkg.json.in') }}

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -48,10 +48,9 @@ jobs:
           path: |
             external/vcpkg/downloads
             external/vcpkg/bincache
-          key: vcpkg-${{ runner.os }}-${{ env.RUNNER_IMAGE }}-${{ env.BUILD_PRESET }}-sanitizers-${{ hashFiles('vcpkg.json.in') }}
+          key: vcpkg-${{ runner.os }}-ubuntu-24.04-x64-gcc-${{ hashFiles('vcpkg.json.in') }}
           restore-keys: |
-            vcpkg-${{ runner.os }}-${{ env.RUNNER_IMAGE }}-${{ env.BUILD_PRESET }}-sanitizers-
-            vcpkg-${{ runner.os }}-${{ env.RUNNER_IMAGE }}-
+            vcpkg-${{ runner.os }}-ubuntu-24.04-x64-gcc-
 
       - name: Bootstrap vcpkg
         run: ./external/vcpkg/bootstrap-vcpkg.sh
@@ -100,10 +99,9 @@ jobs:
           path: |
             external/vcpkg/downloads
             external/vcpkg/bincache
-          key: vcpkg-${{ runner.os }}-${{ env.RUNNER_IMAGE }}-${{ env.BUILD_PRESET }}-sanitizers-${{ hashFiles('vcpkg.json.in') }}
+          key: vcpkg-${{ runner.os }}-ubuntu-24.04-x64-gcc-${{ hashFiles('vcpkg.json.in') }}
           restore-keys: |
-            vcpkg-${{ runner.os }}-${{ env.RUNNER_IMAGE }}-${{ env.BUILD_PRESET }}-sanitizers-
-            vcpkg-${{ runner.os }}-${{ env.RUNNER_IMAGE }}-
+            vcpkg-${{ runner.os }}-ubuntu-24.04-x64-gcc-
 
       - name: Bootstrap vcpkg
         run: ./external/vcpkg/bootstrap-vcpkg.sh

--- a/.github/workflows/sanity-check.yml
+++ b/.github/workflows/sanity-check.yml
@@ -46,6 +46,7 @@ concurrency:
 env:
   VCPKG_ROOT: external/vcpkg
   VCPKG_DISABLE_METRICS: 1 # vcpkg is by default sending build metrics, we do not need it here
+  VCPKG_BINARY_SOURCES: "clear;files,${{ github.workspace }}/external/vcpkg/bincache,readwrite"
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
@@ -101,8 +102,7 @@ jobs:
           path: |
             build/${{ matrix.config.preset }}/vcpkg_installed
             external/vcpkg/downloads
-            external/vcpkg/buildtrees
-            external/vcpkg/packages
+            external/vcpkg/bincache
           key: vcpkg-${{ runner.os }}-${{ matrix.config.name }}-${{ matrix.config.preset }}-${{ hashFiles('vcpkg.json.in') }}
           restore-keys: |
             vcpkg-${{ runner.os }}-${{ matrix.config.name }}-${{ matrix.config.preset }}-
@@ -154,8 +154,7 @@ jobs:
           path: |
             build/${{ matrix.config.preset }}/vcpkg_installed
             external/vcpkg/downloads
-            external/vcpkg/buildtrees
-            external/vcpkg/packages
+            external/vcpkg/bincache
           key: vcpkg-${{ runner.os }}-${{ matrix.config.name }}-${{ matrix.config.preset }}-${{ hashFiles('vcpkg.json.in') }}
           restore-keys: |
             vcpkg-${{ runner.os }}-${{ matrix.config.name }}-${{ matrix.config.preset }}-
@@ -205,8 +204,7 @@ jobs:
           path: |
             build/${{ matrix.config.preset }}/vcpkg_installed
             external/vcpkg/downloads
-            external/vcpkg/buildtrees
-            external/vcpkg/packages
+            external/vcpkg/bincache
           key: vcpkg-${{ runner.os }}-${{ matrix.config.name }}-${{ matrix.config.preset }}-${{ hashFiles('vcpkg.json.in') }}
           restore-keys: |
             vcpkg-${{ runner.os }}-${{ matrix.config.name }}-${{ matrix.config.preset }}-

--- a/.github/workflows/sanity-check.yml
+++ b/.github/workflows/sanity-check.yml
@@ -100,7 +100,6 @@ jobs:
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306  # v5.0.3
         with:
           path: |
-            build/${{ matrix.config.preset }}/vcpkg_installed
             external/vcpkg/downloads
             external/vcpkg/bincache
           key: vcpkg-${{ runner.os }}-${{ matrix.config.name }}-${{ matrix.config.preset }}-${{ hashFiles('vcpkg.json.in') }}
@@ -152,7 +151,6 @@ jobs:
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306  # v5.0.3
         with:
           path: |
-            build/${{ matrix.config.preset }}/vcpkg_installed
             external/vcpkg/downloads
             external/vcpkg/bincache
           key: vcpkg-${{ runner.os }}-${{ matrix.config.name }}-${{ matrix.config.preset }}-${{ hashFiles('vcpkg.json.in') }}
@@ -202,7 +200,6 @@ jobs:
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306  # v5.0.3
         with:
           path: |
-            build/${{ matrix.config.preset }}/vcpkg_installed
             external/vcpkg/downloads
             external/vcpkg/bincache
           key: vcpkg-${{ runner.os }}-${{ matrix.config.name }}-${{ matrix.config.preset }}-${{ hashFiles('vcpkg.json.in') }}

--- a/.github/workflows/sanity-check.yml
+++ b/.github/workflows/sanity-check.yml
@@ -102,9 +102,8 @@ jobs:
           path: |
             external/vcpkg/downloads
             external/vcpkg/bincache
-          key: vcpkg-${{ runner.os }}-${{ matrix.config.name }}-${{ matrix.config.preset }}-${{ hashFiles('vcpkg.json.in') }}
+          key: vcpkg-${{ runner.os }}-${{ matrix.config.name }}-${{ hashFiles('vcpkg.json.in') }}
           restore-keys: |
-            vcpkg-${{ runner.os }}-${{ matrix.config.name }}-${{ matrix.config.preset }}-
             vcpkg-${{ runner.os }}-${{ matrix.config.name }}-
 
       # Bootstrap vcpkg on Linux
@@ -153,9 +152,8 @@ jobs:
           path: |
             external/vcpkg/downloads
             external/vcpkg/bincache
-          key: vcpkg-${{ runner.os }}-${{ matrix.config.name }}-${{ matrix.config.preset }}-${{ hashFiles('vcpkg.json.in') }}
+          key: vcpkg-${{ runner.os }}-${{ matrix.config.name }}-${{ hashFiles('vcpkg.json.in') }}
           restore-keys: |
-            vcpkg-${{ runner.os }}-${{ matrix.config.name }}-${{ matrix.config.preset }}-
             vcpkg-${{ runner.os }}-${{ matrix.config.name }}-
 
       # Bootstrap vcpkg on Windows
@@ -202,9 +200,8 @@ jobs:
           path: |
             external/vcpkg/downloads
             external/vcpkg/bincache
-          key: vcpkg-${{ runner.os }}-${{ matrix.config.name }}-${{ matrix.config.preset }}-${{ hashFiles('vcpkg.json.in') }}
+          key: vcpkg-${{ runner.os }}-${{ matrix.config.name }}-${{ hashFiles('vcpkg.json.in') }}
           restore-keys: |
-            vcpkg-${{ runner.os }}-${{ matrix.config.name }}-${{ matrix.config.preset }}-
             vcpkg-${{ runner.os }}-${{ matrix.config.name }}-
 
       - name: Install build tools (macOS)

--- a/.github/workflows/sanity-check.yml
+++ b/.github/workflows/sanity-check.yml
@@ -135,11 +135,11 @@ jobs:
         build_type: [Release]
 
         config:
-          - name: win.2025-x86
-            preset: windows-x86-msvc-17
+          - name: win.2025-x86-static
+            preset: windows-x86-msvc-17-static
 
-          - name: win.2025-x64
-            preset: windows-x64-msvc-17
+          - name: win.2025-x64-static
+            preset: windows-x64-msvc-17-static
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2

--- a/.github/workflows/signature-interop-check.yml
+++ b/.github/workflows/signature-interop-check.yml
@@ -46,7 +46,6 @@ jobs:
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306  # v5.0.3
         with:
           path: |
-            build/linux-x64-gcc/vcpkg_installed
             external/vcpkg/downloads
             external/vcpkg/bincache
           key: vcpkg-${{ runner.os }}-ubuntu.24.04-x64-linux-x64-gcc-${{ hashFiles('vcpkg.json.in') }}

--- a/.github/workflows/signature-interop-check.yml
+++ b/.github/workflows/signature-interop-check.yml
@@ -48,9 +48,9 @@ jobs:
           path: |
             external/vcpkg/downloads
             external/vcpkg/bincache
-          key: vcpkg-${{ runner.os }}-ubuntu.24.04-x64-linux-x64-gcc-${{ hashFiles('vcpkg.json.in') }}
+          key: vcpkg-${{ runner.os }}-ubuntu.24.04-x64-${{ hashFiles('vcpkg.json.in') }}
           restore-keys: |
-            vcpkg-${{ runner.os }}-ubuntu.24.04-x64-linux-x64-gcc-
+            vcpkg-${{ runner.os }}-ubuntu.24.04-x64-
 
       - name: Install pdfsig
         run: apt-get update && apt-get install -y poppler-utils libnss3-tools

--- a/.github/workflows/signature-interop-check.yml
+++ b/.github/workflows/signature-interop-check.yml
@@ -26,6 +26,7 @@ permissions:
 env:
   VCPKG_ROOT: external/vcpkg
   VCPKG_DISABLE_METRICS: 1
+  VCPKG_BINARY_SOURCES: "clear;files,${{ github.workspace }}/external/vcpkg/bincache,readwrite"
 
 jobs:
 
@@ -47,8 +48,7 @@ jobs:
           path: |
             build/linux-x64-gcc/vcpkg_installed
             external/vcpkg/downloads
-            external/vcpkg/buildtrees
-            external/vcpkg/packages
+            external/vcpkg/bincache
           key: vcpkg-${{ runner.os }}-ubuntu.24.04-x64-linux-x64-gcc-${{ hashFiles('vcpkg.json.in') }}
           restore-keys: |
             vcpkg-${{ runner.os }}-ubuntu.24.04-x64-linux-x64-gcc-


### PR DESCRIPTION
## Summary

- **Remove nightly caching** (Linux + macOS): different distros (Ubuntu 22/24, Rocky 8/9/10, Fedora 41/42/43) use different GCC versions producing distinct vcpkg ABI hashes that cannot be shared. Caching all separately exceeds the 10 GB budget; sharing one key causes a race condition. Weekly cold builds are acceptable.
- **Standardize cache key format** to `vcpkg-{OS}-{name}-{hash}` (drop cmake preset suffix).
- **Rename build-nuget configs**: `linux-x64/arm64` → `rocky.9-x64/arm64`, `osx-arm64` → `osx.15-arm64` to match actual container images. NuGet package IDs (set by cmake `PLATFORM_IDENTIFIER`) are unchanged.
- **Pin runners** for coverage, codeql, and fuzzing to `ubuntu-24.04` instead of `ubuntu-latest`.
- **Drop `vcpkg_installed/`** from all cache paths — it's derived from bincache, not worth caching separately.
- **Unify Windows to static preset**: sanity-check and conformance-check switch from `windows-x64-msvc-17` to `windows-x64-msvc-17-static`, and build-nuget is pinned from `windows-latest` to `windows-2025`. All three now share one cache entry per architecture. Dynamic CRT coverage continues via nightly-check.

## Cache entries after this PR (~12 entries, ~3.5 GB)

| Cache key | Shared by |
|-----------|-----------|
| `vcpkg-Linux-ubuntu.24.04-x64-{hash}` | sanity + conformance + signature-interop |
| `vcpkg-Linux-ubuntu.24.04-arm64-{hash}` | sanity |
| `vcpkg-Linux-rocky.9-x64-{hash}` | sanity + build-nuget |
| `vcpkg-Linux-rocky.9-arm64-{hash}` | sanity + build-nuget |
| `vcpkg-Linux-ubuntu-24.04-x64-gcc-{hash}` | coverage + codeql + sanitizers |
| `vcpkg-Linux-ubuntu-24.04-x64-clang-{hash}` | fuzzing |
| `vcpkg-Windows-win.2025-x64-static-{hash}` | sanity + conformance + build-nuget |
| `vcpkg-Windows-win.2025-x86-static-{hash}` | sanity + build-nuget |
| `vcpkg-macOS-osx.15-x64-{hash}` | sanity + build-nuget |
| `vcpkg-macOS-osx.15-arm64-{hash}` | sanity + conformance + build-nuget |
| *(nightly: no cache)* | — |

## Test plan

- [ ] Verify sanity-check picks up cache hits for Linux and macOS configs
- [ ] Verify build-nuget NuGet package IDs are still correct (`vanillapdf.runtime.linux-x64`, etc.)
- [ ] Verify nightly-check runs cleanly without caching
- [ ] Verify coverage, codeql, sanitizers share the `ubuntu-24.04-x64-gcc` cache entry
- [ ] Verify conformance-check Windows passes with static preset (no DLL PATH workaround needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)