### PR TITLE
chore: Guard against '@'-corrupted commit subjects

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,36 @@
+#!/bin/sh
+#
+# Reject commit messages corrupted by PowerShell here-string delimiters
+# (@'...'@) leaking into a POSIX shell. In POSIX sh, `git commit -m @'...'@`
+# is parsed as a literal `@`, a single-quoted string, and another literal `@`,
+# so the commit SUBJECT becomes a lone `@` and a `@` trailer is appended.
+#
+# Enable this hook once per clone:
+#   git config core.hooksPath .githooks
+#
+# Correct way to write a multi-line message in a POSIX shell:
+#   git commit -F <file>      (write the message to a file first)
+#   git commit -F - <<'EOF' ... EOF
+# The @'...'@ here-string is valid ONLY in PowerShell, never in POSIX sh.
+
+msg_file="$1"
+
+# Subject = first non-comment, non-blank line.
+subject=$(grep -vE '^[[:space:]]*#' "$msg_file" | grep -vE '^[[:space:]]*$' | head -n1)
+
+if [ "$subject" = "@" ]; then
+    echo "commit-msg: the subject line is a lone '@'." >&2
+    echo "  This is a PowerShell here-string (@'...'@) leaking into a POSIX 'git commit'." >&2
+    echo "  Write the message to a file and use:  git commit -F <file>  (or a heredoc <<'EOF')." >&2
+    exit 1
+fi
+
+# A bare '@' on its own line anywhere is a stray here-string delimiter (e.g. the
+# trailing '@'). Legitimate messages never contain a line that is just '@'.
+if grep -qxE '@' "$msg_file"; then
+    echo "commit-msg: the message contains a line that is a lone '@' (stray here-string delimiter)." >&2
+    echo "  Use:  git commit -F <file>, or a heredoc <<'EOF'." >&2
+    exit 1
+fi
+
+exit 0

--- a/.github/workflows/lint-commit-messages.yml
+++ b/.github/workflows/lint-commit-messages.yml
@@ -1,0 +1,44 @@
+name: Lint commit messages
+
+on:
+  pull_request:
+    branches: [ "main", "release/*" ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  commit-subjects:
+    name: Reject corrupted commit subjects
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+
+      - name: Check subjects in PR commit range
+        run: |
+          set -eu
+          base="origin/${{ github.base_ref }}"
+          git rev-parse "$base" >/dev/null
+
+          # A PowerShell here-string (@'...'@) leaking into a POSIX `git commit`
+          # produces a subject that is a lone `@` or begins with `@ `.
+          bad=$(git log --no-merges --format='%H %s' "$base..HEAD" \
+                | awk '{ s=$0; sub(/^[0-9a-f]+ /,"",s); if (s=="@" || s ~ /^@ /) print }')
+
+          if [ -n "$bad" ]; then
+            echo "Corrupted commit subject(s) detected:"
+            echo "$bad"
+            echo
+            echo "These look like a PowerShell here-string (@'...'@) leaked into 'git commit'."
+            echo "Reword them (git rebase -i $base) using: git commit -F <file>."
+            exit 1
+          fi
+
+          echo "All commit subjects OK."

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,6 +73,20 @@ For more information, visit [developercertificate.org](https://developercertific
 
 ---
 
+## 🪝 Git Hooks
+
+The repository ships committed hooks in [`.githooks/`](.githooks/). Enable them once per clone:
+
+```bash
+git config core.hooksPath .githooks
+```
+
+- **`commit-msg`** — rejects commit messages whose subject is a lone `@`. This is the signature of a PowerShell here-string (`@'...'@`) accidentally used in a POSIX shell, which corrupts the subject line. Write multi-line messages with `git commit -F <file>` (or a heredoc) instead.
+
+Hooks are a local, best-effort convenience — they run only after you opt in with the command above. The equivalent server-side enforcement runs automatically on every pull request (see the *Lint commit messages* workflow), so a required check still gates merges even if a clone hasn't enabled the hooks.
+
+---
+
 ## 🔐 Release Tag Signing
 
 All release tags must be GPG-signed by a maintainer. This allows users to cryptographically verify that a release was created by a trusted maintainer and has not been tampered with.


### PR DESCRIPTION
## Summary

Using PowerShell here-string syntax (`@'...'@`) in a POSIX shell corrupts a `git commit` subject into a lone `@` — the delimiters become literal `@` characters. Several such commits have shipped, including one that reached `main`. This adds two layers of protection.

## Changes

- **`.githooks/commit-msg`** — a committed, opt-in hook that rejects a message whose subject is a lone `@` (or contains a stray `@` delimiter line). Enable per clone with `git config core.hooksPath .githooks`. Local, fast feedback at commit time.
- **`.github/workflows/lint-commit-messages.yml`** — server-side enforcement. Lints commit subjects in the PR range on every pull request, so a required status check gates merges regardless of whether a clone enabled the local hook. (Git hooks do **not** run on GitHub, hence the CI job.)
- **`CONTRIBUTING.md`** — new "Git Hooks" section documenting the opt-in and the correct way to write multi-line messages (`git commit -F <file>` / heredoc).

## Validation

- Hook: rejects a `@`-subject message (exit 1, clear guidance), passes a normal message (exit 0).
- CI detection: flags both `@ fix: …` and a lone `@`, passes normal subjects.

## Follow-up to consider (not in this PR)

Given CONTRIBUTING already mandates DCO sign-off and mentions conventional commits, a natural next step is enforcing **`Signed-off-by:`** (and optionally the conventional-commit subject prefix) in the same commit-msg hook + CI lint. Happy to add if wanted.

## Target

main / 2.3.0. No backport.
