### PR TITLE
Fix data race in Document catalog lazy initialization

### DIFF
--- a/src/vanillapdf.unittest/thread_safety_test.cpp
+++ b/src/vanillapdf.unittest/thread_safety_test.cpp
@@ -448,4 +448,90 @@ TEST(DictionaryObjectThreadSafety, ConcurrentReadWrite) {
     EXPECT_EQ(final_size, static_cast<size_type>(NUM_INSERTS + 1));
 }
 
+// Reproduction for the reported native crash in a multi-threaded environment
+// (last frame: LinkAnnotation_GetDestination). Resolving a named destination
+// reaches Document::GetDocumentCatalog, which lazily initializes a cached
+// Catalog (mutable m_catalog) with no synchronization.
+//
+// This test isolates that member: a freshly created document leaves m_catalog
+// cold (CreateCatalog only inserts /Root into the trailer, it does not populate
+// the cache), so the first concurrent Document_GetCatalog calls all hit the
+// lazy-init path simultaneously. A correct implementation caches exactly one
+// instance, so every concurrent call MUST return the same Catalog handle.
+// The double-init race produces distinct Catalog instances (and races on the
+// underlying Deferred<> pointer / refcount, which can also crash).
+//
+// Each document only races on its first access, so we repeat over many fresh
+// documents to get many cold-cache windows, and use a spin barrier so all
+// threads are released into the cold cache at the same moment.
+TEST(CatalogThreadSafety, ConcurrentLazyInitReturnsSameInstance) {
+    constexpr int NUM_DOCUMENTS = 500;
+    constexpr int NUM_THREADS = 16;
+
+    std::atomic<int> mismatch_count{0};
+    std::atomic<int> error_count{0};
+
+    for (int d = 0; d < NUM_DOCUMENTS; ++d) {
+        HandleGuard<InputOutputStreamHandle, InputOutputStream_Release> io_stream;
+        HandleGuard<FileHandle, File_Release> file;
+        HandleGuard<DocumentHandle, Document_Release> doc;
+
+        ASSERT_EQ(InputOutputStream_CreateFromMemory(io_stream.out()), VANILLAPDF_ERROR_SUCCESS);
+        ASSERT_EQ(File_CreateStream(io_stream, "catalog_race", file.out()), VANILLAPDF_ERROR_SUCCESS);
+        ASSERT_EQ(Document_CreateFile(file, doc.out()), VANILLAPDF_ERROR_SUCCESS);
+
+        // Spin barrier so every thread hits the cold cache simultaneously
+        std::atomic<int> ready{0};
+        std::atomic<bool> go{false};
+
+        std::vector<CatalogHandle*> catalogs(NUM_THREADS, nullptr);
+        std::vector<std::thread> threads;
+
+        for (int t = 0; t < NUM_THREADS; ++t) {
+            threads.emplace_back([&, t]() {
+                ready.fetch_add(1);
+                while (!go.load()) { /* spin until released */ }
+
+                CatalogHandle* catalog = nullptr;
+                if (Document_GetCatalog(doc, &catalog) == VANILLAPDF_ERROR_SUCCESS) {
+                    catalogs[t] = catalog;
+                } else {
+                    error_count.fetch_add(1);
+                }
+            });
+        }
+
+        while (ready.load() < NUM_THREADS) { /* wait for all threads to spin up */ }
+        go.store(true);
+
+        for (auto& thread : threads) {
+            thread.join();
+        }
+
+        // Every thread must observe the same cached Catalog instance
+        CatalogHandle* first = nullptr;
+        for (auto* catalog : catalogs) {
+            if (catalog == nullptr) {
+                continue;
+            }
+
+            if (first == nullptr) {
+                first = catalog;
+            } else if (catalog != first) {
+                mismatch_count.fetch_add(1);
+            }
+        }
+
+        for (auto* catalog : catalogs) {
+            if (catalog != nullptr) {
+                Catalog_Release(catalog);
+            }
+        }
+    }
+
+    EXPECT_EQ(error_count.load(), 0);
+    EXPECT_EQ(mismatch_count.load(), 0)
+        << "Document::GetDocumentCatalog returned multiple Catalog instances under concurrency";
+}
+
 } /* thread_safety */

