### PR TITLE
ci: Switch windows-2025 and windows-11-arm to VS 2026 (msvc-18)

### DIFF
--- a/.github/workflows/build-nuget.yml
+++ b/.github/workflows/build-nuget.yml
@@ -160,17 +160,17 @@ jobs:
         config:
           - name: win.2025-x86-static
             os: windows-2025
-            preset: windows-x86-msvc-17-static
+            preset: windows-x86-msvc-18-static
             build_type: Release
 
           - name: win.2025-x64-static
             os: windows-2025
-            preset: windows-x64-msvc-17-static
+            preset: windows-x64-msvc-18-static
             build_type: Release
 
           - name: win.11-arm64-static
             os: windows-11-arm
-            preset: windows-arm64-msvc-17-static
+            preset: windows-arm64-msvc-18-static
             build_type: Release
 
     steps:

--- a/.github/workflows/nightly-check.yml
+++ b/.github/workflows/nightly-check.yml
@@ -195,23 +195,23 @@ jobs:
           # Static dependencies + Static CRT (for NuGet builds)
           - { name: "win.2022-x86-static", os: windows-2022, preset: "windows-x86-msvc-17-static" }
           - { name: "win.2022-x64-static", os: windows-2022, preset: "windows-x64-msvc-17-static" }
-          - { name: "win.2025-x86-static", os: windows-2025, preset: "windows-x86-msvc-17-static" }
-          - { name: "win.2025-x64-static", os: windows-2025, preset: "windows-x64-msvc-17-static" }
-          - { name: "win.11-arm64-static", os: windows-11-arm, preset: "windows-arm64-msvc-17-static" }
+          - { name: "win.2025-x86-static", os: windows-2025, preset: "windows-x86-msvc-18-static" }
+          - { name: "win.2025-x64-static", os: windows-2025, preset: "windows-x64-msvc-18-static" }
+          - { name: "win.11-arm64-static", os: windows-11-arm, preset: "windows-arm64-msvc-18-static" }
 
           # Static dependencies + Dynamic CRT (for Python wrappers)
           - { name: "win.2022-x86-static-md", os: windows-2022, preset: "windows-x86-msvc-17-static-md" }
           - { name: "win.2022-x64-static-md", os: windows-2022, preset: "windows-x64-msvc-17-static-md" }
-          - { name: "win.2025-x86-static-md", os: windows-2025, preset: "windows-x86-msvc-17-static-md" }
-          - { name: "win.2025-x64-static-md", os: windows-2025, preset: "windows-x64-msvc-17-static-md" }
-          - { name: "win.11-arm64-static-md", os: windows-11-arm, preset: "windows-arm64-msvc-17-static-md" }
+          - { name: "win.2025-x86-static-md", os: windows-2025, preset: "windows-x86-msvc-18-static-md" }
+          - { name: "win.2025-x64-static-md", os: windows-2025, preset: "windows-x64-msvc-18-static-md" }
+          - { name: "win.11-arm64-static-md", os: windows-11-arm, preset: "windows-arm64-msvc-18-static-md" }
 
           # Dynamic dependencies + Dynamic CRT
           - { name: "win.2022-x86", os: windows-2022, preset: "windows-x86-msvc-17" }
           - { name: "win.2022-x64", os: windows-2022, preset: "windows-x64-msvc-17" }
-          - { name: "win.2025-x86", os: windows-2025, preset: "windows-x86-msvc-17" }
-          - { name: "win.2025-x64", os: windows-2025, preset: "windows-x64-msvc-17" }
-          - { name: "win.11-arm64", os: windows-11-arm, preset: "windows-arm64-msvc-17" }
+          - { name: "win.2025-x86", os: windows-2025, preset: "windows-x86-msvc-18" }
+          - { name: "win.2025-x64", os: windows-2025, preset: "windows-x64-msvc-18" }
+          - { name: "win.11-arm64", os: windows-11-arm, preset: "windows-arm64-msvc-18" }
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2

--- a/.github/workflows/sanity-check.yml
+++ b/.github/workflows/sanity-check.yml
@@ -136,10 +136,10 @@ jobs:
 
         config:
           - name: win.2025-x86-static
-            preset: windows-x86-msvc-17-static
+            preset: windows-x86-msvc-18-static
 
           - name: win.2025-x64-static
-            preset: windows-x64-msvc-17-static
+            preset: windows-x64-msvc-18-static
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2


### PR DESCRIPTION
## Summary

VS 2026 on the `windows-2025` runner is no longer beta. Updated all `windows-2025` and `windows-11-arm` entries to use `msvc-18` presets across:

- `nightly-check.yml` — 9 entries (static, static-md, dynamic × x86/x64/arm64)
- `sanity-check.yml` — 2 entries (x86/x64 static)
- `build-nuget.yml` — 3 entries (x86/x64/arm64 static)

`windows-2022` entries remain on `msvc-17` (VS 2022) — those runners do not ship VS 2026.

## Test plan

- [ ] Nightly check passes all `win.2025-*` and `win.11-arm64-*` jobs with msvc-18
- [ ] Sanity check passes `win.2025-x86-static` and `win.2025-x64-static`
- [ ] NuGet build succeeds with msvc-18 on all three configurations

🤖 Generated with [Claude Code](https://claude.com/claude-code)