### PR TITLE
test: Add encryption interoperability checks (qpdf + pyhanko)

### DIFF
--- a/.github/workflows/encryption-interop-check.yml
+++ b/.github/workflows/encryption-interop-check.yml
@@ -1,0 +1,124 @@
+name: Encryption interoperability check (qpdf + pyhanko)
+
+on:
+  workflow_dispatch:
+
+  pull_request:
+    branches: [ "main", "release/*" ]
+    paths:
+      - 'src/**'
+      - 'include/**'
+      - 'scripts/verify_encryption_interop_pyhanko.py'
+      - 'scripts/verify_encryption_interop_qpdf.py'
+      - '.github/workflows/encryption-interop-check.yml'
+
+  schedule:
+    - cron: '0 5 * * 1'  # Every Monday at 5 AM UTC
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  packages: read
+
+env:
+  VCPKG_ROOT: external/vcpkg
+  VCPKG_DISABLE_METRICS: 1
+  VCPKG_BINARY_SOURCES: "clear;files,${{ github.workspace }}/external/vcpkg/bincache,readwrite"
+
+jobs:
+
+  pyhanko:
+    name: pyhanko / ubuntu.26.04-x64
+    runs-on: ubuntu-24.04
+    container:
+      image: ghcr.io/vanillapdf/vanillapdf-ubuntu:26.04
+      options: --platform=linux/amd64
+
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          submodules: recursive
+
+      - name: Cache vcpkg
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        with:
+          path: |
+            external/vcpkg/downloads
+            external/vcpkg/bincache
+          key: vcpkg-${{ runner.os }}-ubuntu.26.04-x64-${{ hashFiles('vcpkg.json.in') }}
+          restore-keys: |
+            vcpkg-${{ runner.os }}-ubuntu.26.04-x64-
+
+      - name: Bootstrap vcpkg
+        run: ./external/vcpkg/bootstrap-vcpkg.sh
+
+      - name: Configure
+        run: cmake --preset linux-x64-gcc -DCMAKE_BUILD_TYPE=Release -DVANILLAPDF_ENABLE_TESTS=OFF -DVANILLAPDF_ENABLE_BENCHMARK=OFF
+
+      - name: Build vanillapdf.tools
+        run: cmake --build --preset linux-x64-gcc --target vanillapdf.tools
+
+      - name: Install vanillapdf.tools
+        run: cmake --install build/linux-x64-gcc --prefix install
+
+      # Forward: vanillapdf.tools encrypts -> pyhanko authenticates and decrypts.
+      # AES-256 (V=5, R=6) creation is not available on this branch.
+      - name: "[vanillapdf->pyhanko] RC4-40 encryption interop"
+        run: python3 scripts/verify_encryption_interop_pyhanko.py install/bin/vanillapdf.tools test/pdftest2.pdf /tmp/interop RC4 40
+
+      - name: "[vanillapdf->pyhanko] RC4-128 encryption interop"
+        run: python3 scripts/verify_encryption_interop_pyhanko.py install/bin/vanillapdf.tools test/pdftest2.pdf /tmp/interop RC4 128
+
+      - name: "[vanillapdf->pyhanko] AES-128 encryption interop"
+        run: python3 scripts/verify_encryption_interop_pyhanko.py install/bin/vanillapdf.tools test/pdftest2.pdf /tmp/interop AES 128
+
+  qpdf:
+    name: qpdf / ubuntu.26.04-x64
+    runs-on: ubuntu-24.04
+    container:
+      image: ghcr.io/vanillapdf/vanillapdf-ubuntu:26.04
+      options: --platform=linux/amd64
+
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          submodules: recursive
+
+      - name: Cache vcpkg
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        with:
+          path: |
+            external/vcpkg/downloads
+            external/vcpkg/bincache
+          key: vcpkg-${{ runner.os }}-ubuntu.26.04-x64-${{ hashFiles('vcpkg.json.in') }}
+          restore-keys: |
+            vcpkg-${{ runner.os }}-ubuntu.26.04-x64-
+
+      - name: Install qpdf
+        run: apt-get update && apt-get install -y qpdf
+
+      - name: Bootstrap vcpkg
+        run: ./external/vcpkg/bootstrap-vcpkg.sh
+
+      - name: Configure
+        run: cmake --preset linux-x64-gcc -DCMAKE_BUILD_TYPE=Release -DVANILLAPDF_ENABLE_TESTS=OFF -DVANILLAPDF_ENABLE_BENCHMARK=OFF
+
+      - name: Build vanillapdf.tools
+        run: cmake --build --preset linux-x64-gcc --target vanillapdf.tools
+
+      - name: Install vanillapdf.tools
+        run: cmake --install build/linux-x64-gcc --prefix install
+
+      # Forward: vanillapdf.tools encrypts -> qpdf decrypts.
+      # AES-256 (V=5, R=6) creation is not available on this branch.
+      - name: "[vanillapdf->qpdf] RC4-40 encryption interop"
+        run: python3 scripts/verify_encryption_interop_qpdf.py install/bin/vanillapdf.tools test/pdftest2.pdf /tmp/interop RC4 40
+
+      - name: "[vanillapdf->qpdf] RC4-128 encryption interop"
+        run: python3 scripts/verify_encryption_interop_qpdf.py install/bin/vanillapdf.tools test/pdftest2.pdf /tmp/interop RC4 128
+
+      - name: "[vanillapdf->qpdf] AES-128 encryption interop"
+        run: python3 scripts/verify_encryption_interop_qpdf.py install/bin/vanillapdf.tools test/pdftest2.pdf /tmp/interop AES 128

