### PR TITLE
ci: Add Ubuntu 26.04 support to CI workflows

### DIFF
--- a/.github/workflows/conformance-check.yml
+++ b/.github/workflows/conformance-check.yml
@@ -31,10 +31,10 @@ env:
 jobs:
 
   linux:
-    name: ubuntu.24.04-x64
+    name: ubuntu.26.04-x64
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/vanillapdf/vanillapdf-ubuntu-amd64:24.04
+      image: ghcr.io/vanillapdf/vanillapdf-ubuntu:26.04
       options: --platform=linux/amd64
 
     steps:
@@ -49,9 +49,9 @@ jobs:
           path: |
             external/vcpkg/downloads
             external/vcpkg/bincache
-          key: vcpkg-${{ runner.os }}-ubuntu.24.04-x64-${{ hashFiles('vcpkg.json.in') }}
+          key: vcpkg-${{ runner.os }}-ubuntu.26.04-x64-${{ hashFiles('vcpkg.json.in') }}
           restore-keys: |
-            vcpkg-${{ runner.os }}-ubuntu.24.04-x64-
+            vcpkg-${{ runner.os }}-ubuntu.26.04-x64-
 
       - name: Install qpdf
         run: apt-get update && apt-get install -y qpdf

--- a/.github/workflows/nightly-check.yml
+++ b/.github/workflows/nightly-check.yml
@@ -80,6 +80,18 @@ jobs:
             platform: linux/arm64
             preset: linux-arm64-gcc
 
+          - name: ubuntu.26.04-x64
+            os: ubuntu-24.04
+            image: ghcr.io/vanillapdf/vanillapdf-ubuntu:26.04
+            platform: linux/amd64
+            preset: linux-x64-gcc
+
+          - name: ubuntu.26.04-arm64
+            os: ubuntu-24.04-arm
+            image: ghcr.io/vanillapdf/vanillapdf-ubuntu:26.04
+            platform: linux/arm64
+            preset: linux-arm64-gcc
+
           - name: rocky.8-x64
             os: ubuntu-24.04
             image: ghcr.io/vanillapdf/vanillapdf-rockylinux-amd64:8

--- a/.github/workflows/sanity-check.yml
+++ b/.github/workflows/sanity-check.yml
@@ -75,18 +75,6 @@ jobs:
             platform: linux/arm64
             preset: linux-arm64-gcc
 
-          - name: ubuntu.24.04-x64
-            os: ubuntu-24.04
-            image: ghcr.io/vanillapdf/vanillapdf-ubuntu-amd64:24.04
-            platform: linux/amd64
-            preset: linux-x64-gcc
-
-          - name: ubuntu.24.04-arm64
-            os: ubuntu-24.04-arm
-            image: ghcr.io/vanillapdf/vanillapdf-ubuntu-arm64v8:24.04
-            platform: linux/arm64
-            preset: linux-arm64-gcc
-
           - name: ubuntu.26.04-x64
             os: ubuntu-24.04
             image: ghcr.io/vanillapdf/vanillapdf-ubuntu:26.04

--- a/.github/workflows/sanity-check.yml
+++ b/.github/workflows/sanity-check.yml
@@ -87,6 +87,18 @@ jobs:
             platform: linux/arm64
             preset: linux-arm64-gcc
 
+          - name: ubuntu.26.04-x64
+            os: ubuntu-24.04
+            image: ghcr.io/vanillapdf/vanillapdf-ubuntu:26.04
+            platform: linux/amd64
+            preset: linux-x64-gcc
+
+          - name: ubuntu.26.04-arm64
+            os: ubuntu-24.04-arm
+            image: ghcr.io/vanillapdf/vanillapdf-ubuntu:26.04
+            platform: linux/arm64
+            preset: linux-arm64-gcc
+
     container:
       image: ${{ matrix.config.image }}
       options: --platform=${{ matrix.config.platform }}

--- a/.github/workflows/signature-interop-check.yml
+++ b/.github/workflows/signature-interop-check.yml
@@ -31,10 +31,10 @@ env:
 jobs:
 
   interop:
-    name: ubuntu.24.04-x64
+    name: ubuntu.26.04-x64
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/vanillapdf/vanillapdf-ubuntu-amd64:24.04
+      image: ghcr.io/vanillapdf/vanillapdf-ubuntu:26.04
       options: --platform=linux/amd64
 
     steps:
@@ -48,9 +48,9 @@ jobs:
           path: |
             external/vcpkg/downloads
             external/vcpkg/bincache
-          key: vcpkg-${{ runner.os }}-ubuntu.24.04-x64-${{ hashFiles('vcpkg.json.in') }}
+          key: vcpkg-${{ runner.os }}-ubuntu.26.04-x64-${{ hashFiles('vcpkg.json.in') }}
           restore-keys: |
-            vcpkg-${{ runner.os }}-ubuntu.24.04-x64-
+            vcpkg-${{ runner.os }}-ubuntu.26.04-x64-
 
       - name: Install pdfsig
         run: apt-get update && apt-get install -y poppler-utils libnss3-tools

--- a/.github/workflows/signature-interop-check.yml
+++ b/.github/workflows/signature-interop-check.yml
@@ -53,7 +53,7 @@ jobs:
             vcpkg-${{ runner.os }}-ubuntu.26.04-x64-
 
       - name: Install pdfsig
-        run: apt-get update && apt-get install -y poppler-utils libnss3-tools tzdata
+        run: apt-get update && apt-get install -y poppler-utils libnss3-tools
 
       - name: Bootstrap vcpkg
         run: ./external/vcpkg/bootstrap-vcpkg.sh

--- a/.github/workflows/signature-interop-check.yml
+++ b/.github/workflows/signature-interop-check.yml
@@ -53,7 +53,7 @@ jobs:
             vcpkg-${{ runner.os }}-ubuntu.26.04-x64-
 
       - name: Install pdfsig
-        run: apt-get update && apt-get install -y poppler-utils libnss3-tools
+        run: apt-get update && apt-get install -y poppler-utils libnss3-tools tzdata
 
       - name: Bootstrap vcpkg
         run: ./external/vcpkg/bootstrap-vcpkg.sh


### PR DESCRIPTION
## Summary

- Adds `ubuntu.26.04-x64` and `ubuntu.26.04-arm64` to the nightly full scan and sanity check matrix (alongside existing 22.04 and 24.04)
- Upgrades `conformance-check` and `signature-interop-check` container slots from `vanillapdf-ubuntu-amd64:24.04` to `vanillapdf-ubuntu:26.04` (multi-arch image)

## Notes

- Bare-runner workflows (sanitizers, coverage, fuzzing) are left on `ubuntu-24.04` for now — can follow up once `ubuntu-26.04` runner availability is confirmed
- Artifact/package builds remain on the oldest supported system for maximum binary compatibility

## Test plan

- [x] Nightly scan picks up the two new 26.04 matrix entries
- [x] Conformance check runs successfully inside the 26.04 container
- [x] Signature interop check runs successfully inside the 26.04 container

🤖 Generated with [Claude Code](https://claude.com/claude-code)