### PR TITLE
fix: Set latest=false on GitHub releases for older branches

### DIFF
--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -9,6 +9,10 @@ on:
       prerelease:
         required: true
         type: boolean
+      latest:
+        required: false
+        type: boolean
+        default: true
   workflow_dispatch:
     inputs:
       tag:
@@ -18,6 +22,11 @@ on:
         description: "Set to true for prerelease"
         required: true
         type: boolean
+      latest:
+        description: "Set as latest release"
+        required: false
+        type: boolean
+        default: true
 
 permissions: {}
 
@@ -48,17 +57,24 @@ jobs:
             echo "Release $TAG already exists. Skipping."
             exit 0
           fi
+          LATEST_FLAG=""
+          if [ "${{ inputs.latest }}" = "false" ]; then
+            LATEST_FLAG="--latest=false"
+          fi
+
           if [ "$PRERELEASE" = "true" ]; then
             gh release create "$TAG" \
               --title "vanillapdf $TAG" \
               --generate-notes \
               --draft \
-              --prerelease
+              --prerelease \
+              $LATEST_FLAG
           else
             gh release create "$TAG" \
               --title "vanillapdf $TAG" \
               --generate-notes \
-              --draft
+              --draft \
+              $LATEST_FLAG
           fi
 
       - name: Generate SBOM

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -270,6 +270,7 @@ jobs:
     with:
       tag: ${{ needs.production-gate.outputs.tag }}
       prerelease: ${{ fromJSON(needs.production-gate.outputs.prerelease) }}
+      latest: ${{ needs.production-gate.outputs.tag == needs.production-gate.outputs.latest_tag }}
     secrets: inherit
 
   vcpkg-pr:


### PR DESCRIPTION
## Summary
- Add `latest` input to `github-release.yml` workflow
- Pass `--latest=false` to `gh release create` when the tag is not the latest stable version
- Prevents older branch patches (e.g. v2.1.2 when v2.2.1 exists) from being marked as "Latest" in GitHub Releases

## Test plan
- [ ] Dry-run the release workflow with `workflow_dispatch` and verify the `latest` flag is passed correctly
- [ ] Verify that releasing on an older branch does not set the "Latest" badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)