### PR TITLE
fix: Accept null pointer for zero-length buffer data (#167)

### DIFF
--- a/src/vanillapdf.unittest/utils_test.cpp
+++ b/src/vanillapdf.unittest/utils_test.cpp
@@ -52,6 +52,55 @@ TEST(Buffer, NullCheck) {
     EXPECT_EQ(Buffer_Release(nullptr), VANILLAPDF_ERROR_PARAMETER_VALUE);
 }
 
+TEST(Buffer, CreateFromNullZeroLength) {
+    HandleGuard<BufferHandle, Buffer_Release> buffer_ptr;
+    string_type check_data_ptr = nullptr;
+    size_type check_data_len = 0;
+
+    // A null pointer with zero length is a valid representation of an empty buffer
+    ASSERT_EQ(Buffer_CreateFromData(nullptr, 0, buffer_ptr.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_NE(buffer_ptr.get(), nullptr);
+
+    // The resulting buffer is empty
+    ASSERT_EQ(Buffer_GetData(buffer_ptr, &check_data_ptr, &check_data_len), VANILLAPDF_ERROR_SUCCESS);
+    EXPECT_EQ(check_data_len, 0);
+}
+
+TEST(Buffer, CreateFromNullNonZeroLengthRejected) {
+    HandleGuard<BufferHandle, Buffer_Release> buffer_ptr;
+
+    // A null pointer with a non-zero length is invalid and must be rejected
+    EXPECT_EQ(Buffer_CreateFromData(nullptr, 1, buffer_ptr.out()), VANILLAPDF_ERROR_PARAMETER_VALUE);
+    EXPECT_EQ(buffer_ptr.get(), nullptr);
+}
+
+TEST(Buffer, SetDataNullZeroLength) {
+    const char INITIAL_DATA[] = "initial";
+
+    HandleGuard<BufferHandle, Buffer_Release> buffer_ptr;
+    string_type check_data_ptr = nullptr;
+    size_type check_data_len = 0;
+
+    ASSERT_EQ(Buffer_CreateFromData(INITIAL_DATA, sizeof(INITIAL_DATA) - 1, buffer_ptr.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_NE(buffer_ptr.get(), nullptr);
+
+    // A null pointer with zero length clears the buffer instead of failing
+    ASSERT_EQ(Buffer_SetData(buffer_ptr, nullptr, 0), VANILLAPDF_ERROR_SUCCESS);
+
+    ASSERT_EQ(Buffer_GetData(buffer_ptr, &check_data_ptr, &check_data_len), VANILLAPDF_ERROR_SUCCESS);
+    EXPECT_EQ(check_data_len, 0);
+}
+
+TEST(Buffer, SetDataNullNonZeroLengthRejected) {
+    HandleGuard<BufferHandle, Buffer_Release> buffer_ptr;
+
+    ASSERT_EQ(Buffer_Create(buffer_ptr.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_NE(buffer_ptr.get(), nullptr);
+
+    // A null pointer with a non-zero length is invalid and must be rejected
+    EXPECT_EQ(Buffer_SetData(buffer_ptr, nullptr, 1), VANILLAPDF_ERROR_PARAMETER_VALUE);
+}
+
 TEST(Buffer, Conversion) {
     HandleGuard<BufferHandle, Buffer_Release> buffer_handle;
     HandleGuard<IUnknownHandle, IUnknown_Release> unknown_buffer_handle;

--- a/src/vanillapdf/implementation/utils/c_buffer.cpp
+++ b/src/vanillapdf/implementation/utils/c_buffer.cpp
@@ -17,8 +17,13 @@ VANILLAPDF_API error_type CALLING_CONVENTION Buffer_Create(BufferHandle** result
 }
 
 VANILLAPDF_API error_type CALLING_CONVENTION Buffer_CreateFromData(string_type data, size_type size, BufferHandle** result) {
-    RETURN_ERROR_PARAM_VALUE_IF_NULL(data);
     RETURN_ERROR_PARAM_VALUE_IF_NULL(result);
+
+    // A null pointer is a valid representation of an empty buffer.
+    // Only reject it when the caller also claims a non-zero length.
+    if (data == nullptr && size > 0) {
+        return VANILLAPDF_ERROR_PARAMETER_VALUE;
+    }
 
     try {
         auto buffer = make_deferred_container<Buffer>();
@@ -46,7 +51,12 @@ VANILLAPDF_API error_type CALLING_CONVENTION Buffer_SetData(BufferHandle* handle
 {
     Buffer* obj = reinterpret_cast<Buffer*>(handle);
     RETURN_ERROR_PARAM_VALUE_IF_NULL(obj);
-    RETURN_ERROR_PARAM_VALUE_IF_NULL(data);
+
+    // A null pointer is a valid representation of an empty buffer.
+    // Only reject it when the caller also claims a non-zero length.
+    if (data == nullptr && size > 0) {
+        return VANILLAPDF_ERROR_PARAMETER_VALUE;
+    }
 
     try
     {


### PR DESCRIPTION
## Summary

Closes #167.

`Buffer_CreateFromData` and `Buffer_SetData` rejected a null `data` pointer unconditionally, even when `size` was zero. A null pointer with zero length is a valid representation of an empty buffer and a common C/C++ idiom, so callers (notably the .NET binding) had to pass a sentinel byte to work around it.

## Changes

- Relax the null-pointer guard in both functions to reject a null pointer only when the caller also claims a non-zero length (`data == nullptr && size > 0`).
- The trailing `assign(data, data + size)` stays a single unconditional call: the guard guarantees any null pointer is paired with `size == 0`, so only the standard-defined `nullptr + 0` empty range is ever formed (no UB, no dereference).
- Add unit tests covering both functions:
  - accepted: `null + 0` -> empty buffer
  - rejected: `null + non-zero` -> `VANILLAPDF_ERROR_PARAMETER_VALUE`

## Compatibility

Pure precondition relaxation — an input that previously errored now succeeds. No ABI change; existing callers are unaffected. This lets the .NET binding drop its sentinel-byte workaround.

## Testing

`ctest -R "Buffer"` — 24/24 pass, including the 4 new cases and the pre-existing empty-string (`""`, non-null + zero) case.

## Backport

Not proposed for `release/2.2`: this is a quality-of-life enhancement (the existing workaround functions correctly), and it ships naturally in 2.3.0. Backporting would introduce a behavior change into a patch release, which is undesirable.
