### PR TITLE
release: Bump version to 2.1.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,7 @@ project(vanillapdf)
 # It is important project version before including cmake/packaging.cmake
 set(VANILLAPDF_VERSION_MAJOR 2)
 set(VANILLAPDF_VERSION_MINOR 1)
-set(VANILLAPDF_VERSION_PATCH 1)
+set(VANILLAPDF_VERSION_PATCH 2)
 set(VANILLAPDF_VERSION_BUILD 0)
 set(VANILLAPDF_VERSION_BUILD_SUFFIX "" CACHE STRING "Optional build suffix")
 


### PR DESCRIPTION
## Summary

- Bumps `VANILLAPDF_VERSION_PATCH` from `1` to `2` in `CMakeLists.txt`
- Advances the `release/2.1` line from version **2.1.1** to **2.1.2**

## Changes

In `CMakeLists.txt`:

```cmake
# Before
set(VANILLAPDF_VERSION_PATCH 1)

# After
set(VANILLAPDF_VERSION_PATCH 2)
```

## Test plan

- [x] Verify the CMake configure step reports version `2.1.2`
- [ ] Confirm no other version references need updating (e.g., `vcpkg.json`, changelogs)
- [ ] Merge into `release/2.1` and tag `v2.1.2` as appropriate

🤖 Generated with [Claude Code](https://claude.com/claude-code)