### PR TITLE
fix: Use format-specific separators for pre-release version suffixes

### DIFF
--- a/.github/workflows/build-nuget.yml
+++ b/.github/workflows/build-nuget.yml
@@ -20,7 +20,7 @@ on:
   workflow_dispatch:
     inputs:
       build_suffix:
-        description: "Optional build suffix for version (e.g., -nightly.main)"
+        description: "Optional build suffix for version (e.g., nightly.main, alpha.2)"
         required: false
         default: ""
       patch_override:
@@ -146,7 +146,7 @@ jobs:
       - name: Upload Artifacts
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
         with:
-          name: vanillapdf.runtime.${{ matrix.config.name }}${{ inputs.build_suffix }}
+          name: vanillapdf.runtime.${{ matrix.config.name }}${{ inputs.build_suffix && format('-{0}', inputs.build_suffix) || '' }}
           path: '*.nupkg'
 
 
@@ -225,7 +225,7 @@ jobs:
       - name: Upload Artifacts
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
         with:
-          name: vanillapdf.runtime.${{ matrix.config.name }}${{ inputs.build_suffix }}
+          name: vanillapdf.runtime.${{ matrix.config.name }}${{ inputs.build_suffix && format('-{0}', inputs.build_suffix) || '' }}
           path: '*.nupkg'
 
 
@@ -310,7 +310,7 @@ jobs:
       - name: Upload Artifacts
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
         with:
-          name: vanillapdf.runtime.${{ matrix.config.name }}${{ inputs.build_suffix }}
+          name: vanillapdf.runtime.${{ matrix.config.name }}${{ inputs.build_suffix && format('-{0}', inputs.build_suffix) || '' }}
           path: '*.nupkg'
 
 
@@ -362,5 +362,5 @@ jobs:
       - name: Upload Artifact
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
         with:
-          name: vanillapdf${{ inputs.build_suffix }}
+          name: vanillapdf${{ inputs.build_suffix && format('-{0}', inputs.build_suffix) || '' }}
           path: '*.nupkg'

--- a/.github/workflows/nightly-nuget.yml
+++ b/.github/workflows/nightly-nuget.yml
@@ -81,8 +81,8 @@ jobs:
           # Fallback in the unlikely case the cleaned name is empty
           if [ -z "$CLEAN_NAME" ]; then CLEAN_NAME="branch"; fi
           DATE=$(date +'%Y%m%d')
-          # Format: -nightly.branch (e.g., -nightly.main), date goes to build version
-          echo "nightly_suffix=-nightly.${CLEAN_NAME}" >> "$GITHUB_OUTPUT"
+          # Format: nightly.branch (e.g., nightly.main), date goes to build version
+          echo "nightly_suffix=nightly.${CLEAN_NAME}" >> "$GITHUB_OUTPUT"
           echo "build_date=${DATE}" >> "$GITHUB_OUTPUT"
 
   build-nuget:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,7 +70,7 @@ jobs:
             EXTRA="${BASH_REMATCH[1]}"
           fi
           if [[ -n "$EXTRA" ]]; then
-            echo "build_suffix=-${EXTRA#-}" >> "$GITHUB_OUTPUT"
+            echo "build_suffix=${EXTRA#-}" >> "$GITHUB_OUTPUT"
             echo "prerelease=true" >> "$GITHUB_OUTPUT"
           else
             echo "build_suffix=" >> "$GITHUB_OUTPUT"

--- a/cmake/packaging.cmake
+++ b/cmake/packaging.cmake
@@ -16,12 +16,15 @@ set(CPACK_PACKAGE_INSTALL_DIRECTORY		"Vanilla.PDF Labs/Vanilla.PDF")
 set(CPACK_PACKAGE_DESCRIPTION_SUMMARY	"Cross-platform toolkit for creating and modifying PDF documents")
 set(CPACK_PACKAGE_DESCRIPTION			"Cross-platform toolkit for creating and modifying PDF documents")
 
