### PR TITLE
fix: Emit conformant /P so third-party readers accept RC4/AES-128 encrypted PDFs

### DIFF
--- a/src/vanillapdf/semantics/utils/document_encryption_settings.cpp
+++ b/src/vanillapdf/semantics/utils/document_encryption_settings.cpp
@@ -48,6 +48,14 @@ namespace semantics {
             permission_value &= ~UserAccessPermissionFlags::PrintFaithful;
         }
 
+        // ISO 32000 Table 22: bit positions 1 and 2 are reserved and shall be 0.
+        // Leaving them set yields a /P value (e.g. -1) that we can still decrypt
+        // ourselves but that standards-compliant readers reject: for the V<=4
+        // security handlers /P is folded into the file encryption key, and a
+        // conformant reader normalizes these reserved bits before deriving it.
+        permission_value &= ~0x1;
+        permission_value &= ~0x2;
+
         return permission_value;
     }
 

--- a/src/vanillapdf/syntax/files/file.cpp
+++ b/src/vanillapdf/syntax/files/file.cpp
@@ -390,6 +390,13 @@ bool File::SetEncryptionPassword(const Buffer& password) {
     // This seems very dirty, however it works, so just clean hands afterwards.
     uint32_t permissions_uint32_value = static_cast<uint32_t>(permissions_int64_value);
 
+    // ISO 32000 Table 22: bit positions 1 and 2 are reserved and shall be 0.
+    // Some writers (including older versions of this library) leave them set;
+    // we still decrypt such files, but surface the nonconformance for diagnostics.
+    if ((permissions_uint32_value & 0x1) || (permissions_uint32_value & 0x2)) {
+        spdlog::warn("Permission field has reserved bits 1-2 set ({:#x}), which is not standards-compliant", permissions_uint32_value);
+    }
+
     auto permissions_value = ValueConvertUtils::SafeConvert<uint32_t>(permissions_uint32_value);
     auto revision_value = ValueConvertUtils::SafeConvert<int32_t>(revision->GetIntegerValue());
     auto key_length_value = ValueConvertUtils::SafeConvert<int32_t>(length_bits->GetIntegerValue());


### PR DESCRIPTION
## Summary

Documents encrypted by the library with the RC4-40, RC4-128 and AES-128 security handlers could not be opened by standards-compliant readers (e.g. pyHanko): every password was rejected. The cause is a malformed `/P` permission value.

`GetPermissionInteger` started from `-1` (all bits set) and never cleared permission bits 1 and 2, which ISO 32000 Table 22 reserves and requires to be `0`. The library could still open its own output because it derives the file key from the same malformed `/P` both when writing and reading, so the defect was invisible to a self round-trip. But for the V≤4 security handlers `/P` is folded into the file encryption key, and a conformant reader normalizes these reserved bits before deriving the key — computing a different key and rejecting every password.

AES-256 (R=6) was unaffected because its key derivation does not use `/P`.

## Changes

- **fix**: mask off reserved bits 1–2 so the emitted `/P` is conformant (e.g. `-4` instead of `-1` for the all-permissions case).
- **warn**: when *reading* a document whose `/P` has these reserved bits set (produced by nonconformant writers, including older versions of this library), log a warning. We still decrypt such files — matching the behavior of mainstream readers — but surface the nonconformance for diagnostics.

## Validation

- **Foxit** opens the fixed RC4-40/128 and AES-128 files; before the fix it opened the malformed ones too (mainstream readers are lenient — hence the tolerant-reader warning rather than rejection).
- **pyHanko** (a strict, independent implementation) authenticates both the user and owner passwords, rejects a wrong one, and decrypts the content of the fixed files, and rejected all of them before the fix.

## Backport

This is a pre-existing defect in the RC4/AES-128 create path and is a backport candidate. Encryption interoperability CI tests that guard against this class of bug live in a follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
