### PR TITLE
[Backport release/2.2] fix: Correct AES-CBC PKCS#7 padding and document FIPS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 | **PDF Generation** | Create documents with text, images, paths, and pages |
 | **Advanced Editing** | Modify content streams, metadata, and page structure |
 | **PDF Parsing** | Inspect low-level internals like XRef tables and objects |
-| **Encryption** | Work with standard PDF security models |
+| **Encryption** | Work with standard PDF security models; compatible with FIPS-enabled OpenSSL configurations |
 | **CLI Tools** | Batch-process PDFs directly from the terminal |
 
 ## Supported Platforms

--- a/doc/src/input/install.dox
+++ b/doc/src/input/install.dox
@@ -289,6 +289,37 @@ cmake --preset <your-preset>
 - **macOS**: Install via Homebrew: `brew install openssl@3 jpeg-turbo zlib openjpeg`
 - **Windows**: Use vcpkg presets or ensure Visual Studio 2022 or 2026 is properly installed
 
+\section install_openssl OpenSSL and FIPS Configuration
+
+Vanilla.PDF is compatible with FIPS-enabled and policy-restricted OpenSSL
+configurations commonly found on RHEL-based distributions (Rocky Linux, Fedora,
+AlmaLinux, RHEL). The library uses OpenSSL's PKCS#7 padding for AES encryption
+and loads the OpenSSL \c legacy provider at startup to support the full range
+of PDF encryption standards.
+
+\subsection install_openssl_crypto_policy Crypto Policy Configuration
+
+The PDF specification requires algorithms that some OpenSSL crypto policies
+consider legacy: MD5 for encryption key derivation, RC4 for older encrypted
+documents, and SHA-1 for some digital signatures. On RHEL-based distributions,
+the \c DEFAULT crypto policy may restrict these algorithms.
+
+If encrypted PDF operations fail with crypto errors, enable the legacy
+algorithms via the system crypto policy:
+\code{.bash}
+sudo update-crypto-policies --set LEGACY
+\endcode
+
+\subsection install_openssl_weak_algorithms Weak Algorithm Control
+
+For digital signature verification, the
+\ref SignatureVerificationSettingsHandle API provides fine-grained control over
+whether weak algorithms (MD5, SHA-1, RSA < 2048 bits) are accepted, without
+requiring system-wide policy changes:
+\code{.c}
+SignatureVerificationSettings_SetAllowWeakAlgorithmsFlag(settings, VANILLAPDF_RV_TRUE);
+\endcode
+
 \section install_packages Building packages
 
 Instructions for creating Debian or Homebrew packages are provided in the