-# There is a little trick going on
-# By default, the CPACK_PACKAGE_FILE_NAME is set to
-# "${CPACK_PACKAGE_NAME}-${CPACK_PACKAGE_VERSION}-${CPACK_SYSTEM_NAME}."
-# However! Variable CPACK_PACKAGE_VERSION is only used internally a is not yet set!
-# Therefore we have to create a different variable for storing the version string
-set(PACKAGE_VERSION_NAME				"${CPACK_PACKAGE_VERSION_MAJOR}.${CPACK_PACKAGE_VERSION_MINOR}.${CPACK_PACKAGE_VERSION_PATCH}${VANILLAPDF_VERSION_BUILD_SUFFIX}")
+# CPack computes CPACK_PACKAGE_VERSION internally as MAJOR.MINOR.PATCH,
+# which excludes the build suffix. Override it so pre-release package
+# versions match the dependency declarations.
+# Separator per format: '-' for semver (ZIP, WiX, DMG), '~' for DEB/RPM.
+set(PACKAGE_VERSION_NAME "${CPACK_PACKAGE_VERSION_MAJOR}.${CPACK_PACKAGE_VERSION_MINOR}.${CPACK_PACKAGE_VERSION_PATCH}")
+if(VANILLAPDF_VERSION_BUILD_SUFFIX)
+    set(PACKAGE_VERSION_NAME "${PACKAGE_VERSION_NAME}-${VANILLAPDF_VERSION_BUILD_SUFFIX}")
+    set(CPACK_PACKAGE_VERSION "${PACKAGE_VERSION_NAME}")
+endif()
 set(PACKAGE_SYSTEM_NAME					"${CMAKE_SYSTEM_NAME}")
 
 if (PLATFORM_IDENTIFIER)
@@ -66,6 +69,12 @@ set(CPACK_COMPONENT_DEVELOPMENT_DISPLAY_NAME "Vanilla.PDF Development")
 set(CPACK_COMPONENT_DEVELOPMENT_DESCRIPTION "Headers, static libraries, and CMake config files")
 set(CPACK_COMPONENT_DEVELOPMENT_DEPENDS Runtime)
 
+# DEB and RPM use '~' for pre-release (sorts before release version)
+set(PACKAGE_VERSION_NAME_DEB_RPM "${CPACK_PACKAGE_VERSION_MAJOR}.${CPACK_PACKAGE_VERSION_MINOR}.${CPACK_PACKAGE_VERSION_PATCH}")
+if(VANILLAPDF_VERSION_BUILD_SUFFIX)
+    set(PACKAGE_VERSION_NAME_DEB_RPM "${PACKAGE_VERSION_NAME_DEB_RPM}~${VANILLAPDF_VERSION_BUILD_SUFFIX}")
+endif()
+
 # Variables specific to CPack RPM generator
 set(CPACK_RPM_PACKAGE_LICENSE			"Proprietary")
 set(CPACK_RPM_PACKAGE_GROUP				"Development/Libraries/C and C++")
@@ -73,18 +82,20 @@ set(CPACK_RPM_PACKAGE_URL				"https://vanillapdf.com/")
 set(CPACK_RPM_PACKAGE_AUTOREQ			1)
 set(CPACK_RPM_PACKAGE_AUTOPROV			1)
 set(CPACK_RPM_COMPONENT_INSTALL			ON)
+set(CPACK_RPM_PACKAGE_VERSION			"${PACKAGE_VERSION_NAME_DEB_RPM}")
 set(CPACK_RPM_RUNTIME_PACKAGE_NAME		"vanillapdf")
 set(CPACK_RPM_DEVELOPMENT_PACKAGE_NAME	"vanillapdf-devel")
-set(CPACK_RPM_DEVELOPMENT_PACKAGE_REQUIRES "vanillapdf = ${PACKAGE_VERSION_NAME}")
+set(CPACK_RPM_DEVELOPMENT_PACKAGE_REQUIRES "vanillapdf = ${PACKAGE_VERSION_NAME_DEB_RPM}")
 
 # Variables specific to CPack DEB generator
 set(CPACK_DEBIAN_PACKAGE_HOMEPAGE		"https://vanillapdf.com/")
 set(CPACK_DEBIAN_PACKAGE_SECTION		"devel")
 set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS		YES)
 set(CPACK_DEB_COMPONENT_INSTALL			ON)
+set(CPACK_DEBIAN_PACKAGE_VERSION		"${PACKAGE_VERSION_NAME_DEB_RPM}")
 set(CPACK_DEBIAN_RUNTIME_PACKAGE_NAME	"vanillapdf")
 set(CPACK_DEBIAN_DEVELOPMENT_PACKAGE_NAME "vanillapdf-dev")
