### PR TITLE
fix: Backport OpenSSL legacy provider fix to release/2.2

### DIFF
--- a/doc/sphinx/install.rst
+++ b/doc/sphinx/install.rst
@@ -336,6 +336,30 @@ Troubleshooting
 - **macOS**: Install via Homebrew: ``brew install openssl@3 jpeg-turbo zlib openjpeg``
 - **Windows**: Use vcpkg presets or ensure Visual Studio 2022 or 2026 is properly installed
 
+*OpenSSL legacy provider on Windows:*
+
+**Static linking is the recommended approach on Windows.** Providers are compiled
+directly into the library and no additional configuration is needed.
+
+When linking dynamically, OpenSSL 3.x loads provider modules (e.g. ``legacy.dll``)
+at runtime from a compiled-in directory. If that directory does not match the
+actual installation, provider loading will fail:
+
+.. code-block:: text
+
+   Failed to initialize legacy OSSL provider
+   filename(C:\Program Files (x86)\OpenSSL\bin\legacy.dll)
+
+The caller is responsible for configuring the environment so that OpenSSL can
+find its provider modules. Set the ``OPENSSL_MODULES`` environment variable to
+the directory containing the provider DLLs before running the application:
+
+.. code-block:: bash
+
+   set OPENSSL_MODULES=path/to/bin
+
+The build system handles this automatically for CTest targets.
+
 Building packages
 -----------------
 

--- a/src/vanillapdf.test/CMakeLists.txt
+++ b/src/vanillapdf.test/CMakeLists.txt
@@ -119,4 +119,12 @@ foreach(TEST_FILE ${TEST_FILES})
         "${VANILLAPDF_SOLUTION_SOURCE_DIR}/scripts/VanillaPDF.lic"	# path to license file for test purposes
         "${VANILLAPDF_SOLUTION_SOURCE_DIR}"							# path to root of the source directory
     )
+
+    # OpenSSL 3.x: set provider module search path (see vanillapdf/CMakeLists.txt)
+    if(WIN32 AND VANILLAPDF_INTERNAL_VCPKG AND NOT VANILLAPDF_EXTERNAL_OPENSSL
+            AND VANILLAPDF_OPENSSL_MODULES_DIR)
+        set_tests_properties(${TEST_FILENAME} PROPERTIES
+            ENVIRONMENT "OPENSSL_MODULES=${VANILLAPDF_OPENSSL_MODULES_DIR}"
+        )
+    endif()
 endforeach(TEST_FILE)

--- a/src/vanillapdf.unittest/CMakeLists.txt
+++ b/src/vanillapdf.unittest/CMakeLists.txt
@@ -126,4 +126,13 @@ include(GoogleTest)
 # Without this flag, test names include raw memory addresses making output unreadable:
 #   Before: CertificateTypes/.../40-byte object <B0-4E 79-8B F7-7F 00-00...>
 #   After:  CertificateTypes/.../2kDSA_SHA256
-gtest_discover_tests(vanillapdf.unittest DISCOVERY_MODE PRE_TEST NO_PRETTY_VALUES)
+# OpenSSL 3.x: set provider module search path (see vanillapdf/CMakeLists.txt)
+set(VANILLAPDF_UNITTEST_EXTRA_PROPERTIES "")
+if(WIN32 AND VANILLAPDF_INTERNAL_VCPKG AND NOT VANILLAPDF_EXTERNAL_OPENSSL
+        AND VANILLAPDF_OPENSSL_MODULES_DIR)
+    set(VANILLAPDF_UNITTEST_EXTRA_PROPERTIES PROPERTIES ENVIRONMENT "OPENSSL_MODULES=${VANILLAPDF_OPENSSL_MODULES_DIR}")
+endif()
+
+gtest_discover_tests(vanillapdf.unittest DISCOVERY_MODE PRE_TEST NO_PRETTY_VALUES
+    ${VANILLAPDF_UNITTEST_EXTRA_PROPERTIES}
+)

