### PR TITLE
chore: Ignore Claude Code local settings on release/2.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 
 # User specific configuration
 CMakeSettings.json
+/.claude/settings.local.json
 
 # Test files
 !/test/*.pdf


### PR DESCRIPTION
`.claude/settings.local.json` is per-user local Claude Code configuration and should not be tracked. `main` already ignores it under the "User specific configuration" section; this adds the matching entry to `release/2.2` so it is not committed accidentally on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)