### PR TITLE
ci: Adopt VS 2026 runner toolchain on release/2.2 Windows jobs

### DIFF
--- a/.github/workflows/build-nuget.yml
+++ b/.github/workflows/build-nuget.yml
@@ -155,17 +155,20 @@ jobs:
 
   build-windows:
     name: ${{ matrix.config.name }}
-    runs-on: windows-2025
+    runs-on: windows-2022
 
     strategy:
       fail-fast: false
       matrix:
         config:
-          - name: win.2025-x86-static
+          # Release artifacts must build on GA runner images with a single,
+          # uniform toolchain. windows-2025 dropped VS 2022, so the release
+          # jobs use windows-2022 with msvc-17.
+          - name: win.2022-x86-static
             preset: windows-x86-msvc-17-static
             build_type: Release
 
-          - name: win.2025-x64-static
+          - name: win.2022-x64-static
             preset: windows-x64-msvc-17-static
             build_type: Release
 

--- a/.github/workflows/nightly-check.yml
+++ b/.github/workflows/nightly-check.yml
@@ -195,22 +195,22 @@ jobs:
           # Static dependencies + Static CRT (for NuGet builds)
           - { name: "win.2022-x86-static", os: windows-2022, preset: "windows-x86-msvc-17-static" }
           - { name: "win.2022-x64-static", os: windows-2022, preset: "windows-x64-msvc-17-static" }
-          - { name: "win.2025-x86-static", os: windows-2025, preset: "windows-x86-msvc-17-static" }
-          - { name: "win.2025-x64-static", os: windows-2025, preset: "windows-x64-msvc-17-static" }
+          - { name: "win.2025-x86-static", os: windows-2025, preset: "windows-x86-msvc-18-static" }
+          - { name: "win.2025-x64-static", os: windows-2025, preset: "windows-x64-msvc-18-static" }
           - { name: "win.11-arm64-static", os: windows-11-arm, preset: "windows-arm64-msvc-17-static" }
 
           # Static dependencies + Dynamic CRT (for Python wrappers)
           - { name: "win.2022-x86-static-md", os: windows-2022, preset: "windows-x86-msvc-17-static-md" }
           - { name: "win.2022-x64-static-md", os: windows-2022, preset: "windows-x64-msvc-17-static-md" }
-          - { name: "win.2025-x86-static-md", os: windows-2025, preset: "windows-x86-msvc-17-static-md" }
-          - { name: "win.2025-x64-static-md", os: windows-2025, preset: "windows-x64-msvc-17-static-md" }
+          - { name: "win.2025-x86-static-md", os: windows-2025, preset: "windows-x86-msvc-18-static-md" }
+          - { name: "win.2025-x64-static-md", os: windows-2025, preset: "windows-x64-msvc-18-static-md" }
           - { name: "win.11-arm64-static-md", os: windows-11-arm, preset: "windows-arm64-msvc-17-static-md" }
 
           # Dynamic dependencies + Dynamic CRT
           - { name: "win.2022-x86", os: windows-2022, preset: "windows-x86-msvc-17" }
           - { name: "win.2022-x64", os: windows-2022, preset: "windows-x64-msvc-17" }
-          - { name: "win.2025-x86", os: windows-2025, preset: "windows-x86-msvc-17" }
-          - { name: "win.2025-x64", os: windows-2025, preset: "windows-x64-msvc-17" }
+          - { name: "win.2025-x86", os: windows-2025, preset: "windows-x86-msvc-18" }
+          - { name: "win.2025-x64", os: windows-2025, preset: "windows-x64-msvc-18" }
           - { name: "win.11-arm64", os: windows-11-arm, preset: "windows-arm64-msvc-17" }
 
     steps:

--- a/.github/workflows/sanity-check.yml
+++ b/.github/workflows/sanity-check.yml
@@ -136,10 +136,10 @@ jobs:
 
         config:
           - name: win.2025-x86-static
-            preset: windows-x86-msvc-17-static
+            preset: windows-x86-msvc-18-static
 
           - name: win.2025-x64-static
-            preset: windows-x64-msvc-17-static
+            preset: windows-x64-msvc-18-static
 
     steps:
       - uses: actions/checkout@v6

--- a/examples/fetchcontent-integration/CMakePresets.json
+++ b/examples/fetchcontent-integration/CMakePresets.json
@@ -4,7 +4,7 @@
         {
             "name": "windows-x64-debug",
             "displayName": "Windows x64 Debug",
-            "generator": "Visual Studio 17 2022",
+            "generator": "Visual Studio 18 2026",
             "architecture": "x64",
             "binaryDir": "${sourceDir}/build/${presetName}",
             "cacheVariables": {
@@ -15,7 +15,7 @@
         {
             "name": "windows-x64-release",
             "displayName": "Windows x64 Release",
-            "generator": "Visual Studio 17 2022",
+            "generator": "Visual Studio 18 2026",
             "architecture": "x64",
             "binaryDir": "${sourceDir}/build/${presetName}",
             "cacheVariables": {

--- a/examples/vcpkg-port-integration/CMakePresets.json
+++ b/examples/vcpkg-port-integration/CMakePresets.json
@@ -4,7 +4,7 @@
         {
             "name": "windows-x64-debug",
             "displayName": "Windows x64 Debug",
-            "generator": "Visual Studio 17 2022",
+            "generator": "Visual Studio 18 2026",
             "architecture": "x64",
             "binaryDir": "${sourceDir}/build/${presetName}",
             "cacheVariables": {
@@ -15,7 +15,7 @@
         {
             "name": "windows-x64-release",
             "displayName": "Windows x64 Release",
-            "generator": "Visual Studio 17 2022",
+            "generator": "Visual Studio 18 2026",
             "architecture": "x64",
             "binaryDir": "${sourceDir}/build/${presetName}",
             "cacheVariables": {


### PR DESCRIPTION
## Problem

The Windows jobs on `release/2.2` fail at the CMake **Configure** step:

```
CMake Error at CMakeLists.txt:71 (project):
  Generator Visual Studio 17 2022 could not find any instance of Visual Studio.
```

GitHub repointed the `windows-2025` image (and `windows-latest`) to ship **Visual Studio 18 (2026)** instead of VS 2022. Any preset pinning the "Visual Studio 17 2022" generator (the `msvc-17` presets) now fails configure. This is what blocks #400.

## Fix

Backport the toolchain decision already taken on `main` (#401):

- **build-nuget.yml** — move the release jobs off `windows-2025` onto `windows-2022` with `msvc-17`, keeping release artifacts on a single, uniform GA VS 2022 toolchain. **No toolchain change to shipped binaries.**
- **sanity-check.yml** — flip the `windows-2025` jobs to `msvc-18` presets.
- **nightly-check.yml** — flip only the `windows-2025` rows to `msvc-18`; `windows-2022` and `windows-11-arm` stay on `msvc-17` (those images still ship VS 2022), preserving dual-toolchain coverage.
- **examples/{fetchcontent,vcpkg-port}-integration/CMakePresets.json** — `Visual Studio 17 2022` → `Visual Studio 18 2026` (these run on `windows-latest` via examples-integration.yml, now VS 2026).

Note: the catalog thread-safety test fix (#404) is **not** included — that test (and #391) don't exist on this release branch, so there is nothing to apply it to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)