### PR TITLE
[Backport release/2.1] perf: Standardize vcpkg cache keys, remove nightly caching

### DIFF
--- a/.github/workflows/build-nuget.yml
+++ b/.github/workflows/build-nuget.yml
@@ -72,14 +72,14 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - name: linux-x64
+          - name: rocky.9-x64
             os: ubuntu-24.04
             image: ghcr.io/vanillapdf/vanillapdf-rockylinux-amd64:9
             platform: linux/amd64
             preset: linux-x64-gcc
             build_type: Release
 
-          - name: linux-arm64
+          - name: rocky.9-arm64
             os: ubuntu-24.04-arm
             image: ghcr.io/vanillapdf/vanillapdf-rockylinux-arm64v8:9
             platform: linux/arm64
@@ -106,13 +106,11 @@ jobs:
         uses: actions/cache@v5
         with:
           path: |
-            build/${{ matrix.config.preset }}/vcpkg_installed
             external/vcpkg/downloads
             external/vcpkg/bincache
-          key: vcpkg-${{ runner.os }}-${{ matrix.config.preset }}-${{ hashFiles('vcpkg.json') }}
+          key: vcpkg-${{ runner.os }}-${{ matrix.config.name }}-${{ hashFiles('vcpkg.json') }}
           restore-keys: |
-            vcpkg-${{ runner.os }}-${{ matrix.config.preset }}-
-            vcpkg-${{ runner.os }}-
+            vcpkg-${{ runner.os }}-${{ matrix.config.name }}-
 
       - name: Bootstrap vcpkg (Linux)
         run: ./external/vcpkg/bootstrap-vcpkg.sh
@@ -156,18 +154,18 @@ jobs:
 
   build-windows:
     name: ${{ matrix.config.name }}
-    runs-on: windows-latest
+    runs-on: windows-2025
 
     strategy:
       fail-fast: false
       matrix:
         config:
-          - name: win-x86
-            preset: windows-x86-msvc-17
+          - name: win.2025-x86-static
+            preset: windows-x86-msvc-17-static
             build_type: Release
 
-          - name: win-x64
-            preset: windows-x64-msvc-17
+          - name: win.2025-x64-static
+            preset: windows-x64-msvc-17-static
             build_type: Release
 
     steps:
@@ -182,13 +180,11 @@ jobs:
         uses: actions/cache@v5
         with:
           path: |
-            build/${{ matrix.config.preset }}/vcpkg_installed
             external/vcpkg/downloads
             external/vcpkg/bincache
-          key: vcpkg-${{ runner.os }}-${{ matrix.config.preset }}-${{ hashFiles('vcpkg.json') }}
+          key: vcpkg-${{ runner.os }}-${{ matrix.config.name }}-${{ hashFiles('vcpkg.json') }}
           restore-keys: |
-            vcpkg-${{ runner.os }}-${{ matrix.config.preset }}-
-            vcpkg-${{ runner.os }}-
+            vcpkg-${{ runner.os }}-${{ matrix.config.name }}-
 
       - name: Bootstrap vcpkg (Windows)
         run: ${{ github.workspace }}\\external\\vcpkg\\bootstrap-vcpkg.bat
@@ -238,12 +234,12 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - name: osx-x64
+          - name: osx.15-x64
             runner: macos-15-intel
             preset: macos-x64
             build_type: Release
 
-          - name: osx-arm64
+          - name: osx.15-arm64
             runner: macos-15
             preset: macos-arm64
             build_type: Release
@@ -260,13 +256,11 @@ jobs:
         uses: actions/cache@v5
         with:
           path: |
-            build/${{ matrix.config.preset }}/vcpkg_installed
             external/vcpkg/downloads
             external/vcpkg/bincache
-          key: vcpkg-${{ runner.os }}-${{ matrix.config.preset }}-${{ hashFiles('vcpkg.json') }}
+          key: vcpkg-${{ runner.os }}-${{ matrix.config.name }}-${{ hashFiles('vcpkg.json') }}
           restore-keys: |
-            vcpkg-${{ runner.os }}-${{ matrix.config.preset }}-
-            vcpkg-${{ runner.os }}-
+            vcpkg-${{ runner.os }}-${{ matrix.config.name }}-
 
       - name: Fix JPEG library conflicts (macOS) - TEMPORARY WORKAROUND
         run: |
@@ -344,13 +338,11 @@ jobs:
         uses: actions/cache@v5
         with:
           path: |
-            build/${{ matrix.config.preset }}/vcpkg_installed
             external/vcpkg/downloads
             external/vcpkg/bincache
