### PR TITLE
fix: Correctly detect latest release in tag-driven release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,7 @@ jobs:
     outputs:
       tag: ${{ steps.parse.outputs.tag }}
       latest_tag: ${{ steps.parse.outputs.latest_tag }}
+      is_latest: ${{ steps.parse.outputs.is_latest }}
       build_suffix: ${{ steps.parse.outputs.build_suffix }}
       prerelease: ${{ steps.parse.outputs.prerelease }}
       dry_run: ${{ steps.parse.outputs.dry_run }}
@@ -88,6 +89,27 @@ jobs:
           else
             echo "latest_tag=$TAG" >> "$GITHUB_OUTPUT"
             echo "No real tags found, using synthetic tag: $TAG"
+          fi
+
+          # Decide whether this release is the newest stable version. The
+          # latest_tag above only sees tags that already exist, but the tag
+          # being released is created later by the create-tag job, so it is
+          # never in that list. Compare the existing stable tags *plus* this
+          # tag to drive the "latest" GitHub release flag, the docs deploy and
+          # the vcpkg PR.
+          if [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            HIGHEST=$( { git tag -l 'v*.*.*' | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$'; echo "$TAG"; } | sort -V | tail -1)
+            if [ "$HIGHEST" = "$TAG" ]; then
+              echo "is_latest=true" >> "$GITHUB_OUTPUT"
+              echo "This is the newest stable release"
+            else
+              echo "is_latest=false" >> "$GITHUB_OUTPUT"
+              echo "Not the newest stable release (highest is $HIGHEST)"
+            fi
+          else
+            # Pre-release tags (alpha/beta/rc) are never the latest stable release
+            echo "is_latest=false" >> "$GITHUB_OUTPUT"
+            echo "Pre-release tag, not marked latest"
           fi
 
   verify:
@@ -202,6 +224,7 @@ jobs:
     outputs:
       tag: ${{ needs.prepare.outputs.tag }}
       latest_tag: ${{ needs.prepare.outputs.latest_tag }}
+      is_latest: ${{ needs.prepare.outputs.is_latest }}
       prerelease: ${{ needs.prepare.outputs.prerelease }}
     steps:
       - name: Checkout
@@ -243,8 +266,8 @@ jobs:
 
   github-pages:
     needs: create-tag
-    # Only deploy documentation for official releases that are the latest version
-    if: needs.create-tag.outputs.prerelease == 'false' && needs.create-tag.outputs.tag == needs.create-tag.outputs.latest_tag
+    # Only deploy documentation for the newest stable release
+    if: needs.create-tag.outputs.prerelease == 'false' && needs.create-tag.outputs.is_latest == 'true'
     uses: ./.github/workflows/github-pages.yml
     with:
       deploy: true
@@ -260,8 +283,8 @@ jobs:
 
   vcpkg-pr:
     needs: create-tag
-    # Only create vcpkg PR for official releases that are the latest version
-    if: needs.create-tag.outputs.prerelease == 'false' && needs.create-tag.outputs.tag == needs.create-tag.outputs.latest_tag
+    # Only create vcpkg PR for the newest stable release (single-version registry)
+    if: needs.create-tag.outputs.prerelease == 'false' && needs.create-tag.outputs.is_latest == 'true'
     uses: ./.github/workflows/create-vcpkg-pr.yml
     with:
       tag: ${{ needs.create-tag.outputs.tag }}


### PR DESCRIPTION
## Summary

Unblocks the **v2.2.2** release.

Since #379 moved tag creation **into** the release pipeline, the tag being released no longer exists when `prepare` snapshots `latest_tag` from `git tag -l`. So `tag == latest_tag` is **always false for a new release**, which on this branch causes the `github-pages` (docs deploy) and `vcpkg-pr` jobs to be **skipped** — even though v2.2.2 is the latest stable release.

## Fix

Add an `is_latest` output computed by comparing the tag being released against the existing stable tags **plus itself**, and gate `github-pages` and `vcpkg-pr` on it instead of the broken `tag == latest_tag` comparison. `latest_tag` is kept unchanged for dry-run validation (which needs a real, existing tag).

For v2.2.2 this resolves to `is_latest=true` (no stable 2.3.0 exists yet — the alpha/beta tags are excluded), so docs deploy and the vcpkg PR run as expected.

The GitHub release "latest" flag is left to default `gh` behaviour here (this branch's `github-release.yml` has no `latest` input); v2.2.2 is the highest stable tag, so it is marked latest correctly.

## Related

Companion fix for `main` (which has additional jobs): #395.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