--- a/src/vanillapdf/CMakeLists.txt
+++ b/src/vanillapdf/CMakeLists.txt
@@ -354,6 +354,7 @@ set(VANILLAPDF_UTILS_HEADERS
     utils/buffer.h
     utils/buffer_array.h
     utils/byte_order.h
+    utils/cached_value.h
     utils/character.h
     utils/compiler_utils.h
     utils/constants.h

--- a/src/vanillapdf/semantics/objects/document.cpp
+++ b/src/vanillapdf/semantics/objects/document.cpp
@@ -148,11 +148,10 @@ Document::~Document() {
 }
 
 bool Document::GetDocumentCatalog(OutputCatalogPtr& result) const {
-    if (!m_catalog.empty()) {
-        result = m_catalog;
-        return true;
-    }
+    return m_catalog.GetOrCreate(result, this, &Document::ResolveCatalog);
+}
 
+bool Document::ResolveCatalog(OutputCatalogPtr& result) const {
     auto chain = m_holder->GetXrefChain();
     if (chain->Empty()) {
         return false;
@@ -166,8 +165,7 @@ bool Document::GetDocumentCatalog(OutputCatalogPtr& result) const {
     }
 
     auto root = dictionary->FindAs<syntax::DictionaryObjectPtr>(constant::Name::Root);
-    m_catalog = make_deferred<Catalog>(root);
-    result = m_catalog;
+    result = make_deferred<Catalog>(root);
     return true;
 }
 

--- a/src/vanillapdf/semantics/objects/document.h
+++ b/src/vanillapdf/semantics/objects/document.h
@@ -15,6 +15,8 @@
 #include "syntax/objects/dictionary_object.h"
 #include "syntax/objects/name_object.h"
 
+#include "utils/cached_value.h"
+
 #include <string>
 
 namespace vanillapdf {
@@ -36,6 +38,11 @@ public:
 
     bool GetDocumentCatalog(OutputCatalogPtr& result) const;
     bool GetDocumentInfo(OutputDocumentInfoPtr& result) const;
+
+private:
+    bool ResolveCatalog(OutputCatalogPtr& result) const;
+
+public:
 
     void Save(const std::string& path);
     void Save(syntax::FilePtr destination);
@@ -78,7 +85,7 @@ private:
 private:
     explicit Document(syntax::FilePtr holder);
 
-    mutable OutputCatalogPtr m_catalog;
+    CachedValue<OutputCatalogPtr> m_catalog;
 
     friend class SemanticUtils;
 };

--- a/src/vanillapdf/utils/cached_value.h
+++ b/src/vanillapdf/utils/cached_value.h
@@ -1,0 +1,76 @@
+#ifndef _CACHED_VALUE_H
+#define _CACHED_VALUE_H
+
+#include <atomic>
+#include <mutex>
+#include <functional>
+
+namespace vanillapdf {
+
+// Thread-safe, compute-once lazy cache for a single value.
+//
+// Replaces the hand-rolled lazy-init pattern
+//     if (!m_x.empty()) { result = m_x; return true; }
+//     ... compute ...
+//     m_x = make_deferred<...>(); result = m_x; return true;
+// which is racy under concurrent first access: two threads can both observe the
+// empty cache, both construct, and race on the cached pointer (torn read /
+// double release / use-after-free).
+//
+// Mirrors the established lazy-init idiom in the codebase (see
+// UnicodeCharacterMap::Initialize): a lock-free acquire fast path, a
+// double-checked init under a recursive mutex, and a release store so other
+// threads observe the fully constructed value before they see the flag set.
+//
+// The std::atomic and std::recursive_mutex members make CachedValue
+// non-copyable and non-movable; embed it as a member of a non-copyable owner.
+template <typename T>
+class CachedValue {
+public:
+    // A resolver is a const member function of the owner that produces the
+    // value: bool Owner::Resolve(T& out) const
+    //   returns true  -> value produced; cached and returned via result
+    //   returns false -> entry absent; NOT cached, retried on the next call
+    //
+    // Passing it as a member function pointer (rather than the minimal state)
+    // gives the resolver implicit access to the whole owner — every member and
+    // private helper — which is what most resolvers need. std::invoke performs
+    // the member dispatch so the call reads like an ordinary call. Only the
+    // cold path touches owner and resolver; the already initialized fast path
+    // returns the cached value directly.
+    template <typename Owner>
+    bool GetOrCreate(T& result, const Owner* owner, bool (Owner::*resolver)(T&) const) const {
+        if (m_initialized.load(std::memory_order_acquire)) {
+            result = m_value;
+            return true;
+        }
+
+        std::lock_guard<std::recursive_mutex> lock(m_access_lock);
+
+        // Double-check after acquiring the lock
+        if (m_initialized.load(std::memory_order_relaxed)) {
+            result = m_value;
+            return true;
+        }
+
+        T produced;
+        if (!std::invoke(resolver, owner, produced)) {
+            return false;
+        }
+
+        m_value = produced;
+        m_initialized.store(true, std::memory_order_release);
+
+        result = m_value;
+        return true;
+    }
+
+private:
+    mutable std::atomic<bool> m_initialized = false;
+    mutable std::recursive_mutex m_access_lock;
+    mutable T m_value;
+};
+
+} // vanillapdf
+
+#endif /* _CACHED_VALUE_H */


### PR DESCRIPTION
## Problem

`Document::GetDocumentCatalog` lazily constructed and cached `m_catalog` with no synchronization. Under concurrent first access — e.g. multiple threads resolving link-annotation destinations (`LinkAnnotation_GetDestination`), which was the originally reported native crash in a multi-threaded .NET host — two threads could both observe the empty cache, both construct a `Catalog`, and race on the ref-counted pointer. The result is torn reads, double `Release()`, and use-after-free crashes.

## Fix

Add `CachedValue<T>` (`utils/cached_value.h`), a reusable thread-safe compute-once cache that mirrors the established lazy-init idiom already used by `UnicodeCharacterMap::Initialize`:

- lock-free **acquire** fast path on an `std::atomic<bool>` flag
- double-checked initialization under a `std::recursive_mutex`
- **release** store so other threads observe the fully constructed value before they see the flag set

The value is produced by a const resolver member function the owner passes in (`bool Owner::Resolve(T&) const`, invoked via `std::invoke`), keeping `CachedValue` decoupled from the owning type while the resolver retains full access to owner state. `false` from the resolver means "absent" — not cached, retried on the next call — matching the existing `TryFind`-style contract.

`Document::m_catalog` is routed through `CachedValue`, and the catalog resolution logic moves into `Document::ResolveCatalog`.

## Test

Adds `CatalogThreadSafety.ConcurrentLazyInitReturnsSameInstance` — 16 threads hammer the cold catalog cache across 500 fresh in-memory documents behind a spin barrier, asserting every thread observes the same cached instance and no errors occur. It **segfaults** against the unsynchronized code and **passes** after the fix (verified locally, `windows-x64-msvc-18` Debug).

## Scope / follow-ups

`CachedValue<T>` is intentionally reusable. Three other semantic caches share the identical racy lazy-init pattern and are natural follow-ups (separate PRs): `Catalog::m_pages`, `PageObject::m_contents`, `FontBase::m_character_map`. An end-to-end `LinkAnnotation_GetDestination` concurrency test is also a candidate but needs a small new public API to construct a link annotation + named destination.

🤖 Generated with [Claude Code](https://claude.com/claude-code)