### PR TITLE
ci: Adopt NuGet trusted publishing (OIDC) for release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -250,6 +250,8 @@ jobs:
 
   publish-nuget:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write  # Enable GitHub OIDC token issuance for NuGet trusted publishing
     needs: create-tag
     environment: production
     steps:
@@ -257,11 +259,19 @@ jobs:
         uses: actions/download-artifact@v7
         with:
           path: ./nupkgs
+      # Exchange the OIDC token for a short-lived nuget.org API key (valid 1 hour).
+      # Requires a Trusted Publishing policy on nuget.org bound to this repo,
+      # workflow file (release.yml) and the production environment.
+      - name: NuGet login (OIDC -> temporary API key)
+        uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841  # v1
+        id: nuget-login
+        with:
+          user: ${{ secrets.NUGET_USER }}
       - name: Push to NuGet.org
         run: |
           dotnet nuget push nupkgs/**/*.nupkg \
             --source "${{ vars.NUGET_SOURCE }}" \
-            --api-key "${{ secrets.NUGET_API_KEY }}" \
+            --api-key "${{ steps.nuget-login.outputs.NUGET_API_KEY }}" \
             --skip-duplicate
 
   github-pages:


### PR DESCRIPTION
## Summary

Backport of #399 to `release/2.2`.

Migrate the `publish-nuget` job from a long-lived `NUGET_API_KEY` to **NuGet trusted publishing** (OIDC). The job requests a GitHub OIDC token (`id-token: write`), exchanges it for a short-lived nuget.org API key via `NuGet/login` (pinned to commit SHA), and pushes with that temporary key.

Applied manually rather than via the backport label, since the `publish-nuget` job differs from `main` (no job-level `permissions` block; `download-artifact@v7`), so the cherry-pick would not apply cleanly. This change keeps the `release/2.2` conventions intact.

## Notes

- The `production` environment and its `NUGET_USER` secret are repo-level, so the same Trusted Publishing policy (workflow `release.yml` + `production` environment) covers releases from this branch too — no extra nuget.org setup needed.
- Do not remove `NUGET_API_KEY` until both `main` and `release/2.2` have published successfully via OIDC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
