### PR TITLE
fix: Reject invalid 1-based page index in PageTree::Insert/Remove

### DIFF
--- a/include/vanillapdf/semantics/c_page_tree.h
+++ b/include/vanillapdf/semantics/c_page_tree.h
@@ -36,7 +36,7 @@ extern "C"
     VANILLAPDF_API error_type CALLING_CONVENTION PageTree_GetPageCount(PageTreeHandle* handle, size_type* result);
 
     /**
-    * \brief Get page at index \p at.
+    * \brief Get page at the 1-based index \p at.
     */
     VANILLAPDF_API error_type CALLING_CONVENTION PageTree_GetPage(PageTreeHandle* handle, size_type at, PageObjectHandle** result);
 
@@ -53,11 +53,13 @@ extern "C"
     VANILLAPDF_API error_type CALLING_CONVENTION PageTree_WarmPageCache(PageTreeHandle* handle);
 
     /**
-    * \brief Insert new page at index \p at.
+    * \brief Insert new page at the 1-based index \p at.
     *
     * The page tree is extended by inserting new element before the
     * element \p at the specified position,
-    * effectively increasing the container by one.
+    * effectively increasing the container by one. \p at must be at
+    * least 1; pass \p PageTree_GetPageCount() + 1 (or use \ref
+    * PageTree_AppendPage) to insert after the last page.
     */
     VANILLAPDF_API error_type CALLING_CONVENTION PageTree_InsertPage(PageTreeHandle* handle, size_type at, PageObjectHandle* page);
 
@@ -69,7 +71,7 @@ extern "C"
     VANILLAPDF_API error_type CALLING_CONVENTION PageTree_AppendPage(PageTreeHandle* handle, PageObjectHandle* page);
 
     /**
-    * \brief Removed a page at index \p at.
+    * \brief Removed a page at the 1-based index \p at.
     *
     * This effectively reduces the container size by one.
     */

--- a/src/vanillapdf.unittest/page_tree_test.cpp
+++ b/src/vanillapdf.unittest/page_tree_test.cpp
@@ -95,6 +95,45 @@ TEST(PageTree, InsertAndRemovePage) {
     ASSERT_EQ(InputOutputStream_Release(io_stream), VANILLAPDF_ERROR_SUCCESS);
 }
 
+TEST(PageTree, InsertPageZeroIndexIsRejected) {
+    FileHandle* file = nullptr;
+    DocumentHandle* doc = nullptr;
+    InputOutputStreamHandle* io_stream = nullptr;
+    CatalogHandle* catalog = nullptr;
+    PageTreeHandle* page_tree = nullptr;
+    size_type page_count = 0;
+
+    // Create in-memory document
+    ASSERT_EQ(InputOutputStream_CreateFromMemory(&io_stream), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(File_CreateStream(io_stream, "temp", &file), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Document_CreateFile(file, &doc), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Document_GetCatalog(doc, &catalog), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Catalog_GetPages(catalog, &page_tree), VANILLAPDF_ERROR_SUCCESS);
+
+    PageObjectHandle* new_page = nullptr;
+    ASSERT_EQ(PageObject_CreateFromDocument(doc, &new_page), VANILLAPDF_ERROR_SUCCESS);
+
+    // Page indices are 1-based; index 0 must be rejected, not silently
+    // reinterpreted as "insert at the front"
+    EXPECT_EQ(PageTree_InsertPage(page_tree, 0, new_page), VANILLAPDF_ERROR_PARAMETER_VALUE);
+    EXPECT_EQ(PageTree_RemovePage(page_tree, 0), VANILLAPDF_ERROR_PARAMETER_VALUE);
+
+    // 1-based index 1 still works, including on the front of the tree
+    ASSERT_EQ(PageTree_GetPageCount(page_tree, &page_count), VANILLAPDF_ERROR_SUCCESS);
+    size_type initial_count = page_count;
+    ASSERT_EQ(PageTree_InsertPage(page_tree, 1, new_page), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(PageTree_GetPageCount(page_tree, &page_count), VANILLAPDF_ERROR_SUCCESS);
+    EXPECT_EQ(page_count, initial_count + 1);
+
+    // Cleanup
+    ASSERT_EQ(PageObject_Release(new_page), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(PageTree_Release(page_tree), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Catalog_Release(catalog), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Document_Release(doc), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(File_Release(file), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(InputOutputStream_Release(io_stream), VANILLAPDF_ERROR_SUCCESS);
+}
+
 TEST(PageTree, ToAndFromUnknown) {
     FileHandle* file = nullptr;
     DocumentHandle* doc = nullptr;

--- a/src/vanillapdf/semantics/objects/page_tree.cpp
+++ b/src/vanillapdf/semantics/objects/page_tree.cpp
@@ -127,6 +127,10 @@ bool PageTree::FindPageIndexInternal(PageTreeNodePtr node, DictionaryObjectPtr p
 
 
 void PageTree::Insert(PageObjectPtr object, types::size_type page_index) {
+    if (page_index < 1) {
+        throw InvalidParameterException(fmt::format("Invalid page index: {}. Page indices are 1-based", page_index));
+    }
+
     auto array_index = page_index - 1;
 
     auto raw_obj = object->GetObject();
@@ -147,6 +151,10 @@ void PageTree::Append(PageObjectPtr object) {
 }
 
 void PageTree::Remove(types::size_type page_index) {
+    if (page_index < 1) {
+        throw InvalidParameterException(fmt::format("Invalid page index: {}. Page indices are 1-based", page_index));
+    }
+
     auto array_index = page_index - 1;
 
     auto kids = GetKidsInternal();


### PR DESCRIPTION
## Summary

Fixes #226. `PageTree_InsertPage(tree, 0, page)` failed with a confusing generic `"Index was outside the bounds of the array"` instead of a clear error.

The originally reported diagnosis (0-based vs 1-based mismatch between the C wrapper and the C++ layer) turned out not to be quite right - see the investigation comment on #226. The `PageTree` API is consistently **1-based** throughout:

- `PageTree::GetCachedPage()` (backing `PageTree_GetPage`) already rejects `page_number < 1`.
- `PageTree_FindPageIndex` is documented as returning a 1-based index.
- `PageTree::Append()` computes `Insert(object, kids->GetSize() + 1)`, which only produces a correct front-insert under a 1-based contract.

So index `0` is simply invalid input, not an alternate valid convention. The actual bug: `PageTree::Insert()`/`Remove()` computed `page_index - 1` on the *unsigned* `types::size_type` without validating `page_index >= 1` first, so `0` silently underflowed to a huge value that then failed a generic array-bounds check deep in `MixedArrayObject`, instead of failing clearly at the `PageTree` API boundary.

## Changes

- `PageTree::Insert`/`PageTree::Remove` (`page_tree.cpp`) now throw `InvalidParameterException` for `page_index < 1`, mirroring the existing `GetCachedPage` validation pattern.
- `c_page_tree.h` doc comments for `PageTree_GetPage`/`PageTree_InsertPage`/`PageTree_RemovePage` now explicitly say "1-based index" (matching `PageTree_FindPageIndex`'s existing doc), since the missing documentation is likely why 0-based was assumed.
- Added `PageTree.InsertPageZeroIndexIsRejected` unit test covering both: index `0` now returns `VANILLAPDF_ERROR_PARAMETER_VALUE`, and index `1` still correctly inserts at the front of an existing tree.

## Test plan

- [x] `ctest --preset windows-x64-msvc-18 --build-config Debug -R "PageTree" --output-on-failure` - all 6 tests pass, including the new one.

Generated with Claude Code