### PR TITLE
fix: Overwrite stale Limits key on TreeBase::Rebuild

### DIFF
--- a/src/vanillapdf.unittest/name_dictionary_test.cpp
+++ b/src/vanillapdf.unittest/name_dictionary_test.cpp
@@ -343,14 +343,13 @@ TEST_F(DestinationNameTreeWithDocument, Remove) {
     ArrayObject_Release(dest_arr);
 }
 
-// Test iterator with single item (requires document context)
-// Note: Multiple inserts fail due to "Limits key already present" bug - see issue #227
+// Test iterator with multiple items (requires document context)
 TEST_F(DestinationNameTreeWithDocument, Iterator_WithItems) {
     HandleGuard<DestinationNameTreeHandle, DestinationNameTree_Release> tree;
     ASSERT_EQ(DestinationNameTree_Create(tree.out()), VANILLAPDF_ERROR_SUCCESS);
     ASSERT_NE(tree.get(), nullptr);
 
-    // Create one destination (multiple inserts blocked by issue #227)
+    // Create first destination
     DestinationHandle* dest1 = nullptr;
     ArrayObjectHandle* dest_arr1 = nullptr;
     CreateFitDestinationWithPage(&dest1, &dest_arr1);
@@ -363,6 +362,21 @@ TEST_F(DestinationNameTreeWithDocument, Iterator_WithItems) {
     ASSERT_NE(name_str1.get(), nullptr);
 
     ASSERT_EQ(DestinationNameTree_Insert(tree, name_str1, dest1), VANILLAPDF_ERROR_SUCCESS);
+
+    // Create a second destination. A second Insert previously failed with
+    // "The key Limits was already present in the dictionary" - see issue #227
+    DestinationHandle* dest2 = nullptr;
+    ArrayObjectHandle* dest_arr2 = nullptr;
+    CreateFitDestinationWithPage(&dest2, &dest_arr2);
+
+    HandleGuard<LiteralStringObjectHandle, LiteralStringObject_Release> name2;
+    ASSERT_EQ(LiteralStringObject_CreateFromEncodedString("OtherDest", name2.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_NE(name2.get(), nullptr);
+    HandleGuard<StringObjectHandle, StringObject_Release> name_str2;
+    ASSERT_EQ(LiteralStringObject_ToStringObject(name2, name_str2.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_NE(name_str2.get(), nullptr);
+
+    ASSERT_EQ(DestinationNameTree_Insert(tree, name_str2, dest2), VANILLAPDF_ERROR_SUCCESS);
 
     // Get iterator
     HandleGuard<DestinationNameTreeIteratorHandle, DestinationNameTreeIterator_Release> iter;
@@ -389,8 +403,10 @@ TEST_F(DestinationNameTreeWithDocument, Iterator_WithItems) {
         ASSERT_EQ(DestinationNameTreeIterator_IsValid(iter, &valid), VANILLAPDF_ERROR_SUCCESS);
     }
 
-    EXPECT_EQ(count, 1);
+    EXPECT_EQ(count, 2);
 
     Destination_Release(dest1);
     ArrayObject_Release(dest_arr1);
+    Destination_Release(dest2);
+    ArrayObject_Release(dest_arr2);
 }

--- a/src/vanillapdf/semantics/objects/tree.h
+++ b/src/vanillapdf/semantics/objects/tree.h
@@ -347,9 +347,12 @@ void TreeBase<KeyT, ValueT>::Rebuild() {
         limit_values->Append(lower_bound->Clone());
         limit_values->Append(upper_bound->Clone());
 
-        // Insert as first item into leaf dictionary
+        // Insert as first item into leaf dictionary. Overwrite: RemoveAllChilds()
+        // does not clear Limits (it may be absent if a prior Rebuild() had no
+        // values), so a plain Insert() would throw DuplicateKeyException here
+        // on the second Rebuild() of an otherwise-unchanged tree.
         //leaf_dict->Insert(constant::Name::Limits, limit_values);
-        _obj->Insert(constant::Name::Limits, limit_values);
+        _obj->Insert(constant::Name::Limits, limit_values, true);
     }
 
     // Insert leaf values


### PR DESCRIPTION
## Summary

Fixes #227. `DestinationNameTree_Insert` (and `NumberTree`) failed on the second insert with `"The key Limits was already present in the dictionary"`.

## Root cause

`TreeBase::RemoveAllChilds()` clears the value array (`Names`/`Nums`, via `GetValueName()`) before `Rebuild()` regenerates it, but never clears `Limits`. `Rebuild()` only inserts `Limits` when the value list is non-empty, and does so with a plain `Insert()` (no overwrite). So after any rebuild that had at least one value, the *next* `Rebuild()` call hits `Insert(Limits, ...)` on a key that's already there and throws `DuplicateKeyException`.

## Fix

`DictionaryObject::Insert` already supports an `overwrite` flag for exactly this (`dictionary_object.h:133`, used elsewhere in the codebase). Passing `overwrite=true` for the `Limits` insert in `Rebuild()` is a one-line fix and avoids adding removal bookkeeping to `RemoveAllChilds()` - it also sidesteps a subtler edge case that a `RemoveAllChilds()`-based fix would need to account for (whether `Limits` currently exists depends on whether the *previous* rebuild had any values, not just whether `GetValueName()` currently exists).

## Test plan

- [x] Extended the existing `DestinationNameTreeWithDocument.Iterator_WithItems` unit test to insert a second destination (previously worked around with a single insert + comment referencing #227). Verified this test fails with the exact reported error before the fix (`git stash`'d the fix, confirmed `VANILLAPDF_ERROR_DUPLICATE_KEY` / "Limits was already present"), and passes after.
- [x] `ctest --preset windows-x64-msvc-18 --build-config Debug -R "NameDictionary |DestinationNameTree" --output-on-failure` - all 14 tests pass.

Generated with Claude Code