### PR TITLE
test: Yield in CatalogThreadSafety spin barrier to avoid CI timeout

### DIFF
--- a/src/vanillapdf.unittest/thread_safety_test.cpp
+++ b/src/vanillapdf.unittest/thread_safety_test.cpp
@@ -490,7 +490,7 @@ TEST(CatalogThreadSafety, ConcurrentLazyInitReturnsSameInstance) {
         for (int t = 0; t < NUM_THREADS; ++t) {
             threads.emplace_back([&, t]() {
                 ready.fetch_add(1);
-                while (!go.load()) { /* spin until released */ }
+                while (!go.load()) { std::this_thread::yield(); }
 
                 CatalogHandle* catalog = nullptr;
                 if (Document_GetCatalog(doc, &catalog) == VANILLAPDF_ERROR_SUCCESS) {
@@ -501,7 +501,7 @@ TEST(CatalogThreadSafety, ConcurrentLazyInitReturnsSameInstance) {
             });
         }
 
-        while (ready.load() < NUM_THREADS) { /* wait for all threads to spin up */ }
+        while (ready.load() < NUM_THREADS) { std::this_thread::yield(); }
         go.store(true);
 
         for (auto& thread : threads) {


### PR DESCRIPTION
## Problem

`CatalogThreadSafety.ConcurrentLazyInitReturnsSameInstance` timed out on the `win.2022-x64-static` CI job:

```
573/639 Test #573: CatalogThreadSafety.ConcurrentLazyInitReturnsSameInstance ...***Timeout 1500.52 sec
```

This is **not** a crash or a regression in the `CachedValue` lazy-init fix (#391) — that logic is correct. It is a test-only performance pathology.

## Root cause

The test's release barrier uses pure busy-wait spin loops with no yield — 16 worker threads plus the main thread:

```cpp
ready.fetch_add(1);
while (!go.load()) { /* spin */ }          // 16 workers hot-spin
...
while (ready.load() < NUM_THREADS) { }     // main thread hot-spins
```

GitHub's `windows-2022` runners have only 4 vCPUs. With 17 threads hot-spinning on 4 cores, each spinning thread burns its full scheduler quantum doing nothing, starving the threads that still need to increment `ready` or observe `go`. The barrier that should resolve in microseconds instead took ~10s per document × 500 documents ≈ 5000s, well past the 1500s CTest timeout. It only surfaced on this more oversubscribed runner.

## Fix

Yield inside both spin loops so spinning threads release the core instead of starving the barrier. Test-only change; the code under test is untouched.

## Verification

Locally (Release, `windows-x64-msvc-18`):

```
1/1 Test #573: CatalogThreadSafety.ConcurrentLazyInitReturnsSameInstance ... Passed 0.54 sec
```

Down from a 1500s+ timeout to ~0.5s, still passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)