### PR TITLE
ci: Move tag creation into release pipeline (backport #379)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,6 @@
 name: Release
 
 on:
-  push:
-    tags:
-      - 'v*.*.*'
   pull_request:
     paths:
       - '.github/workflows/release.yml'
@@ -14,11 +11,11 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "Tag name to simulate (e.g. v2.2.0)"
+        description: "Tag name to create (e.g. v2.2.1)"
         required: true
         type: string
       dry_run:
-        description: "Dry run - validate workflow without publishing"
+        description: "Dry run - validate workflow without publishing or tagging"
         required: false
         type: boolean
         default: true
@@ -75,13 +72,11 @@ jobs:
             echo "prerelease=false" >> "$GITHUB_OUTPUT"
           fi
 
-          # pull_request and workflow_dispatch are always dry_run; tag push is never dry_run
+          # pull_request is always dry_run; workflow_dispatch uses the input value
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             echo "dry_run=true" >> "$GITHUB_OUTPUT"
-          elif [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "dry_run=${{ inputs.dry_run }}" >> "$GITHUB_OUTPUT"
           else
-            echo "dry_run=false" >> "$GITHUB_OUTPUT"
+            echo "dry_run=${{ inputs.dry_run }}" >> "$GITHUB_OUTPUT"
           fi
 
           # Find the latest real tag for dry-run validation workflows
@@ -199,10 +194,40 @@ jobs:
     steps:
       - run: echo "Awaiting production approval"
 
+  create-tag:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    needs: [production-gate, prepare]
+    outputs:
+      tag: ${{ needs.prepare.outputs.tag }}
+      latest_tag: ${{ needs.prepare.outputs.latest_tag }}
+      prerelease: ${{ needs.prepare.outputs.prerelease }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.BOT_TOKEN }}
+
+      - name: Configure Git
+        run: |
+          git config --global user.name "vanillapdf-bot"
+          git config --global user.email "info@vanillapdf.com"
+
+      - name: Create and push tag
+        run: |
+          TAG="${{ needs.prepare.outputs.tag }}"
+          if git tag -l "$TAG" | grep -q "^${TAG}$"; then
+            echo "::error::Tag $TAG already exists"
+            exit 1
+          fi
+          git tag "$TAG"
+          git push origin "$TAG"
+
   publish-nuget:
     runs-on: ubuntu-latest
-    needs: [production-gate, prepare]
-    if: needs.prepare.outputs.dry_run == 'false'
+    needs: create-tag
     environment: production
     steps:
       - name: Download NuGet packages
@@ -217,28 +242,27 @@ jobs:
             --skip-duplicate
 
   github-pages:
-    needs: [production-gate, prepare]
+    needs: create-tag
     # Only deploy documentation for official releases that are the latest version
-    if: needs.prepare.outputs.prerelease == 'false' && needs.prepare.outputs.dry_run == 'false' && needs.prepare.outputs.tag == needs.prepare.outputs.latest_tag
+    if: needs.create-tag.outputs.prerelease == 'false' && needs.create-tag.outputs.tag == needs.create-tag.outputs.latest_tag
     uses: ./.github/workflows/github-pages.yml
     with:
       deploy: true
     secrets: inherit
 
   github-release:
-    needs: [production-gate, prepare]
-    if: needs.prepare.outputs.dry_run == 'false'
+    needs: create-tag
     uses: ./.github/workflows/github-release.yml
     with:
-      tag: ${{ needs.prepare.outputs.tag }}
-      prerelease: ${{ fromJSON(needs.prepare.outputs.prerelease) }}
+      tag: ${{ needs.create-tag.outputs.tag }}
+      prerelease: ${{ fromJSON(needs.create-tag.outputs.prerelease) }}
     secrets: inherit
 
   vcpkg-pr:
-    needs: [production-gate, prepare]
+    needs: create-tag
     # Only create vcpkg PR for official releases that are the latest version
-    if: needs.prepare.outputs.prerelease == 'false' && needs.prepare.outputs.dry_run == 'false' && needs.prepare.outputs.tag == needs.prepare.outputs.latest_tag
+    if: needs.create-tag.outputs.prerelease == 'false' && needs.create-tag.outputs.tag == needs.create-tag.outputs.latest_tag
     uses: ./.github/workflows/create-vcpkg-pr.yml
     with:
-      tag: ${{ needs.prepare.outputs.tag }}
+      tag: ${{ needs.create-tag.outputs.tag }}
     secrets: inherit


### PR DESCRIPTION
## Summary

Manual backport of #379 to `release/2.2`. The auto-backport bot couldn't cherry-pick because `.github/workflows/release.yml` has diverged ~340 lines between `main` and `release/2.2`.

## Conceptual change (same as #379)

- Removes the `push.tags` trigger — tags are no longer pushed manually to start a release.
- Adds a `create-tag` job between `production-gate` and the publishing jobs — the tag is created with `BOT_TOKEN` only after the build succeeds and production approval is granted.
- Simplifies `dry_run` logic (no tag-push `else` branch).
- Updates `workflow_dispatch` input descriptions to reflect the new intent.

## New flow

```
workflow_dispatch(tag, dry_run=true by default)
  → prepare → verify → build-nuget → nuget-staging
  → production-gate  (manual approval)
  → create-tag       (pushes the git tag using BOT_TOKEN)
  → publish-nuget, github-pages, github-release, vcpkg-pr
```

## Conflict resolution notes

- `create-tag` sources its `tag` / `latest_tag` / `prerelease` outputs from `prepare` rather than `production-gate`, because `release/2.2`'s `production-gate` has no outputs (unlike `main`, where #321/#337 added pass-through outputs).
- `actions/checkout` is kept on `@v6` to match the rest of `release/2.2`. The SHA-pinning policy from CLAUDE.md was applied on `main` after this branch forked; a pinning sweep is a separate concern.
- Downstream jobs ported: `publish-nuget`, `github-pages`, `github-release`, `vcpkg-pr`. The `homebrew-pr`, `conan-pr`, `attest`, and `update-port` jobs from `main` do not exist on `release/2.2`.

## Test plan

- [x] Open the PR — `pull_request` event runs the workflow in dry-run mode and exercises `prepare → verify → build-nuget → dry-run-*` (no tagging, no publishing).
- [x] After merge, run `workflow_dispatch` with a throwaway pre-release tag (e.g. `v2.2.1-rc.1`) and `dry_run=true` to confirm the dry-run path still skips `create-tag` and `production-gate`.
- [ ] Real 2.2.x release: `workflow_dispatch` with `dry_run=false`, approve the production gate, confirm `create-tag` creates the tag and downstream publishing runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)