-set(CPACK_DEBIAN_DEVELOPMENT_PACKAGE_DEPENDS "vanillapdf (= ${PACKAGE_VERSION_NAME})")
+set(CPACK_DEBIAN_DEVELOPMENT_PACKAGE_DEPENDS "vanillapdf (= ${PACKAGE_VERSION_NAME_DEB_RPM})")
 
 # Variables specific to CPack FreeBSD generator
 set(CPACK_FREEBSD_PACKAGE_MAINTAINER	"info@vanillapdf.com")

--- a/cmake/version.cmake
+++ b/cmake/version.cmake
@@ -18,12 +18,16 @@ if(VANILLAPDF_VERSION_BUILD_OVERRIDE)
     set(VANILLAPDF_VERSION_BUILD_STRING ".${VANILLAPDF_VERSION_BUILD_OVERRIDE}")
 endif()
 
-# Optional build suffix for pre-release builds
-# Examples: -dev, -alpha.1, -beta.1, -rc.1, -nightly.main
+# Optional build suffix for pre-release builds (without leading separator).
+# The separator is added per format: '-' for semver/NuGet, '~' for DEB/RPM.
+# Examples: dev, alpha.1, beta.1, rc.1, nightly.main
 if(NOT DEFINED VANILLAPDF_VERSION_BUILD_SUFFIX)
     set(VANILLAPDF_VERSION_BUILD_SUFFIX "")
 endif()
 
 # Compose full version string for configuration files
-# Examples: 2.3.0, 2.3.0-dev, 2.3.0-alpha.1, 2.3.0-beta.1, 2.3.0-rc.1, 2.3.999.20251228-nightly.main
-set(VANILLAPDF_VERSION "${VANILLAPDF_VERSION_MAJOR}.${VANILLAPDF_VERSION_MINOR}.${VANILLAPDF_VERSION_PATCH}${VANILLAPDF_VERSION_BUILD_STRING}${VANILLAPDF_VERSION_BUILD_SUFFIX}")
+# Examples: 2.3.0, 2.3.0-dev, 2.3.0-alpha.1, 2.3.0-rc.1, 2.3.999.20251228-nightly.main
+set(VANILLAPDF_VERSION "${VANILLAPDF_VERSION_MAJOR}.${VANILLAPDF_VERSION_MINOR}.${VANILLAPDF_VERSION_PATCH}${VANILLAPDF_VERSION_BUILD_STRING}")
+if(VANILLAPDF_VERSION_BUILD_SUFFIX)
+    set(VANILLAPDF_VERSION "${VANILLAPDF_VERSION}-${VANILLAPDF_VERSION_BUILD_SUFFIX}")
+endif()

--- a/nuget/vanillapdf.csproj.in
+++ b/nuget/vanillapdf.csproj.in
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <PackageId>vanillapdf</PackageId>
-    <Version>@VANILLAPDF_VERSION_MAJOR@.@VANILLAPDF_VERSION_MINOR@.@VANILLAPDF_VERSION_PATCH@@VANILLAPDF_VERSION_BUILD_STRING@@VANILLAPDF_VERSION_BUILD_SUFFIX@</Version>
+    <Version>@VANILLAPDF_VERSION@</Version>
     <Title>vanillapdf</Title>
     <Authors>Vanilla.PDF Labs s.r.o.</Authors>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