--- a/scripts/verify_encryption_interop_pyhanko.py
+++ b/scripts/verify_encryption_interop_pyhanko.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""PDF encryption interoperability test (pyHanko).
+
+Encrypts a PDF with the vanillapdf command-line tool using the requested
+algorithm and key length, then verifies that an independent implementation
+(pyHanko) can authenticate both the user and owner passwords, reject a wrong
+password, and decrypt the document content.
+
+This guards against key-derivation bugs that a self round-trip cannot catch: a
+scheme that is wrong but internally consistent decrypts fine against itself
+while being rejected by every third-party reader. It applies to every standard
+security handler:
+
+    RC4  40  -> V=1/V=2, R=2/R=3
+    RC4 128  -> V=2,     R=3
+    AES 128  -> V=4,     R=4  (AESV2)
+    AES 256  -> V=5,     R=6  (AESV3, ISO 32000-2 Algorithm 2.B)
+
+Usage:
+    verify_encryption_interop_pyhanko.py <tools_exe> <source_pdf> <output_dir> \
+        <algorithm> <key_length>
+
+    algorithm   : RC4 | AES
+    key_length  : 40 | 128 | 256
+"""
+
+import os
+import subprocess
+import sys
+
+OWNER_PASSWORD = "owner-secret"
+USER_PASSWORD = "user-secret"
+WRONG_PASSWORD = "definitely-not-the-password"
+
+
+def main():
+    if len(sys.argv) < 6:
+        print(__doc__)
+        return 2
+
+    tools_exe, source_pdf, output_dir, algorithm, key_length = sys.argv[1:6]
+
+    os.makedirs(output_dir, exist_ok=True)
+    destination = os.path.join(
+        output_dir, "interop_{}_{}.pdf".format(algorithm.lower(), key_length)
+    )
+
+    command = [
+        tools_exe, "encrypt",
+        "-s", source_pdf,
+        "-d", destination,
+        "-op", OWNER_PASSWORD,
+        "-up", USER_PASSWORD,
+        "-ka", algorithm,
+        "-kl", key_length,
+    ]
+
+    # Do not print the command: it carries the -op/-up passwords.
+    print("Encrypting {} as {} {}".format(source_pdf, algorithm, key_length))
+    result = subprocess.run(command)
+    if result.returncode != 0:
+        print("FAILED: vanillapdf encryption exited with", result.returncode)
+        return 1
+
+    from pyhanko.pdf_utils.reader import PdfFileReader
+    from pyhanko.pdf_utils.crypt import AuthStatus
+
+    def open_and_authenticate(password):
+        with open(destination, "rb") as handle:
+            reader = PdfFileReader(handle, strict=False)
+            if not reader.encrypted:
+                raise AssertionError("output document is not encrypted")
+
+            auth = reader.decrypt(password)
+
+            # Only touch encrypted content when authentication succeeded; reading
+            # objects without a valid key raises rather than returning a status.
+            if auth.status != AuthStatus.FAILED:
+                # Prove the file encryption key works, not just that the password
+                # hash matched, by decrypting real content.
+                page_count = int(reader.root["/Pages"]["/Count"])
+                if page_count < 1:
+                    raise AssertionError("decrypted document reports no pages")
+
+                if "/Metadata" in reader.root:
+                    metadata = reader.root["/Metadata"].data
+                    if not metadata:
+                        raise AssertionError("metadata stream decrypted to empty data")
+
+            return auth.status
+
+    user_status = open_and_authenticate(USER_PASSWORD)
+    if user_status != AuthStatus.USER:
+        print("FAILED: pyHanko user authentication returned", user_status)
+        return 1
+    print("pyHanko: user password authenticated as USER")
+
+    owner_status = open_and_authenticate(OWNER_PASSWORD)
+    if owner_status != AuthStatus.OWNER:
+        print("FAILED: pyHanko owner authentication returned", owner_status)
+        return 1
+    print("pyHanko: owner password authenticated as OWNER")
+
+    wrong_status = open_and_authenticate(WRONG_PASSWORD)
+    if wrong_status != AuthStatus.FAILED:
+        print("FAILED: pyHanko accepted a wrong password as", wrong_status)
+        return 1
+    print("pyHanko: wrong password correctly rejected")
+
+    print("{} {} interop test PASSED".format(algorithm, key_length))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/verify_encryption_interop_qpdf.py
+++ b/scripts/verify_encryption_interop_qpdf.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""PDF encryption interoperability test (qpdf).
+
+Encrypts a PDF with the vanillapdf command-line tool using the requested
+algorithm and key length, then verifies that an independent implementation
+(qpdf) can decrypt it with the user and owner passwords and rejects a wrong
+password.
+
+This guards against key-derivation bugs that a self round-trip cannot catch: a
+scheme that is wrong but internally consistent decrypts fine against itself
+while being rejected by every third-party reader. It applies to every standard
+security handler:
+
+    RC4  40  -> V=1/V=2, R=2/R=3
+    RC4 128  -> V=2,     R=3
+    AES 128  -> V=4,     R=4  (AESV2)
+    AES 256  -> V=5,     R=6  (AESV3, ISO 32000-2 Algorithm 2.B)
+
+Usage:
+    verify_encryption_interop_qpdf.py <tools_exe> <source_pdf> <output_dir> \
+        <algorithm> <key_length>
+
+    algorithm   : RC4 | AES
+    key_length  : 40 | 128 | 256
+"""
+
+import os
+import subprocess
+import sys
+
+OWNER_PASSWORD = "owner-secret"
+USER_PASSWORD = "user-secret"
+WRONG_PASSWORD = "definitely-not-the-password"
+
+
+def main():
+    if len(sys.argv) < 6:
+        print(__doc__)
+        return 2
+
+    tools_exe, source_pdf, output_dir, algorithm, key_length = sys.argv[1:6]
+
+    os.makedirs(output_dir, exist_ok=True)
+    destination = os.path.join(
+        output_dir, "interop_{}_{}.pdf".format(algorithm.lower(), key_length)
+    )
+
+    command = [
+        tools_exe, "encrypt",
+        "-s", source_pdf,
+        "-d", destination,
+        "-op", OWNER_PASSWORD,
+        "-up", USER_PASSWORD,
+        "-ka", algorithm,
+        "-kl", key_length,
+    ]
+
+    # Do not print the command: it carries the -op/-up passwords.
+    print("Encrypting {} as {} {}".format(source_pdf, algorithm, key_length))
+    result = subprocess.run(command)
+    if result.returncode != 0:
+        print("FAILED: vanillapdf encryption exited with", result.returncode)
+        return 1
+
+    decrypted = os.path.join(output_dir, "qpdf_" + os.path.basename(destination))
+
+    def qpdf_decrypt(password):
+        # qpdf exits 0 on success, non-zero on error (e.g. wrong password).
+        return subprocess.run(
+            ["qpdf", "--decrypt", "--password=" + password, destination, decrypted]
+        ).returncode
+
+    if qpdf_decrypt(USER_PASSWORD) != 0:
+        print("FAILED: qpdf could not decrypt with the user password")
+        return 1
+    print("qpdf: user password decrypted successfully")
+
+    if qpdf_decrypt(OWNER_PASSWORD) != 0:
+        print("FAILED: qpdf could not decrypt with the owner password")
+        return 1
+    print("qpdf: owner password decrypted successfully")
+
+    if qpdf_decrypt(WRONG_PASSWORD) == 0:
+        print("FAILED: qpdf accepted a wrong password")
+        return 1
+    print("qpdf: wrong password correctly rejected")
+
+    print("{} {} interop test PASSED".format(algorithm, key_length))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/vanillapdf.tools/encrypt.c
+++ b/src/vanillapdf.tools/encrypt.c
@@ -75,11 +75,8 @@ int process_encrypt(int argc, char *argv[]) {
         return VANILLAPDF_TOOLS_ERROR_INVALID_PARAMETERS;
     }
 