-          key: vcpkg-${{ runner.os }}-${{ matrix.config.preset }}-${{ hashFiles('vcpkg.json') }}
+          key: vcpkg-${{ runner.os }}-${{ matrix.config.name }}-${{ hashFiles('vcpkg.json') }}
           restore-keys: |
-            vcpkg-${{ runner.os }}-${{ matrix.config.preset }}-
-            vcpkg-${{ runner.os }}-
+            vcpkg-${{ runner.os }}-${{ matrix.config.name }}-
 
       - name: Bootstrap vcpkg (Windows)
         run: ${{ github.workspace }}\\external\\vcpkg\\bootstrap-vcpkg.bat

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -42,7 +42,7 @@ jobs:
     #   - https://gh.io/supported-runners-and-hardware-resources
     #   - https://gh.io/using-larger-runners (GitHub.com only)
     # Consider using larger runners or machines with greater resources for possible analysis time improvements.
-    runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
+    runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-24.04' }}
     permissions:
       # required for all workflows
       security-events: write
@@ -82,14 +82,11 @@ jobs:
       uses: actions/cache@v5
       with:
         path: |
-          build/**/vcpkg_installed
           external/vcpkg/downloads
-          external/vcpkg/buildtrees
-          external/vcpkg/packages
           external/vcpkg/bincache
-        key: codeql-vcpkg-${{ runner.os }}-${{ hashFiles('vcpkg.json') }}
+        key: vcpkg-${{ runner.os }}-ubuntu-24.04-x64-gcc-${{ hashFiles('vcpkg.json') }}
         restore-keys: |
-          codeql-vcpkg-${{ runner.os }}-
+          vcpkg-${{ runner.os }}-ubuntu-24.04-x64-gcc-
 
     - name: Bootstrap vcpkg
       run: ./external/vcpkg/bootstrap-vcpkg.sh

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -35,9 +35,14 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  VCPKG_ROOT: external/vcpkg
+  VCPKG_DISABLE_METRICS: 1
+  VCPKG_BINARY_SOURCES: "clear;files,${{ github.workspace }}/external/vcpkg/bincache,readwrite"
+
 jobs:
   coverage:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@v6
@@ -51,15 +56,11 @@ jobs:
         uses: actions/cache@v5
         with:
           path: |
-            build/linux-x64-gcc/vcpkg_installed
             external/vcpkg/downloads
-            external/vcpkg/buildtrees
-            external/vcpkg/packages
-          key: vcpkg-${{ runner.os }}-ubuntu-latest-linux-x64-gcc-coverage-${{ hashFiles('vcpkg.json') }}
+            external/vcpkg/bincache
+          key: vcpkg-${{ runner.os }}-ubuntu-24.04-x64-gcc-${{ hashFiles('vcpkg.json') }}
           restore-keys: |
-            vcpkg-${{ runner.os }}-ubuntu-latest-linux-x64-gcc-coverage-
-            vcpkg-${{ runner.os }}-ubuntu-latest-linux-x64-gcc-
-            vcpkg-${{ runner.os }}-ubuntu-latest-
+            vcpkg-${{ runner.os }}-ubuntu-24.04-x64-gcc-
 
       - name: Bootstrap vcpkg
         run: ./external/vcpkg/bootstrap-vcpkg.sh

--- a/.github/workflows/nightly-check.yml
+++ b/.github/workflows/nightly-check.yml
@@ -7,17 +7,17 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-  # Run workflow on any push into main branch
+  # Run workflow on any push into main or release branches
   # only there was a change in the workflow file
   push:
-    branches: [ "main" ]
+    branches: [ "main", "release/*" ]
     paths:
       - '.github/workflows/nightly-check.yml'
 
-  # Run workflow when there is a pull request towards main branch
+  # Run workflow when there is a pull request towards main or release branches
   # only there was a change in the workflow file
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "release/*" ]
     paths:
       - '.github/workflows/nightly-check.yml'
 

--- a/.github/workflows/nightly-check.yml
+++ b/.github/workflows/nightly-check.yml
@@ -107,17 +107,9 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Cache vcpkg
-        uses: actions/cache@v5
-        with:
-          path: |
-            build/${{ matrix.config.preset }}/vcpkg_installed
-            external/vcpkg/downloads
-            external/vcpkg/bincache
-          key: vcpkg-${{ runner.os }}-${{ matrix.config.preset }}-${{ hashFiles('vcpkg.json') }}
-          restore-keys: |
-            vcpkg-${{ runner.os }}-${{ matrix.config.preset }}-
-            vcpkg-${{ runner.os }}-
+      # Note: vcpkg caching disabled for Linux weekly scan to reduce cache storage usage.
+      # Different distros use different GCC versions, producing distinct ABI hashes that
+      # cannot share a cache entry. Caching all distros separately would exceed budget.
 
       - name: Bootstrap vcpkg (Linux)
         run: ./external/vcpkg/bootstrap-vcpkg.sh