@@ -18,13 +18,13 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="vanillapdf.runtime.linux-x64" Version="@VANILLAPDF_VERSION_MAJOR@.@VANILLAPDF_VERSION_MINOR@.@VANILLAPDF_VERSION_PATCH@@VANILLAPDF_VERSION_BUILD_STRING@@VANILLAPDF_VERSION_BUILD_SUFFIX@" />
-    <PackageReference Include="vanillapdf.runtime.linux-arm64" Version="@VANILLAPDF_VERSION_MAJOR@.@VANILLAPDF_VERSION_MINOR@.@VANILLAPDF_VERSION_PATCH@@VANILLAPDF_VERSION_BUILD_STRING@@VANILLAPDF_VERSION_BUILD_SUFFIX@" />
-    <PackageReference Include="vanillapdf.runtime.win-x86" Version="@VANILLAPDF_VERSION_MAJOR@.@VANILLAPDF_VERSION_MINOR@.@VANILLAPDF_VERSION_PATCH@@VANILLAPDF_VERSION_BUILD_STRING@@VANILLAPDF_VERSION_BUILD_SUFFIX@" />
-    <PackageReference Include="vanillapdf.runtime.win-x64" Version="@VANILLAPDF_VERSION_MAJOR@.@VANILLAPDF_VERSION_MINOR@.@VANILLAPDF_VERSION_PATCH@@VANILLAPDF_VERSION_BUILD_STRING@@VANILLAPDF_VERSION_BUILD_SUFFIX@" />
-    <PackageReference Include="vanillapdf.runtime.win-arm64" Version="@VANILLAPDF_VERSION_MAJOR@.@VANILLAPDF_VERSION_MINOR@.@VANILLAPDF_VERSION_PATCH@@VANILLAPDF_VERSION_BUILD_STRING@@VANILLAPDF_VERSION_BUILD_SUFFIX@" />
-    <PackageReference Include="vanillapdf.runtime.osx-x64" Version="@VANILLAPDF_VERSION_MAJOR@.@VANILLAPDF_VERSION_MINOR@.@VANILLAPDF_VERSION_PATCH@@VANILLAPDF_VERSION_BUILD_STRING@@VANILLAPDF_VERSION_BUILD_SUFFIX@" />
-    <PackageReference Include="vanillapdf.runtime.osx-arm64" Version="@VANILLAPDF_VERSION_MAJOR@.@VANILLAPDF_VERSION_MINOR@.@VANILLAPDF_VERSION_PATCH@@VANILLAPDF_VERSION_BUILD_STRING@@VANILLAPDF_VERSION_BUILD_SUFFIX@" />
+    <PackageReference Include="vanillapdf.runtime.linux-x64" Version="@VANILLAPDF_VERSION@" />
+    <PackageReference Include="vanillapdf.runtime.linux-arm64" Version="@VANILLAPDF_VERSION@" />
+    <PackageReference Include="vanillapdf.runtime.win-x86" Version="@VANILLAPDF_VERSION@" />
+    <PackageReference Include="vanillapdf.runtime.win-x64" Version="@VANILLAPDF_VERSION@" />
+    <PackageReference Include="vanillapdf.runtime.win-arm64" Version="@VANILLAPDF_VERSION@" />
+    <PackageReference Include="vanillapdf.runtime.osx-x64" Version="@VANILLAPDF_VERSION@" />
+    <PackageReference Include="vanillapdf.runtime.osx-arm64" Version="@VANILLAPDF_VERSION@" />
   </ItemGroup>
   <ItemGroup>
     <None Include="../include/**/*.h" Pack="true" PackagePath="build/native/include" />

--- a/nuget/vanillapdf.runtime.csproj.in
+++ b/nuget/vanillapdf.runtime.csproj.in
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <PackageId>vanillapdf.runtime.@PLATFORM_IDENTIFIER@</PackageId>
-    <Version>@VANILLAPDF_VERSION_MAJOR@.@VANILLAPDF_VERSION_MINOR@.@VANILLAPDF_VERSION_PATCH@@VANILLAPDF_VERSION_BUILD_STRING@@VANILLAPDF_VERSION_BUILD_SUFFIX@</Version>
+    <Version>@VANILLAPDF_VERSION@</Version>
     <Title>vanillapdf</Title>
     <Authors>Vanilla.PDF Labs s.r.o.</Authors>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>


### PR DESCRIPTION
## Summary

- Store `VANILLAPDF_VERSION_BUILD_SUFFIX` without the leading dash (e.g., `alpha.2` instead of `-alpha.2`)
- Each consumer adds the appropriate separator: `-` for semver/NuGet/ZIP/WiX/DMG, `~` for DEB/RPM
- Override `CPACK_PACKAGE_VERSION`, `CPACK_DEBIAN_PACKAGE_VERSION`, and `CPACK_RPM_PACKAGE_VERSION` to include the suffix
- Simplify NuGet templates to use pre-composed `@VANILLAPDF_VERSION@`

## Context

DEB/RPM packages failed to install on pre-release builds because CPack computed the package version as `2.3.0` (no suffix) while the dev/devel package declared a dependency on the full version with suffix. Additionally, `-` is not valid in DEB/RPM version strings — pre-releases use `~` instead.

## Test plan

- [x] Release with suffix produces correct versions per format
- [x] Stable release (no suffix) produces base version everywhere
- [x] Nightly build suffix works correctly
- [ ] DEB dev package installs alongside runtime package

🤖 Generated with [Claude Code](https://claude.com/claude-code)