### PR TITLE
fix: Add missing <cstring> include for std::strlen/std::memcpy

### DIFF
--- a/src/vanillapdf/syntax/utils/encryption.cpp
+++ b/src/vanillapdf/syntax/utils/encryption.cpp
@@ -6,6 +6,8 @@
 #include "syntax/utils/encryption.h"
 #include "syntax/utils/name_constants.h"
 
+#include <cstring>
+
 #if defined(VANILLAPDF_HAVE_OPENSSL)
 
 #include <openssl/rc4.h>

--- a/src/vanillapdf/utils/buffer.h
+++ b/src/vanillapdf/utils/buffer.h
@@ -12,6 +12,7 @@
 #include <string>
 #include <ostream>
 #include <cassert>
+#include <cstring>
 #include <type_traits>
 
 namespace vanillapdf {


### PR DESCRIPTION
## Summary

`buffer.h` uses `std::strlen` and `encryption.cpp` uses `std::memcpy` without including `<cstring>`. These compiled only because an older `fmt`/`spdlog` pulled `<cstring>` in transitively. The vcpkg `2026.06.24` bump (#412) updates that dependency, drops the transitive include, and exposes the latent missing include as a hard build error across the Linux/Rocky/Fedora matrix:

```
buffer.h:39: error: 'strlen' is not a member of 'std'; did you mean 'mbrlen'?
```

## Fix

Add `#include <cstring>` explicitly where these symbols are used:
- `src/vanillapdf/utils/buffer.h` — `std::strlen`
- `src/vanillapdf/syntax/utils/encryption.cpp` — `std::memcpy`

This is independent of the vcpkg bump and correct on its own, so it lands separately ahead of #412 (which will be rebased on `main` afterward). The same latent code exists on `release/2.2`, hence the backport label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
