### PR TITLE
fix: Reject invalid 1-based page index in PageTree::Insert/Remove (backport #418)

### DIFF
--- a/include/vanillapdf/semantics/c_page_tree.h
+++ b/include/vanillapdf/semantics/c_page_tree.h
@@ -36,16 +36,18 @@ extern "C"
     VANILLAPDF_API error_type CALLING_CONVENTION PageTree_GetPageCount(PageTreeHandle* handle, size_type* result);
 
     /**
-    * \brief Get page at index \p at.
+    * \brief Get page at the 1-based index \p at.
     */
     VANILLAPDF_API error_type CALLING_CONVENTION PageTree_GetPage(PageTreeHandle* handle, size_type at, PageObjectHandle** result);
 
     /**
-    * \brief Insert new page at index \p at.
+    * \brief Insert new page at the 1-based index \p at.
     *
     * The page tree is extended by inserting new element before the
     * element \p at the specified position,
-    * effectively increasing the container by one.
+    * effectively increasing the container by one. \p at must be at
+    * least 1; pass \p PageTree_GetPageCount() + 1 (or use \ref
+    * PageTree_AppendPage) to insert after the last page.
     */
     VANILLAPDF_API error_type CALLING_CONVENTION PageTree_InsertPage(PageTreeHandle* handle, size_type at, PageObjectHandle* page);
 
@@ -57,7 +59,7 @@ extern "C"
     VANILLAPDF_API error_type CALLING_CONVENTION PageTree_AppendPage(PageTreeHandle* handle, PageObjectHandle* page);
 
     /**
-    * \brief Removed a page at index \p at.
+    * \brief Removed a page at the 1-based index \p at.
     *
     * This effectively reduces the container size by one.
     */

--- a/src/vanillapdf.unittest/document_test.cpp
+++ b/src/vanillapdf.unittest/document_test.cpp
@@ -552,4 +552,41 @@ TEST(Document, NonTerminalFieldCreation) {
     ASSERT_EQ(DictionaryObject_Release(dict), VANILLAPDF_ERROR_SUCCESS);
 }
 
+TEST(PageTree, InsertRemovePageZeroIndexIsRejected) {
+    InputOutputStreamHandle* io_stream = nullptr;
+    FileHandle* file = nullptr;
+    DocumentHandle* doc = nullptr;
+    CatalogHandle* catalog = nullptr;
+    PageTreeHandle* page_tree = nullptr;
+    PageObjectHandle* new_page = nullptr;
+    size_type page_count = 0;
+
+    // Create in-memory document with an empty page tree
+    ASSERT_EQ(InputOutputStream_CreateFromMemory(&io_stream), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(File_CreateStream(io_stream, "temp", &file), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Document_CreateFile(file, &doc), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Document_GetCatalog(doc, &catalog), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Catalog_GetPages(catalog, &page_tree), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(PageObject_CreateFromDocument(doc, &new_page), VANILLAPDF_ERROR_SUCCESS);
+
+    // Page indices are 1-based; index 0 must be rejected, not silently
+    // reinterpreted as "insert at the front" via an unsigned underflow.
+    EXPECT_NE(PageTree_InsertPage(page_tree, 0, new_page), VANILLAPDF_ERROR_SUCCESS);
+    EXPECT_NE(PageTree_RemovePage(page_tree, 0), VANILLAPDF_ERROR_SUCCESS);
+
+    // 1-based index 1 still works, including on the front of the tree
+    ASSERT_EQ(PageTree_GetPageCount(page_tree, &page_count), VANILLAPDF_ERROR_SUCCESS);
+    size_type initial_count = page_count;
+    ASSERT_EQ(PageTree_InsertPage(page_tree, 1, new_page), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(PageTree_GetPageCount(page_tree, &page_count), VANILLAPDF_ERROR_SUCCESS);
+    EXPECT_EQ(page_count, initial_count + 1);
+
+    ASSERT_EQ(PageObject_Release(new_page), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(PageTree_Release(page_tree), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Catalog_Release(catalog), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Document_Release(doc), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(File_Release(file), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(InputOutputStream_Release(io_stream), VANILLAPDF_ERROR_SUCCESS);
+}
+
 } /* documents */

--- a/src/vanillapdf/semantics/objects/page_tree.cpp
+++ b/src/vanillapdf/semantics/objects/page_tree.cpp
@@ -114,6 +114,10 @@ bool PageTree::HasTreeChilds(PageTreeNodePtr node) const {
 }
 
 void PageTree::Insert(PageObjectPtr object, types::size_type page_index) {
+    if (page_index < 1) {
+        throw GeneralException(fmt::format("Invalid page index: {}. Page indices are 1-based", page_index));
+    }
+
     auto array_index = page_index - 1;
 
     auto raw_obj = object->GetObject();
@@ -133,6 +137,10 @@ void PageTree::Append(PageObjectPtr object) {
 }
 
 void PageTree::Remove(types::size_type page_index) {
+    if (page_index < 1) {
+        throw GeneralException(fmt::format("Invalid page index: {}. Page indices are 1-based", page_index));
+    }
+
     auto array_index = page_index - 1;
 
     auto kids = GetKidsInternal();


### PR DESCRIPTION
Manual backport of #418 to `release/2.2`. The automated backport workflow ([run](https://github.com/vanillapdf/vanillapdf/actions/runs/28882234249)) failed with cherry-pick conflicts.

## What changed
- `src/vanillapdf/semantics/objects/page_tree.cpp` — production fix: explicit page-index `< 1` validation in `Insert`/`Append`. On `release/2.2` this throws `GeneralException` (there is no `InvalidParameterException` class on this branch — that typed-exception hierarchy is main-only), matching the existing validation throws in this file.
- `include/vanillapdf/semantics/c_page_tree.h` — documents the 1-based contract on `GetPage`/`InsertPage`/`RemovePage`.
- `src/vanillapdf.unittest/document_test.cpp` — **backport-specific test** covering the new validation (see below).

## Conflict resolution notes
- **`c_page_tree.h`** had a content conflict because `release/2.2` does not carry the main-only `PageTree_WarmPageCache` API. Resolved by keeping the 2.2 structure and applying only the doc-comment changes; `WarmPageCache` was **not** introduced.
- **`src/vanillapdf.unittest/page_tree_test.cpp`** (the upstream test file) was dropped — it does not exist on `release/2.2` and depends on test infrastructure (`unittest.h` helpers, `handle_guard.h`) that diverged from `main`.

## Test coverage
To avoid a 0% patch-coverage regression, an equivalent test (`PageTree.InsertRemovePageZeroIndexIsRejected`) was added to `document_test.cpp`, which already builds documents and page trees via the C API on this branch. It covers both index-0 rejection branches and the valid 1-based insert path. It asserts a non-success return (rather than a specific error code) since `release/2.2` surfaces `GeneralException` as `VANILLAPDF_ERROR_GENERAL`.

Fixes #226 on the release branch.