--- a/src/vanillapdf/CMakeLists.txt
+++ b/src/vanillapdf/CMakeLists.txt
@@ -803,67 +803,54 @@ install(FILES
 # Define installation files and procedures
 include("${VANILLAPDF_SOLUTION_SOURCE_DIR}/cmake/vanillapdf_install.cmake")
 
-# Install dependent libraries on windows
-if(WIN32)
+# vcpkg's VCPKG_APPLOCAL_DEPS (ON by default) automatically copies linked
+# DLL dependencies to the build output directory. Enable its install
+# counterpart so that cmake --install also includes them.
+if(WIN32 AND VANILLAPDF_INTERNAL_VCPKG)
+    set(X_VCPKG_APPLOCAL_DEPS_INSTALL ON CACHE BOOL
+        "Automatically copy vcpkg dependencies into install target directory" FORCE)
+endif()
 
-    # OpenSSL dependent libraries
-    if (OPENSSL_FOUND)
-    
-        # Find dll runtime binary file
-        find_file(LIBEAY_RUNTIME
-            NAMES libcrypto-3.dll libcrypto-3-x64.dll legacy.dll
-            PATHS ${VANILLPDF_BINARY_DIR}
+# OpenSSL 3.x legacy provider module — runtime-loaded via OSSL_PROVIDER_load,
+# not a linked dependency, so VCPKG_APPLOCAL_DEPS does not handle it.
+# Neither vcpkg nor CMake's FindOpenSSL expose whether OpenSSL was built as
+# shared or static (VCPKG_LIBRARY_LINKAGE is not available to consumer projects,
+# and imported targets are created as UNKNOWN). The most reliable check is to
+# look for the provider file directly. On static vcpkg triplets, providers are
+# compiled into the library and no separate DLL exists, so find_file fails
+# silently. OPENSSL_MODULES_DIR is set by OpenSSL's own OpenSSLConfig.cmake.
+if(WIN32 AND VANILLAPDF_INTERNAL_VCPKG
+        AND OPENSSL_FOUND AND NOT VANILLAPDF_EXTERNAL_OPENSSL
+        AND OPENSSL_VERSION VERSION_GREATER_EQUAL "3.0.0")
+
+    find_file(OPENSSL_LEGACY_PROVIDER
+        NAMES legacy.dll
+        PATHS "${OPENSSL_MODULES_DIR}"
+              "${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/bin"
+        NO_DEFAULT_PATH
+    )
+
+    if(EXISTS "${OPENSSL_LEGACY_PROVIDER}")
+        message(STATUS "OpenSSL legacy provider found at ${OPENSSL_LEGACY_PROVIDER}")
+
+        add_custom_command(
+            TARGET vanillapdf POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -E copy_if_different
+            "${OPENSSL_LEGACY_PROVIDER}"
+            "$<TARGET_FILE_DIR:vanillapdf>"
+            COMMENT "Copying OpenSSL legacy provider module"
         )
+        install(FILES "${OPENSSL_LEGACY_PROVIDER}" DESTINATION bin)
 
-        if (NOT EXISTS ${LIBEAY_RUNTIME})
-            # message(FATAL_ERROR "OpenSSL support is enabled, but the LIBEAY_RUNTIME does not exist")
-        endif(NOT EXISTS ${LIBEAY_RUNTIME})
-        
-        # message(STATUS "LIBEAY runtime was found at ${LIBEAY_RUNTIME}")
-        
-        # Install dependency into output package
-        # install(FILES ${LIBEAY_RUNTIME} DESTINATION bin)
-
-    endif (OPENSSL_FOUND)
-
-    # libjpeg dependent libraries
-    if (JPEG_FOUND)
-
-        # Find dll runtime binary file
-        find_file(LIBJPEG_RUNTIME
-            NAMES turbojpeg.dll
-            PATHS ${VANILLPDF_BINARY_DIR}
-        )
-
-        if (NOT EXISTS ${LIBJPEG_RUNTIME})
-            # message(FATAL_ERROR "JPEG support is enabled, but the LIBJPEG_RUNTIME does not exist")
-        endif(NOT EXISTS ${LIBJPEG_RUNTIME})
-        
-        # message(STATUS "LIBJPEG runtime was found at ${LIBJPEG_RUNTIME}")
-        
-        # Install dependency into output package
-        # install(FILES ${LIBJPEG_RUNTIME} DESTINATION bin)
-    endif (JPEG_FOUND)
-
-    # zlib dependent libraries
-    if (VANILLAPDF_ENABLE_ZLIB AND ZLIB_FOUND)
-
-        # Find dll runtime binary file
-        find_file(ZLIB_RUNTIME
-            NAMES zlib1.dll
-            PATHS ${VANILLPDF_BINARY_DIR}
-        )
-
-        if (NOT EXISTS ${ZLIB_RUNTIME})
-            # message(FATAL_ERROR "zlib support is enabled, but the ZLIB_RUNTIME does not exist")
-        endif(NOT EXISTS ${ZLIB_RUNTIME})
-        
-        # message(STATUS "ZLIB runtime was found at ${ZLIB_RUNTIME}")
-        
-        # Install dependency into output package
-        # install(FILES ${ZLIB_RUNTIME} DESTINATION bin)
-    endif (VANILLAPDF_ENABLE_ZLIB AND ZLIB_FOUND)
-endif(WIN32)
+        # Set the modules directory so test targets can set OPENSSL_MODULES env var.
+        # OpenSSL checks this env var at runtime to locate provider modules.
+        # Users can override via -DVANILLAPDF_OPENSSL_MODULES_DIR=<path>.
+        set(VANILLAPDF_OPENSSL_MODULES_DIR "${OPENSSL_MODULES_DIR}"
+            CACHE PATH "Directory containing OpenSSL provider modules")
+    else()
+        message(STATUS "OpenSSL legacy provider not found — assuming static linkage (providers compiled in)")
+    endif()
+endif()
 
 # Add export verification test for shared library builds
 # Only add the test if testing is enabled and we're building shared libraries

--- a/src/vanillapdf/utils/crypto_utils.cpp
+++ b/src/vanillapdf/utils/crypto_utils.cpp
@@ -29,6 +29,7 @@ static std::mutex g_openssl_lock;
 static bool g_openssl_initialized = false;
 static OSSL_PROVIDER* g_legacy_provider = nullptr;
 static OSSL_PROVIDER* g_default_provider = nullptr;
+
 #endif
 
 const EVP_MD* CryptoUtils::GetAlgorithm(MessageDigestAlgorithm algorithm) {
@@ -200,6 +201,7 @@ const EVP_MD* CryptoUtils::GetAlgorithm(MessageDigestAlgorithm) {
 std::string CryptoUtils::GetLastOpensslError() {
     throw NotSupportedException("This library was compiled without OpenSSL support");
 }
+
 
 void CryptoUtils::InitializeOpenSSL() {
     throw NotSupportedException("This library was compiled without OpenSSL support");


### PR DESCRIPTION
## Summary

Backport of #365 to `release/2.2`.

- Make OpenSSL legacy provider detection non-fatal for static vcpkg triplets
- Remove `BUILD_SHARED_LIBS` guard — use file existence check instead
- Use `OPENSSL_MODULES_DIR` from OpenSSL's `OpenSSLConfig.cmake` as primary search path
- Document static linking as recommended approach on Windows

Needed for the upcoming vcpkg update where the OpenSSL port removes `--openssldir`.

## Test plan

- [x] `windows-x64-msvc-17-static` configures without error
- [x] `windows-x64-msvc-17` (dynamic) finds and copies `legacy.dll`
- [x] CTest targets on dynamic Windows builds get `OPENSSL_MODULES` env var

🤖 Generated with [Claude Code](https://claude.com/claude-code)