--- a/src/vanillapdf.unittest/document_test.cpp
+++ b/src/vanillapdf.unittest/document_test.cpp
@@ -153,27 +153,27 @@ TEST_P(AESEncryptionRoundtrip, VerifyStringContent) {
     auto param = GetParam();
 
     // Create source document in memory
-    HandleGuard<InputOutputStreamHandle, InputOutputStream_Release> src_io;
-    HandleGuard<FileHandle, File_Release> src_file;
-    HandleGuard<DocumentHandle, Document_Release> src_doc;
-    HandleGuard<DocumentEncryptionSettingsHandle, DocumentEncryptionSettings_Release> enc_settings;
+    InputOutputStreamHandle* src_io = nullptr;
+    FileHandle* src_file = nullptr;
+    DocumentHandle* src_doc = nullptr;
+    DocumentEncryptionSettingsHandle* enc_settings = nullptr;
 
-    ASSERT_EQ(InputOutputStream_CreateFromMemory(src_io.out()), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(File_CreateStream(src_io, "src", src_file.out()), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Document_CreateFile(src_file, src_doc.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(InputOutputStream_CreateFromMemory(&src_io), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(File_CreateStream(src_io, "src", &src_file), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Document_CreateFile(src_file, &src_doc), VANILLAPDF_ERROR_SUCCESS);
 
     // Configure AES-128 encryption
-    HandleGuard<BufferHandle, Buffer_Release> owner_pw;
-    HandleGuard<BufferHandle, Buffer_Release> user_pw;
+    BufferHandle* owner_pw = nullptr;
+    BufferHandle* user_pw = nullptr;
     std::string owner_password = "owner";
     std::string user_password = "user";
 
-    ASSERT_EQ(DocumentEncryptionSettings_Create(enc_settings.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(DocumentEncryptionSettings_Create(&enc_settings), VANILLAPDF_ERROR_SUCCESS);
     ASSERT_EQ(DocumentEncryptionSettings_SetAlgorithm(enc_settings, EncryptionAlgorithmType_AES), VANILLAPDF_ERROR_SUCCESS);
     ASSERT_EQ(DocumentEncryptionSettings_SetKeyLength(enc_settings, 128), VANILLAPDF_ERROR_SUCCESS);
     ASSERT_EQ(DocumentEncryptionSettings_SetUserAccessPermissions(enc_settings, UserAccessPermissionFlag_None), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Buffer_CreateFromData(owner_password.data(), owner_password.length(), owner_pw.out()), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Buffer_CreateFromData(user_password.data(), user_password.length(), user_pw.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Buffer_CreateFromData(owner_password.data(), owner_password.length(), &owner_pw), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Buffer_CreateFromData(user_password.data(), user_password.length(), &user_pw), VANILLAPDF_ERROR_SUCCESS);
     ASSERT_EQ(DocumentEncryptionSettings_SetOwnerPassword(enc_settings, owner_pw), VANILLAPDF_ERROR_SUCCESS);
     ASSERT_EQ(DocumentEncryptionSettings_SetUserPassword(enc_settings, user_pw), VANILLAPDF_ERROR_SUCCESS);
     ASSERT_EQ(Document_AddEncryption(src_doc, enc_settings), VANILLAPDF_ERROR_SUCCESS);
@@ -181,43 +181,43 @@ TEST_P(AESEncryptionRoundtrip, VerifyStringContent) {
     // Insert a test string into the page dictionary under a custom key.
     // Page dictionaries survive save/reopen and their string values are
     // encrypted, so this exercises the full AES encrypt→decrypt roundtrip.
-    HandleGuard<CatalogHandle, Catalog_Release> src_catalog;
-    HandleGuard<PageTreeHandle, PageTree_Release> src_pages;
-    HandleGuard<PageObjectHandle, PageObject_Release> src_page;
-    HandleGuard<DictionaryObjectHandle, DictionaryObject_Release> src_page_dict;
+    CatalogHandle* src_catalog = nullptr;
+    PageTreeHandle* src_pages = nullptr;
+    PageObjectHandle* src_page = nullptr;
+    DictionaryObjectHandle* src_page_dict = nullptr;
 
-    ASSERT_EQ(Document_GetCatalog(src_doc, src_catalog.out()), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Catalog_GetPages(src_catalog, src_pages.out()), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(PageObject_CreateFromDocument(src_doc, src_page.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Document_GetCatalog(src_doc, &src_catalog), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Catalog_GetPages(src_catalog, &src_pages), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(PageObject_CreateFromDocument(src_doc, &src_page), VANILLAPDF_ERROR_SUCCESS);
     ASSERT_EQ(PageTree_AppendPage(src_pages, src_page), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(PageObject_GetBaseObject(src_page, src_page_dict.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(PageObject_GetBaseObject(src_page, &src_page_dict), VANILLAPDF_ERROR_SUCCESS);
 
-    HandleGuard<NameObjectHandle, NameObject_Release> key_name;
-    HandleGuard<BufferHandle, Buffer_Release> data_buf;
-    HandleGuard<LiteralStringObjectHandle, LiteralStringObject_Release> str_obj;
-    HandleGuard<StringObjectHandle, StringObject_Release> str_base;
-    HandleGuard<ObjectHandle, Object_Release> str_as_obj;
+    NameObjectHandle* key_name = nullptr;
+    BufferHandle* data_buf = nullptr;
+    LiteralStringObjectHandle* str_obj = nullptr;
+    StringObjectHandle* str_base = nullptr;
+    ObjectHandle* str_as_obj = nullptr;
 
-    ASSERT_EQ(NameObject_CreateFromEncodedString("TestData", key_name.out()), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Buffer_CreateFromData(param.test_data.data(), param.test_data.size(), data_buf.out()), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(LiteralStringObject_CreateFromEncodedBuffer(data_buf, str_obj.out()), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(LiteralStringObject_ToStringObject(str_obj, str_base.out()), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(StringObject_ToObject(str_base, str_as_obj.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(NameObject_CreateFromEncodedString("TestData", &key_name), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Buffer_CreateFromData(param.test_data.data(), param.test_data.size(), &data_buf), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(LiteralStringObject_CreateFromEncodedBuffer(data_buf, &str_obj), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(LiteralStringObject_ToStringObject(str_obj, &str_base), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(StringObject_ToObject(str_base, &str_as_obj), VANILLAPDF_ERROR_SUCCESS);
     ASSERT_EQ(DictionaryObject_Insert(src_page_dict, key_name, str_as_obj, VANILLAPDF_RV_TRUE), VANILLAPDF_ERROR_SUCCESS);
 
     // Save encrypted document to memory
-    HandleGuard<InputOutputStreamHandle, InputOutputStream_Release> dst_io;
-    HandleGuard<FileHandle, File_Release> dst_save_file;
+    InputOutputStreamHandle* dst_io = nullptr;
+    FileHandle* dst_save_file = nullptr;
 
-    ASSERT_EQ(InputOutputStream_CreateFromMemory(dst_io.out()), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(File_CreateStream(dst_io, "dst", dst_save_file.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(InputOutputStream_CreateFromMemory(&dst_io), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(File_CreateStream(dst_io, "dst", &dst_save_file), VANILLAPDF_ERROR_SUCCESS);
     ASSERT_EQ(Document_SaveFile(src_doc, dst_save_file), VANILLAPDF_ERROR_SUCCESS);
 
     // Reopen the encrypted document and navigate to the page
-    HandleGuard<FileHandle, File_Release> dst_load_file;
-    HandleGuard<DocumentHandle, Document_Release> dst_doc;
+    FileHandle* dst_load_file = nullptr;
+    DocumentHandle* dst_doc = nullptr;
 
-    ASSERT_EQ(File_OpenStream(dst_io, "dst", dst_load_file.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(File_OpenStream(dst_io, "dst", &dst_load_file), VANILLAPDF_ERROR_SUCCESS);
     ASSERT_EQ(File_Initialize(dst_load_file), VANILLAPDF_ERROR_SUCCESS);
 
     boolean_type is_encrypted = VANILLAPDF_RV_FALSE;
@@ -225,38 +225,38 @@ TEST_P(AESEncryptionRoundtrip, VerifyStringContent) {
     ASSERT_EQ(is_encrypted, VANILLAPDF_RV_TRUE);
     ASSERT_EQ(File_SetEncryptionPassword(dst_load_file, user_password.data()), VANILLAPDF_ERROR_SUCCESS);
 
-    ASSERT_EQ(Document_OpenFile(dst_load_file, dst_doc.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Document_OpenFile(dst_load_file, &dst_doc), VANILLAPDF_ERROR_SUCCESS);
 
-    HandleGuard<CatalogHandle, Catalog_Release> dst_catalog;
-    HandleGuard<PageTreeHandle, PageTree_Release> dst_pages;
-    HandleGuard<PageObjectHandle, PageObject_Release> dst_page;
-    HandleGuard<DictionaryObjectHandle, DictionaryObject_Release> dst_page_dict;
+    CatalogHandle* dst_catalog = nullptr;
+    PageTreeHandle* dst_pages = nullptr;
+    PageObjectHandle* dst_page = nullptr;
+    DictionaryObjectHandle* dst_page_dict = nullptr;
 
-    ASSERT_EQ(Document_GetCatalog(dst_doc, dst_catalog.out()), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Catalog_GetPages(dst_catalog, dst_pages.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Document_GetCatalog(dst_doc, &dst_catalog), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Catalog_GetPages(dst_catalog, &dst_pages), VANILLAPDF_ERROR_SUCCESS);
 
     size_type page_count = 0;
     ASSERT_EQ(PageTree_GetPageCount(dst_pages, &page_count), VANILLAPDF_ERROR_SUCCESS);
     ASSERT_GE(page_count, 1u);
 
-    ASSERT_EQ(PageTree_GetPage(dst_pages, page_count, dst_page.out()), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(PageObject_GetBaseObject(dst_page, dst_page_dict.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(PageTree_GetPage(dst_pages, page_count, &dst_page), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(PageObject_GetBaseObject(dst_page, &dst_page_dict), VANILLAPDF_ERROR_SUCCESS);
 
     // Read back the test string and verify content matches
-    HandleGuard<NameObjectHandle, NameObject_Release> read_key;
-    HandleGuard<ObjectHandle, Object_Release> read_obj;
-    ASSERT_EQ(NameObject_CreateFromEncodedString("TestData", read_key.out()), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(DictionaryObject_Find(dst_page_dict, read_key, read_obj.out()), VANILLAPDF_ERROR_SUCCESS);
+    NameObjectHandle* read_key = nullptr;
+    ObjectHandle* read_obj = nullptr;
+    ASSERT_EQ(NameObject_CreateFromEncodedString("TestData", &read_key), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(DictionaryObject_Find(dst_page_dict, read_key, &read_obj), VANILLAPDF_ERROR_SUCCESS);
 
     ObjectType read_type = ObjectType_Undefined;
     ASSERT_EQ(Object_GetObjectType(read_obj, &read_type), VANILLAPDF_ERROR_SUCCESS);
     ASSERT_EQ(read_type, ObjectType_String);
 
-    HandleGuard<StringObjectHandle, StringObject_Release> read_str;
-    ASSERT_EQ(StringObject_FromObject(read_obj, read_str.out()), VANILLAPDF_ERROR_SUCCESS);
+    StringObjectHandle* read_str = nullptr;
+    ASSERT_EQ(StringObject_FromObject(read_obj, &read_str), VANILLAPDF_ERROR_SUCCESS);
 
-    HandleGuard<BufferHandle, Buffer_Release> read_buf;
-    ASSERT_EQ(StringObject_GetValue(read_str, read_buf.out()), VANILLAPDF_ERROR_SUCCESS);
+    BufferHandle* read_buf = nullptr;
+    ASSERT_EQ(StringObject_GetValue(read_str, &read_buf), VANILLAPDF_ERROR_SUCCESS);
 
     string_type read_data = nullptr;
     size_type read_len = 0;
@@ -266,6 +266,35 @@ TEST_P(AESEncryptionRoundtrip, VerifyStringContent) {
     for (size_type i = 0; i < read_len; ++i) {
         EXPECT_EQ(read_data[i], param.test_data[i]);
     }
+
+    // Cleanup
+    ASSERT_EQ(Buffer_Release(read_buf), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(StringObject_Release(read_str), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(NameObject_Release(read_key), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Object_Release(read_obj), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(DictionaryObject_Release(dst_page_dict), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(PageObject_Release(dst_page), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(PageTree_Release(dst_pages), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Catalog_Release(dst_catalog), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Document_Release(dst_doc), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(File_Release(dst_load_file), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(File_Release(dst_save_file), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(InputOutputStream_Release(dst_io), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Object_Release(str_as_obj), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(StringObject_Release(str_base), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(LiteralStringObject_Release(str_obj), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Buffer_Release(data_buf), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(NameObject_Release(key_name), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(DictionaryObject_Release(src_page_dict), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(PageObject_Release(src_page), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(PageTree_Release(src_pages), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Catalog_Release(src_catalog), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Buffer_Release(owner_pw), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Buffer_Release(user_pw), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(DocumentEncryptionSettings_Release(enc_settings), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Document_Release(src_doc), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(File_Release(src_file), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(InputOutputStream_Release(src_io), VANILLAPDF_ERROR_SUCCESS);
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/src/vanillapdf.unittest/document_test.cpp
+++ b/src/vanillapdf.unittest/document_test.cpp
@@ -137,6 +137,155 @@ TEST(Document, Encrypt_AES_128) {
 //	EncryptDocument("owner", "user", EncryptionAlgorithmType_AES, 256, UserAccessPermissionFlag_None);
 //}
 
+// Parameterized test for AES encryption roundtrip with various string sizes.
+// Verifies that encrypt→save→reopen→decrypt preserves the original data.
+// Uses sizes that are not multiples of the AES block size (16) to exercise
+// PKCS#7 padding correctness.
+struct AESRoundtripParam {
+    std::string name;
+    std::string test_data;
+};
+
+class AESEncryptionRoundtrip : public ::testing::TestWithParam<AESRoundtripParam> {
+};
+
+TEST_P(AESEncryptionRoundtrip, VerifyStringContent) {
+    auto param = GetParam();
+
+    // Create source document in memory
+    HandleGuard<InputOutputStreamHandle, InputOutputStream_Release> src_io;
+    HandleGuard<FileHandle, File_Release> src_file;
+    HandleGuard<DocumentHandle, Document_Release> src_doc;
+    HandleGuard<DocumentEncryptionSettingsHandle, DocumentEncryptionSettings_Release> enc_settings;
+
+    ASSERT_EQ(InputOutputStream_CreateFromMemory(src_io.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(File_CreateStream(src_io, "src", src_file.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Document_CreateFile(src_file, src_doc.out()), VANILLAPDF_ERROR_SUCCESS);
+
+    // Configure AES-128 encryption
+    HandleGuard<BufferHandle, Buffer_Release> owner_pw;
+    HandleGuard<BufferHandle, Buffer_Release> user_pw;
+    std::string owner_password = "owner";
+    std::string user_password = "user";
+
+    ASSERT_EQ(DocumentEncryptionSettings_Create(enc_settings.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(DocumentEncryptionSettings_SetAlgorithm(enc_settings, EncryptionAlgorithmType_AES), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(DocumentEncryptionSettings_SetKeyLength(enc_settings, 128), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(DocumentEncryptionSettings_SetUserAccessPermissions(enc_settings, UserAccessPermissionFlag_None), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Buffer_CreateFromData(owner_password.data(), owner_password.length(), owner_pw.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Buffer_CreateFromData(user_password.data(), user_password.length(), user_pw.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(DocumentEncryptionSettings_SetOwnerPassword(enc_settings, owner_pw), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(DocumentEncryptionSettings_SetUserPassword(enc_settings, user_pw), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Document_AddEncryption(src_doc, enc_settings), VANILLAPDF_ERROR_SUCCESS);
+
+    // Insert a test string into the page dictionary under a custom key.
+    // Page dictionaries survive save/reopen and their string values are
+    // encrypted, so this exercises the full AES encrypt→decrypt roundtrip.
+    HandleGuard<CatalogHandle, Catalog_Release> src_catalog;
+    HandleGuard<PageTreeHandle, PageTree_Release> src_pages;
+    HandleGuard<PageObjectHandle, PageObject_Release> src_page;
+    HandleGuard<DictionaryObjectHandle, DictionaryObject_Release> src_page_dict;
+
+    ASSERT_EQ(Document_GetCatalog(src_doc, src_catalog.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Catalog_GetPages(src_catalog, src_pages.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(PageObject_CreateFromDocument(src_doc, src_page.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(PageTree_AppendPage(src_pages, src_page), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(PageObject_GetBaseObject(src_page, src_page_dict.out()), VANILLAPDF_ERROR_SUCCESS);
+
+    HandleGuard<NameObjectHandle, NameObject_Release> key_name;
+    HandleGuard<BufferHandle, Buffer_Release> data_buf;
+    HandleGuard<LiteralStringObjectHandle, LiteralStringObject_Release> str_obj;
+    HandleGuard<StringObjectHandle, StringObject_Release> str_base;
+    HandleGuard<ObjectHandle, Object_Release> str_as_obj;
+
+    ASSERT_EQ(NameObject_CreateFromEncodedString("TestData", key_name.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Buffer_CreateFromData(param.test_data.data(), param.test_data.size(), data_buf.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(LiteralStringObject_CreateFromEncodedBuffer(data_buf, str_obj.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(LiteralStringObject_ToStringObject(str_obj, str_base.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(StringObject_ToObject(str_base, str_as_obj.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(DictionaryObject_Insert(src_page_dict, key_name, str_as_obj, VANILLAPDF_RV_TRUE), VANILLAPDF_ERROR_SUCCESS);
+
+    // Save encrypted document to memory
+    HandleGuard<InputOutputStreamHandle, InputOutputStream_Release> dst_io;
+    HandleGuard<FileHandle, File_Release> dst_save_file;
+
+    ASSERT_EQ(InputOutputStream_CreateFromMemory(dst_io.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(File_CreateStream(dst_io, "dst", dst_save_file.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Document_SaveFile(src_doc, dst_save_file), VANILLAPDF_ERROR_SUCCESS);
+
+    // Reopen the encrypted document and navigate to the page
+    HandleGuard<FileHandle, File_Release> dst_load_file;
+    HandleGuard<DocumentHandle, Document_Release> dst_doc;
+
+    ASSERT_EQ(File_OpenStream(dst_io, "dst", dst_load_file.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(File_Initialize(dst_load_file), VANILLAPDF_ERROR_SUCCESS);
+
+    boolean_type is_encrypted = VANILLAPDF_RV_FALSE;
+    ASSERT_EQ(File_IsEncrypted(dst_load_file, &is_encrypted), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(is_encrypted, VANILLAPDF_RV_TRUE);
+    ASSERT_EQ(File_SetEncryptionPassword(dst_load_file, user_password.data()), VANILLAPDF_ERROR_SUCCESS);
+
+    ASSERT_EQ(Document_OpenFile(dst_load_file, dst_doc.out()), VANILLAPDF_ERROR_SUCCESS);
+
+    HandleGuard<CatalogHandle, Catalog_Release> dst_catalog;
+    HandleGuard<PageTreeHandle, PageTree_Release> dst_pages;
+    HandleGuard<PageObjectHandle, PageObject_Release> dst_page;
+    HandleGuard<DictionaryObjectHandle, DictionaryObject_Release> dst_page_dict;
+
+    ASSERT_EQ(Document_GetCatalog(dst_doc, dst_catalog.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Catalog_GetPages(dst_catalog, dst_pages.out()), VANILLAPDF_ERROR_SUCCESS);
+
+    size_type page_count = 0;
+    ASSERT_EQ(PageTree_GetPageCount(dst_pages, &page_count), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_GE(page_count, 1u);
+
+    ASSERT_EQ(PageTree_GetPage(dst_pages, page_count, dst_page.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(PageObject_GetBaseObject(dst_page, dst_page_dict.out()), VANILLAPDF_ERROR_SUCCESS);
+
+    // Read back the test string and verify content matches
+    HandleGuard<NameObjectHandle, NameObject_Release> read_key;
+    HandleGuard<ObjectHandle, Object_Release> read_obj;
+    ASSERT_EQ(NameObject_CreateFromEncodedString("TestData", read_key.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(DictionaryObject_Find(dst_page_dict, read_key, read_obj.out()), VANILLAPDF_ERROR_SUCCESS);
+
+    ObjectType read_type = ObjectType_Undefined;
+    ASSERT_EQ(Object_GetObjectType(read_obj, &read_type), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(read_type, ObjectType_String);
+
+    HandleGuard<StringObjectHandle, StringObject_Release> read_str;
+    ASSERT_EQ(StringObject_FromObject(read_obj, read_str.out()), VANILLAPDF_ERROR_SUCCESS);
+
+    HandleGuard<BufferHandle, Buffer_Release> read_buf;
+    ASSERT_EQ(StringObject_GetValue(read_str, read_buf.out()), VANILLAPDF_ERROR_SUCCESS);
+
+    string_type read_data = nullptr;
+    size_type read_len = 0;
+    ASSERT_EQ(Buffer_GetData(read_buf, &read_data, &read_len), VANILLAPDF_ERROR_SUCCESS);
+
+    ASSERT_EQ(read_len, param.test_data.size());
+    for (size_type i = 0; i < read_len; ++i) {
+        EXPECT_EQ(read_data[i], param.test_data[i]);
+    }
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    EncryptionPadding,
+    AESEncryptionRoundtrip,
+    ::testing::Values(
+        AESRoundtripParam{"1byte",  "X"},
+        AESRoundtripParam{"5bytes", "Hello"},
+        AESRoundtripParam{"15bytes", "FifteenBytesXX!"},
+        AESRoundtripParam{"16bytes", "SixteenBytes!!!!"},
+        AESRoundtripParam{"17bytes", "SeventeenBytesXX!"},
+        AESRoundtripParam{"31bytes", "ThirtyOneBytesOfTestDataHere!!!"},
+        AESRoundtripParam{"32bytes", "ThirtyTwoBytesOfTestDataGoHere!!"},
+        AESRoundtripParam{"33bytes", "ThirtyThreeBytesOfTestDataGoHere!"}
+    ),
+    [](const ::testing::TestParamInfo<AESRoundtripParam>& info) {
+        return info.param.name;
+    }
+);
+
 TEST(Document, Sign) {
 
     FileHandle* source_memory_file = nullptr;

--- a/src/vanillapdf/syntax/utils/encryption.cpp
+++ b/src/vanillapdf/syntax/utils/encryption.cpp
@@ -323,34 +323,29 @@ BufferPtr EncryptionUtils::AESDecrypt(const Buffer& key, types::size_type key_le
         LOG_ERROR_AND_THROW_GENERAL("Could not initialize AES digest: {}", openssl_error);
     }
 
-    // Disable OpenSSL padding — PKCS#7 is handled manually via RemovePkcs7Padding.
-    // Some malformed PDFs have invalid padding (e.g. signature fields padded with
-    // zeroes), so manual removal with graceful fallback is preferred.
-    auto padding_result = EVP_CIPHER_CTX_set_padding(evp_cipher_ctx, 0);
-    if (padding_result != 1) {
-        auto openssl_error = CryptoUtils::GetLastOpensslError();
-        LOG_ERROR_AND_THROW_GENERAL("Could not disable AES decryption padding: {}", openssl_error);
-    }
-    
+    // OpenSSL PKCS#7 padding is enabled by default — let it handle
+    // padding validation and removal during EVP_DecryptFinal.
+
+
     int current_offset = 0;
     int total_result_length = 0;
 
     int data_size = ValueConvertUtils::SafeConvert<int>(data.size() - AES_CBC_IV_LENGTH);
-    
+
     auto update_result = EVP_DecryptUpdate(
         evp_cipher_ctx,
         reinterpret_cast<unsigned char*>(result->data()),
         &current_offset,
         reinterpret_cast<const unsigned char*>(data.data() + AES_CBC_IV_LENGTH),
         data_size);
-    
+
     if (update_result != 1) {
         auto openssl_error = CryptoUtils::GetLastOpensslError();
         LOG_ERROR_AND_THROW_GENERAL("Could not decrypt update AES cipher: {}", openssl_error);
     }
 
     total_result_length += current_offset;
-    
+
     auto final_result = EVP_DecryptFinal(
         evp_cipher_ctx,
         reinterpret_cast<unsigned char*>(result->data() + current_offset),
@@ -366,7 +361,7 @@ BufferPtr EncryptionUtils::AESDecrypt(const Buffer& key, types::size_type key_le
     // Remove trailing zeroes
     result->resize(total_result_length);
 
-    return RemovePkcs7Padding(result, AES_CBC_BLOCK_SIZE);
+    return result;
 
 #else
     (void) key; (void) key_length; (void) data;
@@ -395,8 +390,8 @@ BufferPtr EncryptionUtils::AESEncrypt(const Buffer& key, types::size_type key_le
         LOG_ERROR_AND_THROW_GENERAL("Could not generate initialization vector for AES: {}", openssl_error);
     }
 
-    BufferPtr data_padded = AddPkcs7Padding(data, AES_CBC_BLOCK_SIZE);
-    BufferPtr result = make_deferred_container<Buffer>(AES_CBC_IV_LENGTH + data_padded->size());
+    // Allocate IV + data + up to one block of PKCS#7 padding
+    BufferPtr result = make_deferred_container<Buffer>(AES_CBC_IV_LENGTH + data.size() + AES_CBC_BLOCK_SIZE);
 
     const EVP_CIPHER* evp_cipher = nullptr;
 
@@ -430,12 +425,8 @@ BufferPtr EncryptionUtils::AESEncrypt(const Buffer& key, types::size_type key_le
         LOG_ERROR_AND_THROW_GENERAL("Could not initialize AES cipher: {}", openssl_error);
     }
 
-    // Disable OpenSSL padding — PKCS#7 is handled manually via AddPkcs7Padding
-    auto padding_result = EVP_CIPHER_CTX_set_padding(evp_cipher_ctx, 0);
-    if (padding_result != 1) {
-        auto openssl_error = CryptoUtils::GetLastOpensslError();
-        LOG_ERROR_AND_THROW(CryptoErrorException, "Could not disable AES encryption padding: {}", openssl_error);
-    }
+    // OpenSSL PKCS#7 padding is enabled by default — let it handle
+    // padding during EVP_EncryptFinal.
 
     // Write IV at the beginning of the result buffer
     std::memcpy(result->data(), iv.data(), AES_CBC_IV_LENGTH);
@@ -443,13 +434,13 @@ BufferPtr EncryptionUtils::AESEncrypt(const Buffer& key, types::size_type key_le
     int current_offset = 0;
     int total_result_length = AES_CBC_IV_LENGTH;
 
-    int data_size = ValueConvertUtils::SafeConvert<int>(data_padded->size());
+    int data_size = ValueConvertUtils::SafeConvert<int>(data.size());
 
     auto update_result = EVP_EncryptUpdate(
         evp_cipher_ctx,
         reinterpret_cast<unsigned char*>(result->data() + AES_CBC_IV_LENGTH),
         &current_offset,
-        reinterpret_cast<const unsigned char*>(data_padded->data()),
+        reinterpret_cast<const unsigned char*>(data.data()),
         data_size);
 
     if (update_result != 1) {

--- a/src/vanillapdf/syntax/utils/encryption.cpp
+++ b/src/vanillapdf/syntax/utils/encryption.cpp
@@ -323,12 +323,13 @@ BufferPtr EncryptionUtils::AESDecrypt(const Buffer& key, types::size_type key_le
         LOG_ERROR_AND_THROW_GENERAL("Could not initialize AES digest: {}", openssl_error);
     }
 
-    // OpenSSL uses padding by default and sometimes it is not correct
-    // We do handle the padding after the decryption has been done
+    // Disable OpenSSL padding — PKCS#7 is handled manually via RemovePkcs7Padding.
+    // Some malformed PDFs have invalid padding (e.g. signature fields padded with
+    // zeroes), so manual removal with graceful fallback is preferred.
     auto padding_result = EVP_CIPHER_CTX_set_padding(evp_cipher_ctx, 0);
     if (padding_result != 1) {
         auto openssl_error = CryptoUtils::GetLastOpensslError();
-        LOG_ERROR_AND_THROW_GENERAL("Could not set AES decryption padding: {}", openssl_error);
+        LOG_ERROR_AND_THROW_GENERAL("Could not disable AES decryption padding: {}", openssl_error);
     }
     
     int current_offset = 0;
@@ -395,7 +396,7 @@ BufferPtr EncryptionUtils::AESEncrypt(const Buffer& key, types::size_type key_le
     }
 
     BufferPtr data_padded = AddPkcs7Padding(data, AES_CBC_BLOCK_SIZE);
-    BufferPtr result = make_deferred_container<Buffer>(data_padded->size() + AES_CBC_IV_LENGTH);
+    BufferPtr result = make_deferred_container<Buffer>(AES_CBC_IV_LENGTH + data_padded->size());
 
     const EVP_CIPHER* evp_cipher = nullptr;
 
@@ -429,14 +430,24 @@ BufferPtr EncryptionUtils::AESEncrypt(const Buffer& key, types::size_type key_le
         LOG_ERROR_AND_THROW_GENERAL("Could not initialize AES cipher: {}", openssl_error);
     }
 
+    // Disable OpenSSL padding — PKCS#7 is handled manually via AddPkcs7Padding
+    auto padding_result = EVP_CIPHER_CTX_set_padding(evp_cipher_ctx, 0);
+    if (padding_result != 1) {
+        auto openssl_error = CryptoUtils::GetLastOpensslError();
+        LOG_ERROR_AND_THROW(CryptoErrorException, "Could not disable AES encryption padding: {}", openssl_error);
+    }
+
+    // Write IV at the beginning of the result buffer
+    std::memcpy(result->data(), iv.data(), AES_CBC_IV_LENGTH);
+
     int current_offset = 0;
-    int total_result_length = 0;
+    int total_result_length = AES_CBC_IV_LENGTH;
 
     int data_size = ValueConvertUtils::SafeConvert<int>(data_padded->size());
 
     auto update_result = EVP_EncryptUpdate(
         evp_cipher_ctx,
-        reinterpret_cast<unsigned char*>(result->data()),
+        reinterpret_cast<unsigned char*>(result->data() + AES_CBC_IV_LENGTH),
         &current_offset,
         reinterpret_cast<const unsigned char*>(data_padded->data()),
         data_size);
@@ -450,7 +461,7 @@ BufferPtr EncryptionUtils::AESEncrypt(const Buffer& key, types::size_type key_le
 
     auto final_result = EVP_EncryptFinal(
         evp_cipher_ctx,
-        reinterpret_cast<unsigned char*>(result->data() + current_offset),
+        reinterpret_cast<unsigned char*>(result->data() + total_result_length),
         &current_offset);
 
     if (final_result != 1) {
@@ -463,9 +474,6 @@ BufferPtr EncryptionUtils::AESEncrypt(const Buffer& key, types::size_type key_le
     // Remove trailing zeroes
     result->resize(total_result_length);
 
-    // Insert the IV data in in the beginning
-    result->insert(result->begin(), iv.begin(), iv.end());
-
     return result;
 
 #else
@@ -476,10 +484,7 @@ BufferPtr EncryptionUtils::AESEncrypt(const Buffer& key, types::size_type key_le
 }
 
 BufferPtr EncryptionUtils::AddPkcs7Padding(const Buffer& data, types::size_type block_size) {
-    types::size_type remaining = data.size() % block_size;
-    if (0 == remaining) {
-        remaining = block_size;
-    }
+    types::size_type remaining = block_size - (data.size() % block_size);
 
     Buffer::value_type converted = ValueConvertUtils::SafeConvert<Buffer::value_type>(remaining);
 

--- a/src/vanillapdf/syntax/utils/encryption.cpp
+++ b/src/vanillapdf/syntax/utils/encryption.cpp
@@ -358,7 +358,7 @@ BufferPtr EncryptionUtils::AESDecrypt(const Buffer& key, types::size_type key_le
 
     total_result_length += current_offset;
 
-    // Remove trailing zeroes
+    // Trim buffer to actual plaintext length (padding bytes removed by EVP_DecryptFinal)
     result->resize(total_result_length);
 
     return result;
@@ -462,7 +462,7 @@ BufferPtr EncryptionUtils::AESEncrypt(const Buffer& key, types::size_type key_le
 
     total_result_length += current_offset;
 
-    // Remove trailing zeroes
+    // Trim buffer to actual ciphertext length (IV + encrypted blocks with padding)
     result->resize(total_result_length);
 
     return result;
@@ -472,58 +472,6 @@ BufferPtr EncryptionUtils::AESEncrypt(const Buffer& key, types::size_type key_le
     throw NotSupportedException("This library was compiled without OpenSSL support");
 #endif
 
-}
-
-BufferPtr EncryptionUtils::AddPkcs7Padding(const Buffer& data, types::size_type block_size) {
-    types::size_type remaining = block_size - (data.size() % block_size);
-
-    Buffer::value_type converted = ValueConvertUtils::SafeConvert<Buffer::value_type>(remaining);
-
-    BufferPtr result;
-    result->reserve(data.size() + remaining);
-    result->insert(result.begin(), data.begin(), data.end());
-    result->insert(result.end(), remaining, converted);
-
-    return result;
-}
-
-BufferPtr EncryptionUtils::RemovePkcs7Padding(const Buffer& data, types::size_type block_size) {
-    do {
-        // Empty data are invalid
-        if (data.empty()) {
-            break;
-        }
-
-        char bytes = data.back();
-        unsigned char converted = reinterpret_cast<unsigned char&>(bytes);
-        if (data.size() < converted || converted > block_size) {
-            break;
-        }
-
-        // verify PKCS#7 padding
-        // The value of each added byte is the number of bytes that are added, i.e. N bytes, each of value N are added
-        bool padding_error = false;
-        for (auto it = data.end() - converted; it != data.end(); it++) {
-            if (*it != bytes) {
-                padding_error = true;
-                break;
-            }
-        }
-
-        if (padding_error) {
-            break;
-        }
-
-        return make_deferred_container<Buffer>(data.begin(), data.end() - converted);
-    } while (false);
-
-    // I would really like to be strict about padding,
-    // but in test document "example_128-aes.pdf" there is a signature field
-    // that allocated space with zeroes and did not care about setting proper
-    // pkcs padding. That means, that there is some trash after we decrypt the
-    // signature contents and padding could not be validated
-    spdlog::warn("Pkcs padding is incorrect");
-    return make_deferred_container<Buffer>(data);
 }
 
 BufferPtr EncryptionUtils::GenerateOwnerEncryptionKey(

--- a/src/vanillapdf/syntax/utils/encryption.h
+++ b/src/vanillapdf/syntax/utils/encryption.h
@@ -38,9 +38,6 @@ public:
     static BufferPtr AESEncrypt(const Buffer& key, const Buffer& data);
     static BufferPtr AESEncrypt(const Buffer& key, types::size_type key_length, const Buffer& data);
 
-    static BufferPtr AddPkcs7Padding(const Buffer& data, types::size_type block_size);
-    static BufferPtr RemovePkcs7Padding(const Buffer& data, types::size_type block_size);
-
     static BufferPtr DecryptEnvelopedData(const syntax::ArrayObject<syntax::StringObjectPtr>& recipients, IEncryptionKey& key);
     static BufferPtr ComputeAuthenticationOwnerData(const Buffer& pad_password, const syntax::DictionaryObject& encryption_dictionary);
     static BufferPtr GetRecipientKey(


### PR DESCRIPTION
Backport of #361 to `release/2.2` for the upcoming v2.2.2 release.

## Changes

- Correct AES-CBC PKCS#7 padding in encryption roundtrip
- Use OpenSSL's built-in PKCS#7 padding instead of manual implementation
- Remove unused `AddPkcs7Padding` / `RemovePkcs7Padding` helpers

## Conflicts resolved

- `encryption.cpp`: `CryptoErrorException` does not exist on `release/2.2` (introduced in #283 which was not backported) — resolved by using `LOG_ERROR_AND_THROW_GENERAL` consistently
- `scripts/conformance_check.py`: skipped (file does not exist on `release/2.2`)
- `.claude/rules/troubleshooting.md`: skipped (file does not exist on `release/2.2`)

## Original PR

#361