@@ -156,17 +148,8 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Cache vcpkg
-        uses: actions/cache@v5
-        with:
-          path: |
-            build/${{ matrix.config.preset }}/vcpkg_installed
-            external/vcpkg/downloads
-            external/vcpkg/bincache
-          key: vcpkg-${{ runner.os }}-${{ matrix.config.preset }}-${{ hashFiles('vcpkg.json') }}
-          restore-keys: |
-            vcpkg-${{ runner.os }}-${{ matrix.config.preset }}-
-            vcpkg-${{ runner.os }}-
+      # Note: vcpkg caching disabled for Windows weekly scan to reduce cache storage usage.
+      # Windows has many configurations and each cache is large (~1 GB).
 
       - name: Bootstrap vcpkg (Windows)
         run: ${{ github.workspace }}\\external\\vcpkg\\bootstrap-vcpkg.bat
@@ -200,17 +183,8 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Cache vcpkg
-        uses: actions/cache@v5
-        with:
-          path: |
-            build/${{ matrix.config.preset }}/vcpkg_installed
-            external/vcpkg/downloads
-            external/vcpkg/bincache
-          key: vcpkg-${{ runner.os }}-${{ matrix.config.preset }}-${{ hashFiles('vcpkg.json') }}
-          restore-keys: |
-            vcpkg-${{ runner.os }}-${{ matrix.config.preset }}-
-            vcpkg-${{ runner.os }}-
+      # Note: vcpkg caching disabled for macOS weekly scan to reduce cache storage usage.
+      # macOS 14 and 15 have different compiler versions, so caches cannot be shared.
 
       - name: Fix JPEG library conflicts (macOS) - TEMPORARY WORKAROUND
         run: |

--- a/.github/workflows/sanity-check.yml
+++ b/.github/workflows/sanity-check.yml
@@ -98,13 +98,11 @@ jobs:
         uses: actions/cache@v5
         with:
           path: |
-            build/${{ matrix.config.preset }}/vcpkg_installed
             external/vcpkg/downloads
             external/vcpkg/bincache
-          key: vcpkg-${{ runner.os }}-${{ matrix.config.preset }}-${{ hashFiles('vcpkg.json') }}
+          key: vcpkg-${{ runner.os }}-${{ matrix.config.name }}-${{ hashFiles('vcpkg.json') }}
           restore-keys: |
-            vcpkg-${{ runner.os }}-${{ matrix.config.preset }}-
-            vcpkg-${{ runner.os }}-
+            vcpkg-${{ runner.os }}-${{ matrix.config.name }}-
 
       # Bootstrap vcpkg on Linux
       - name: Bootstrap vcpkg (Linux)
@@ -135,11 +133,11 @@ jobs:
         build_type: [Release]
 
         config:
-          - name: win.2025-x86
-            preset: windows-x86-msvc-17
+          - name: win.2025-x86-static
+            preset: windows-x86-msvc-17-static
 
-          - name: win.2025-x64
-            preset: windows-x64-msvc-17
+          - name: win.2025-x64-static
+            preset: windows-x64-msvc-17-static
 
     steps:
       - uses: actions/checkout@v6
@@ -150,13 +148,11 @@ jobs:
         uses: actions/cache@v5
         with:
           path: |
-            build/${{ matrix.config.preset }}/vcpkg_installed
             external/vcpkg/downloads
             external/vcpkg/bincache
-          key: vcpkg-${{ runner.os }}-${{ matrix.config.preset }}-${{ hashFiles('vcpkg.json') }}
+          key: vcpkg-${{ runner.os }}-${{ matrix.config.name }}-${{ hashFiles('vcpkg.json') }}
           restore-keys: |
-            vcpkg-${{ runner.os }}-${{ matrix.config.preset }}-
-            vcpkg-${{ runner.os }}-
+            vcpkg-${{ runner.os }}-${{ matrix.config.name }}-
 
       # Bootstrap vcpkg on Windows
       - name: Bootstrap vcpkg (Windows)
@@ -200,13 +196,11 @@ jobs:
         uses: actions/cache@v5
         with:
           path: |
-            build/${{ matrix.config.preset }}/vcpkg_installed
             external/vcpkg/downloads
             external/vcpkg/bincache
