### PR TITLE
fix: Pin all GitHub Actions to full commit SHAs in sanitizers.yml

### DIFF
--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           submodules: recursive
 
@@ -43,7 +43,7 @@ jobs:
           sudo apt-get install -y libssl-dev libjpeg-turbo8 libjpeg-turbo8-dev zlib1g-dev libopenjp2-7-dev libopenjp2-tools
 
       - name: Cache vcpkg
-        uses: actions/cache@v5
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306  # v5.0.3
         with:
           path: |
             build/${{ env.BUILD_PRESET }}/vcpkg_installed
@@ -88,7 +88,7 @@ jobs:
             cmake_flag: VANILLAPDF_ENABLE_TSAN
 
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           submodules: recursive
 
@@ -98,7 +98,7 @@ jobs:
           sudo apt-get install -y libssl-dev libjpeg-turbo8 libjpeg-turbo8-dev zlib1g-dev libopenjp2-7-dev libopenjp2-tools
 
       - name: Restore vcpkg cache
-        uses: actions/cache/restore@v5
+        uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306  # v5.0.3
         with:
           path: |
             build/${{ env.BUILD_PRESET }}/vcpkg_installed


### PR DESCRIPTION
## Summary

- Pins `actions/checkout@v6.0.2` to `@de0fac2e4500dabe0009e67214ff5f5447ce83dd` (×2)
- Pins `actions/cache@v5` to `@cdf6c1fa76f9f475f3d7449005a359c84ca0f306` (v5.0.3)
- Pins `actions/cache/restore@v5` to `@cdf6c1fa76f9f475f3d7449005a359c84ca0f306` (v5.0.3)

All other workflow files in the repository already use pinned SHAs. This change brings `sanitizers.yml` into compliance with the OpenSSF Scorecard Pinned-Dependencies check and eliminates the remaining supply-chain risk from mutable action tags.

## Test plan

- [x] Verify Scorecard Pinned-Dependencies check passes
- [x] Verify sanitizer workflow still runs successfully (ASan, UBSan, TSan jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)