### PR TITLE
fix: Add CRT linkage support to vcpkg portfile

### DIFF
--- a/ports/vanillapdf/portfile.cmake
+++ b/ports/vanillapdf/portfile.cmake
@@ -6,10 +6,13 @@ vcpkg_from_github(
     HEAD_REF main
 )
 
+string(COMPARE EQUAL "${VCPKG_CRT_LINKAGE}" "static" VANILLAPDF_USE_STATIC_CRT)
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
       -DVANILLAPDF_INTERNAL_VCPKG=OFF
+      -DVANILLAPDF_USE_STATIC_CRT=${VANILLAPDF_USE_STATIC_CRT}
 )
 
 vcpkg_cmake_install()


### PR DESCRIPTION
## Summary
- Propagate `VCPKG_CRT_LINKAGE` to `VANILLAPDF_USE_STATIC_CRT` in the local vcpkg portfile
- Without this, static CRT triplets (`x64-windows-static`) would incorrectly use dynamic CRT
- Aligns local portfile with the official [microsoft/vcpkg port](https://github.com/microsoft/vcpkg/blob/master/ports/vanillapdf/portfile.cmake)

## Test plan
- [x] Build with `x64-windows-static` triplet and verify `/MT` is used
- [x] Build with `x64-windows` triplet and verify `/MD` is used

🤖 Generated with [Claude Code](https://claude.com/claude-code)