### PR TITLE
fix: Handle existing branch in vcpkg update script

### DIFF
--- a/scripts/update_vcpkg.py
+++ b/scripts/update_vcpkg.py
@@ -160,9 +160,9 @@ class VcpkgUpdater:
         return True
 
     def push_branch(self, branch_name: str) -> None:
-        """Push the update branch to remote."""
+        """Push the update branch to remote (force-push to update existing automated branches)."""
         print(f"Pushing branch {branch_name} to remote...")
-        self.run_command(['git', 'push', 'origin', branch_name])
+        self.run_command(['git', 'push', '--force-with-lease', 'origin', branch_name])
 
     def create_pull_request(self, current_version: str, new_version: str, commit_hash: str, branch_name: str) -> Optional[str]:
         """Create a pull request for the vcpkg update."""
@@ -195,6 +195,20 @@ This PR was created using the `scripts/update_vcpkg.py` script.
 🤖 Generated with update_vcpkg.py script"""
 
         try:
+            # Check if a PR already exists for this branch
+            existing = self.run_command([
+                'gh', 'pr', 'list',
+                '--head', branch_name,
+                '--state', 'open',
+                '--json', 'url',
+                '--jq', '.[0].url'
+            ], check=False)
+
+            if existing.returncode == 0 and existing.stdout.strip():
+                pr_url = existing.stdout.strip()
+                print(f"Pull request already exists: {pr_url} — branch has been updated")
+                return pr_url
+
             print("Creating pull request...")
             result = self.run_command([
                 'gh', 'pr', 'create',


### PR DESCRIPTION
## Summary
- Use `--force-with-lease` when pushing the automated update branch so re-runs update the existing branch instead of failing
- Skip PR creation if an open PR already exists for that branch, matching Dependabot's behavior

## Test plan
- [ ] Run `update_vcpkg.py` when the branch already exists on remote — should force-push and skip PR creation
- [ ] Run `update_vcpkg.py` with no existing branch — should behave as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)