-          key: vcpkg-${{ runner.os }}-${{ matrix.config.preset }}-${{ hashFiles('vcpkg.json') }}
+          key: vcpkg-${{ runner.os }}-${{ matrix.config.name }}-${{ hashFiles('vcpkg.json') }}
           restore-keys: |
-            vcpkg-${{ runner.os }}-${{ matrix.config.preset }}-
-            vcpkg-${{ runner.os }}-
+            vcpkg-${{ runner.os }}-${{ matrix.config.name }}-
 
       - name: Fix JPEG library conflicts (macOS) - TEMPORARY WORKAROUND
         run: |

--- a/.github/workflows/sanity-check.yml
+++ b/.github/workflows/sanity-check.yml
@@ -133,11 +133,11 @@ jobs:
         build_type: [Release]
 
         config:
-          - name: win.2025-x86-static
-            preset: windows-x86-msvc-17-static
+          - name: win.2025-x86
+            preset: windows-x86-msvc-17
 
-          - name: win.2025-x64-static
-            preset: windows-x64-msvc-17-static
+          - name: win.2025-x64
+            preset: windows-x64-msvc-17
 
     steps:
       - uses: actions/checkout@v6

--- a/cmake/presets/windows.json
+++ b/cmake/presets/windows.json
@@ -49,6 +49,28 @@
             }
         },
         {
+            "name": "windows-x86-msvc-17-static",
+            "inherits": "default",
+            "generator": "Visual Studio 17 2022",
+            "architecture": "Win32",
+            "cacheVariables": {
+                "VCPKG_TARGET_TRIPLET": "x86-windows-static",
+                "PLATFORM_IDENTIFIER": "win-x86",
+                "VANILLAPDF_USE_STATIC_CRT": "ON"
+            }
+        },
+        {
+            "name": "windows-x64-msvc-17-static",
+            "inherits": "default",
+            "generator": "Visual Studio 17 2022",
+            "architecture": "x64",
+            "cacheVariables": {
+                "VCPKG_TARGET_TRIPLET": "x64-windows-static",
+                "PLATFORM_IDENTIFIER": "win-x64",
+                "VANILLAPDF_USE_STATIC_CRT": "ON"
+            }
+        },
+        {
             "name": "windows-x86-ninja",
             "inherits": "default",
             "generator": "Ninja",
@@ -89,6 +111,14 @@
             "configurePreset": "windows-x64-msvc-17"
         },
         {
+            "name": "windows-x86-msvc-17-static",
+            "configurePreset": "windows-x86-msvc-17-static"
+        },
+        {
+            "name": "windows-x64-msvc-17-static",
+            "configurePreset": "windows-x64-msvc-17-static"
+        },
+        {
             "name": "windows-x86-ninja",
             "configurePreset": "windows-x86-ninja"
         },
@@ -113,6 +143,14 @@
         {
             "name": "windows-x64-msvc-17",
             "configurePreset": "windows-x64-msvc-17"
+        },
+        {
+            "name": "windows-x86-msvc-17-static",
+            "configurePreset": "windows-x86-msvc-17-static"
+        },
+        {
+            "name": "windows-x64-msvc-17-static",
+            "configurePreset": "windows-x64-msvc-17-static"
         },
         {
             "name": "windows-x86-ninja",


### PR DESCRIPTION
Backport of #336 to `release/2.1`.

## Changes

- Drop `vcpkg_installed` from all cache paths; keep only `downloads` and `bincache`
- Fix `sanity-check` cache key to use `config.name` instead of `config.preset` (the preset-only key caused all distros to race writing to the same cache entry)
- Standardize all keys to `vcpkg-{OS}-{name}-{hash}`
- Simplify restore-keys to single fallback line
- Remove caching from `nightly-check` (cross-distro GCC ABI hash mismatch; weekly cold builds are acceptable)
- Switch `sanity-check` Windows to static preset (`win.2025-x{64,86}-static`) — shared cache with `build-nuget`
- Pin `build-nuget` Windows to `windows-2025` with static presets; rename configs to `win.2025-x{64,86}-static`
- Rename `build-nuget` Linux: `linux-x64/arm64` → `rocky.9-x64/arm64`
- Rename `build-nuget` macOS: `osx-x64` → `osx.15-x64`, `osx-arm64` → `osx.15-arm64`
- Add `VCPKG_BINARY_SOURCES` and pin runner to `ubuntu-24.04` for `coverage`
- Pin `codeql` runner to `ubuntu-24.04`; unify key to `ubuntu-24.04-x64-gcc`

🤖 Generated with [Claude Code](https://claude.com/claude-code)