### PR TITLE
ci: Authenticate vcpkg --head GitHub API calls to fix macOS 403s

### DIFF
--- a/.github/workflows/examples-integration.yml
+++ b/.github/workflows/examples-integration.yml
@@ -226,9 +226,13 @@ jobs:
       - name: Update portfile to use current branch
         env:
           BRANCH: ${{ github.head_ref || github.ref_name }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ./scripts/update_portfile_branch.sh "$BRANCH"
 
       - name: Install vanillapdf via vcpkg (classic mode with --head)
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VCPKG_KEEP_ENV_VARS: GITHUB_TOKEN
         run: ./external/vcpkg/vcpkg install vanillapdf --head --overlay-ports=./ports --triplet=x64-linux
 
       - name: Configure CMake
@@ -273,9 +277,13 @@ jobs:
         shell: bash
         env:
           BRANCH: ${{ github.head_ref || github.ref_name }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ./scripts/update_portfile_branch.sh "$BRANCH"
 
       - name: Install vanillapdf via vcpkg (classic mode with --head)
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VCPKG_KEEP_ENV_VARS: GITHUB_TOKEN
         run: .\external\vcpkg\vcpkg.exe install vanillapdf --head --overlay-ports=./ports --triplet=x64-windows
 
       - name: Configure CMake
@@ -314,9 +322,13 @@ jobs:
       - name: Update portfile to use current branch
         env:
           BRANCH: ${{ github.head_ref || github.ref_name }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ./scripts/update_portfile_branch.sh "$BRANCH"
 
       - name: Install vanillapdf via vcpkg (classic mode with --head)
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VCPKG_KEEP_ENV_VARS: GITHUB_TOKEN
         run: ./external/vcpkg/vcpkg install vanillapdf --head --overlay-ports=./ports --triplet=arm64-osx
 
       - name: Configure CMake

--- a/scripts/update_portfile_branch.sh
+++ b/scripts/update_portfile_branch.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 # Update portfile.cmake to use a specific branch for HEAD_REF
 # Usage: ./update_portfile_branch.sh <branch_name>
+#
+# If GITHUB_TOKEN is set, an AUTHORIZATION_TOKEN reference is also added so
+# vcpkg's GitHub API call resolving the branch head (--head mode) is
+# authenticated. Anonymous API requests share a per-IP rate limit, which
+# shared CI runners (especially macOS) frequently exhaust, causing 403s.
 
 set -e
 
@@ -14,11 +19,17 @@ fi
 
 echo "Updating HEAD_REF to: $BRANCH"
 
+REPLACEMENT="HEAD_REF $BRANCH"
+if [ -n "${GITHUB_TOKEN:-}" ]; then
+    echo "Adding AUTHORIZATION_TOKEN (read from GITHUB_TOKEN at build time)"
+    REPLACEMENT="$REPLACEMENT AUTHORIZATION_TOKEN \"\$ENV{GITHUB_TOKEN}\""
+fi
+
 # Use different sed syntax for macOS vs Linux
 if [[ "$OSTYPE" == "darwin"* ]]; then
-    sed -i '' "s|HEAD_REF main|HEAD_REF $BRANCH|" "$PORTFILE"
+    sed -i '' "s|HEAD_REF main|$REPLACEMENT|" "$PORTFILE"
 else
-    sed -i "s|HEAD_REF main|HEAD_REF $BRANCH|" "$PORTFILE"
+    sed -i "s|HEAD_REF main|$REPLACEMENT|" "$PORTFILE"
 fi
 
 echo "Updated portfile:"


### PR DESCRIPTION
@
## Summary

The `vcpkg Port - macOS` jobs in the Examples Integration workflow have been failing long-term with:

```
Downloading https://api.github.com/repos/vanillapdf/vanillapdf/git/refs/heads/<branch> -> ...
error: curl operation failed with response code 403.
```

`vcpkg install --head` resolves the branch tip through the GitHub REST API **anonymously**. Anonymous API requests share a per-IP rate limit, and GitHub-hosted macOS runners sit behind a small shared IP pool that is almost permanently exhausted, so the job fails before the build even starts (example: run 27231470201). Linux and Windows runners hit the same limit only sporadically.

## Fix

Authenticate the API call with the workflow `GITHUB_TOKEN` using the `AUTHORIZATION_TOKEN` parameter of `vcpkg_from_github`:

- `scripts/update_portfile_branch.sh` now appends `AUTHORIZATION_TOKEN "$ENV{GITHUB_TOKEN}"` to the `HEAD_REF` line when `GITHUB_TOKEN` is set. The token is referenced as a literal env lookup resolved by CMake at build time, so the secret is never written to disk and the committed portfile (used for upstream Microsoft vcpkg PRs) stays unchanged. Without `GITHUB_TOKEN` (local usage) the script behaves exactly as before.
- The three vcpkg Port jobs (Linux/Windows/macOS) pass `GITHUB_TOKEN` to the script step and to the install step, with `VCPKG_KEEP_ENV_VARS: GITHUB_TOKEN` so the variable survives into the clean environment vcpkg uses to execute portfiles.

Security notes: `GITHUB_TOKEN` is job-scoped and auto-expires, the workflow already runs with `permissions: contents: read`, and GitHub masks the value in logs.

## Test plan

- [x] Script verified locally with and without `GITHUB_TOKEN` set (token path produces `HEAD_REF <branch> AUTHORIZATION_TOKEN "$ENV{GITHUB_TOKEN}"`, no-token path unchanged)
- [x] `vcpkg Port - macOS` jobs on this PR resolve the head ref without 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@