### PR TITLE
docs: Fix gh PR body convention and refresh CLAUDE rule files

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -7,6 +7,7 @@
 - **src/vanillapdf.test/** - Integration tests (C, one test per PDF)
 - **src/vanillapdf.unittest/** - Unit tests (GoogleTest, C++)
 - **src/vanillapdf.benchmark/** - Benchmarks (Google Benchmark, C++)
+- **src/vanillapdf.fuzzer/** - Fuzz targets (libFuzzer, C++), gated by `VANILLAPDF_ENABLE_FUZZING` (requires Clang)
 
 ## Layered Architecture
 

--- a/.claude/rules/build-system.md
+++ b/.claude/rules/build-system.md
@@ -8,7 +8,7 @@
 
 ## CMake Presets
 
-Presets organized by platform in `cmake/presets/{windows,linux,macos,android}.json`. Each includes configure, build, and test configurations. List with `cmake --list-presets`.
+Presets organized by platform in `cmake/presets/{windows,linux,macos,android}.json`, with shared base configs in `cmake/presets/shared.json`. Each includes configure, build, and test configurations. List with `cmake --list-presets`.
 
 Common patterns: `windows-x64-msvc-17`, `windows-x64-msvc-17-static` (static CRT), `windows-x64-msvc-17-static-md` (static libs + dynamic CRT). Same variants for `msvc-18` (VS 2026). Linux: `linux-x64-gcc`, `linux-x64-clang`, `linux-x64-musl`. macOS: `macos-x64`, `macos-arm64`.
 
@@ -21,6 +21,7 @@ Common patterns: `windows-x64-msvc-17`, `windows-x64-msvc-17-static` (static CRT
 | `vanillapdf.unittest` | Executable | C++ | `VANILLAPDF_ENABLE_TESTS=ON` |
 | `vanillapdf.test` | Executable | C | `VANILLAPDF_ENABLE_TESTS=ON` |
 | `vanillapdf.benchmark` | Executable | C++ | `VANILLAPDF_ENABLE_BENCHMARK=ON` |
+| `vanillapdf.fuzzer` | Executable | C++ | `VANILLAPDF_ENABLE_FUZZING=ON` (Clang only) |
 
 ## Adding New Source Files
 

--- a/.claude/rules/ci-cd.md
+++ b/.claude/rules/ci-cd.md
@@ -2,16 +2,25 @@
 
 ## GitHub Actions Workflows
 
+- `sanity-check.yml` - Fast per-PR build and test gate
 - `nightly-check.yml` - Full platform matrix testing (Linux, Windows, macOS, Android)
 - `coverage.yml` - Code coverage with Codecov
 - `sanitizers.yml` - ASan, UBSan, and TSan checks (one workflow, 3 parallel jobs after shared vcpkg-setup)
+- `fuzzing.yml` - Fuzz testing (builds `vanillapdf.fuzzer`)
 - `codeql.yml` - Security analysis
-- `build-nuget.yml` / `build-deb-package.yml` / `build-brew-package.yml` - Package building
+- `scorecard.yml` - OpenSSF Scorecard supply-chain analysis
+- `dependency-review.yml` - Dependency review on pull requests
+- `conformance-check.yml` - PDF conformance validation
+- `signature-interop-check.yml` - Digital signature interoperability checks
+- `examples-integration.yml` - Integration testing of usage examples
+- `validate-workflows.yml` - Lints/validates the workflow YAML files
+- `build-nuget.yml` / `nightly-nuget.yml` - NuGet package building (release / nightly)
+- `build-deb-package.yml` / `build-rpm-package.yml` / `build-brew-package.yml` - Distro package building
 - `github-pages.yml` - Documentation deployment
 - `update-vcpkg.yml` / `create-vcpkg-pr.yml` - vcpkg updates (vanillapdf-bot)
 - `update-homebrew.yml` - Homebrew formula PRs (vanillapdf-bot)
 - `create-conan-pr.yml` - Conan Center PRs (vanillapdf-bot)
-- `release.yml` - Release automation (vanillapdf-bot)
+- `release.yml` / `github-release.yml` - Release automation (vanillapdf-bot)
 - `backport.yml` - Auto-backport merged PRs to release branches
 
 ## Build Matrix
@@ -29,4 +38,4 @@ Add label `backport release/X.Y` to a PR before merging. The workflow cherry-pic
 
 ## Homebrew
 
-Formula in `homebrew/vanillapdf.rb`. Test: `brew install --build-from-source --HEAD ./homebrew/vanillapdf.rb`. Releases auto-PR to `Homebrew/homebrew-core` via `update-homebrew.yml`.
+Formula template in `homebrew/vanillapdf.rb.in` (the concrete `.rb` is generated at release time). Releases auto-PR to `Homebrew/homebrew-core` via `update-homebrew.yml`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,6 +48,12 @@ git submodule sync --recursive && git submodule update --init --recursive
 - Wrong: `git add ... && git commit -m "..." && git push`
 - Right: commit first, then push as a separate step after confirming
 
+**Pull request bodies (gh on PowerShell):**
+- NEVER use `gh pr create --body @-` (or `--body-file -`). In this PowerShell harness nothing is piped to stdin, so `gh` stores the literal string `@-` as the body. This has silently shipped empty PR descriptions.
+- Pass the body inline with a single-quoted here-string: `gh pr create --base main --title "..." --body @'` … `'@`. Inside a single-quoted here-string, apostrophes are literal — do NOT double them (`GitHub's`, not `GitHub''s`); the only restriction is that a line may not begin with `'@`.
+- Alternatively write the body to a temp file and use `--body-file <path>`.
+- ALWAYS verify after creation: `gh pr view <num> --json body --jq '.body'` and confirm the body is the intended text (not `@-`, not empty, apostrophes intact). The same applies to `gh pr edit --body` and `gh issue create --body`.
+
 ## GitHub Issues
 
 **Always add labels** when creating GitHub issues using `gh issue create`. Use appropriate labels from the repository to categorize issues for grouping and filtering. Common labels:


### PR DESCRIPTION
Two documentation fixes for the `CLAUDE.md` / `.claude/rules` guidance.

## 1. gh PR body convention (avoid empty descriptions)

`gh pr create --body @-` silently shipped **empty PR descriptions** — most recently #402 and #403, whose bodies were the literal string `@-`. In the PowerShell harness nothing is piped to stdin, so `gh` stores the `@-` argument verbatim.

Adds a **Pull request bodies (gh on PowerShell)** subsection to `CLAUDE.md`: use an inline single-quoted here-string (apostrophes literal, not doubled) or `--body-file <path>`, and **always verify after creation** with `gh pr view <num> --json body --jq '.body'`.

## 2. Refresh `.claude/rules` to match the repo

- **ci-cd.md** — add the workflows that landed since the list was written (`sanity-check`, `fuzzing`, `scorecard`, `dependency-review`, `conformance-check`, `signature-interop-check`, `examples-integration`, `validate-workflows`, `nightly-nuget`, `build-rpm-package`, `github-release`).
- **ci-cd.md** — correct the Homebrew path: the source is now the template `homebrew/vanillapdf.rb.in` (the `.rb` is generated at release time by `cmake/configure_homebrew_formula.cmake`), so the old `brew install ./homebrew/vanillapdf.rb` command no longer applies.
- **architecture.md / build-system.md** — document the `vanillapdf.fuzzer` target (libFuzzer, gated by `VANILLAPDF_ENABLE_FUZZING`, Clang only).
- **build-system.md** — mention `cmake/presets/shared.json`.

Docs-only; no code or workflow behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)