### PR TITLE
fix: Overwrite stale Limits key on TreeBase::Rebuild (backport #419)

### DIFF
--- a/src/vanillapdf/semantics/objects/tree.h
+++ b/src/vanillapdf/semantics/objects/tree.h
@@ -337,9 +337,12 @@ void TreeBase<KeyT, ValueT>::Rebuild() {
         limit_values->Append(lower_bound->Clone());
         limit_values->Append(upper_bound->Clone());
 
-        // Insert as first item into leaf dictionary
+        // Insert as first item into leaf dictionary. Overwrite: RemoveAllChilds()
+        // does not clear Limits (it may be absent if a prior Rebuild() had no
+        // values), so a plain Insert() would throw DuplicateKeyException here
+        // on the second Rebuild() of an otherwise-unchanged tree.
         //leaf_dict->Insert(constant::Name::Limits, limit_values);
-        _obj->Insert(constant::Name::Limits, limit_values);
+        _obj->Insert(constant::Name::Limits, limit_values, true);
     }
 
     // Insert leaf values


### PR DESCRIPTION
Manual backport of #419 to `release/2.2`. The automated backport workflow ([run](https://github.com/vanillapdf/vanillapdf/actions/runs/28882272714)) failed with a cherry-pick conflict.

## What changed
- `src/vanillapdf/semantics/objects/tree.h` — production fix: `TreeBase::Rebuild()` now inserts `Limits` with `overwrite = true`, avoiding a `DuplicateKeyException` on a second `Rebuild()` of an otherwise-unchanged tree (applied cleanly). The `Insert(name, value, bool overwrite)` overload already exists on `release/2.2`.

## Conflict resolution notes
- **`src/vanillapdf.unittest/name_dictionary_test.cpp`** was dropped (modify/delete conflict). This test file does not exist on `release/2.2` and depends on unit-test infrastructure (`test_data.h`/`handle_guard.h` helpers) that diverged from `main`, so the test change cannot be backported without a large, risky test-infra port onto the release branch.

## Codecov / patch coverage
The `codecov/patch` check reports 0% (1 uncovered line) for this change. Unlike #418, that coverage **cannot** be restored on `release/2.2`: the fixed line only executes when a name tree is rebuilt after inserting entries, and the mutable name-tree C API used to cover it on `main` (`DestinationNameTree_Insert`) does not exist on this branch — `release/2.2` exposes only the read-only `NamedDestinations_Contains`/`_Find`. The unit tests are C-API-based, so the branch cannot be reached from a test here. `release/2.2` is not a protected branch, so this informational check does not block merge. The fix itself is a harmless, correct defensive change and applies cleanly.

Fixes #227 on the release branch.
