### PR TITLE
fix: Add missing <cstring> include for std::strlen/std::memcpy (backport #414)

### DIFF
--- a/src/vanillapdf/syntax/utils/encryption.cpp
+++ b/src/vanillapdf/syntax/utils/encryption.cpp
@@ -6,6 +6,8 @@
 #include "syntax/utils/encryption.h"
 #include "syntax/utils/name_constants.h"
 
+#include <cstring>
+
 #if defined(VANILLAPDF_HAVE_OPENSSL)
 
 #include <openssl/rc4.h>

--- a/src/vanillapdf/utils/buffer.h
+++ b/src/vanillapdf/utils/buffer.h
@@ -12,6 +12,7 @@
 #include <string>
 #include <ostream>
 #include <cassert>
+#include <cstring>
 
 namespace vanillapdf {
 


### PR DESCRIPTION
## Summary

Manual backport of #414 to `release/2.2`. The automated backport ([run](https://github.com/vanillapdf/vanillapdf/actions/runs/28511519140)) failed with a cherry-pick conflict in `buffer.h` — the include block on `release/2.2` differs from `main` (no `<type_traits>` line), so the patch context didn't apply. This PR applies the equivalent change by hand.

## Fix

Add `#include <cstring>` where these symbols are used:
- `src/vanillapdf/utils/buffer.h` — `std::strlen`
- `src/vanillapdf/syntax/utils/encryption.cpp` — `std::memcpy`

These compiled only via a transitive include pulled in by an older `fmt`/`spdlog`. `release/2.2` builds fine today because it pins an older vcpkg, but a future vcpkg bump on this branch would drop the transitive include and break the build — the same failure that hit #412 on `main`. This lands the fix proactively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