-    if (license_file_path == NULL) {
-        print_encrypt_help();
-        return VANILLAPDF_TOOLS_ERROR_INVALID_PARAMETERS;
-    }
-
+    // Licensing is opt-in (VANILLAPDF_ENABLE_LICENSING, off by default), so the
+    // license file is optional; only apply it when one was supplied.
     if (license_file_path != NULL) {
         RETURN_ERROR_IF_NOT_SUCCESS(LicenseInfo_SetLicenseFile(license_file_path));
     }


### PR DESCRIPTION
## Summary

Adds continuous encryption interoperability testing so the class of bug fixed in #420 cannot regress. A self round-trip (encrypt then decrypt with our own library) cannot catch a key-derivation scheme that is wrong but internally consistent — it decrypts fine against itself while every conformant third-party reader rejects it (exactly what happened with the malformed `/P` value). These checks close that gap by validating our output against independent implementations.

## What it does

Encrypts a PDF with `vanillapdf.tools` and verifies that independent implementations can authenticate both the user and owner passwords, reject a wrong password, and decrypt the content — for RC4-40, RC4-128 and AES-128.

Two validators, one script each, run as separate jobs mirroring `signature-interop-check.yml`:

- **qpdf** (`verify_encryption_interop_qpdf.py`) — mature C++ implementation, reliable CLI exit codes.
- **pyHanko** (`verify_encryption_interop_pyhanko.py`) — strict Python implementation via its reader API. Its `decrypt` CLI always exits 2, so the Python API is required rather than inline CLI.

AES-256 (V=5, R=6) creation is not yet on `main`; its case will be added to this workflow once that feature lands.

## Also included

- **Make the license file optional for the encrypt tool.** Licensing is opt-in (`VANILLAPDF_ENABLE_LICENSING`, off by default) and the library does not require a license to encrypt when it is disabled. The `encrypt` command previously rejected any invocation without `-l`; it now applies a license only when one is supplied. This lets the interop tests (and users) run without a license file. When licensing is enabled but no license is given, the crypto call still fails with a clear `LicenseRequiredException`.

## Validation

The pyHanko path passes locally end-to-end for RC4-40/128 and AES-128; the qpdf path runs in CI where qpdf is installed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
