### PR TITLE
ci: Lint PR titles against Conventional Commits

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,11 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 20
+    # Produce Conventional Commits titles (e.g. "build(deps): Bump ...") so PRs
+    # pass the "Lint PR title" check that gates the squash-merge commit subject.
+    commit-message:
+      prefix: "build"
+      include: "scope"
     groups:
       github-actions:
         patterns:

--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -1,0 +1,29 @@
+name: Lint PR title
+
+# This repository squash-merges pull requests, so the PR TITLE becomes the
+# commit subject that lands on the target branch. Validate it against the
+# Conventional Commits spec. A lone "@" (the signature of a PowerShell
+# here-string leaking into `git commit`) is not a valid type, so this also
+# rejects the historical "@"-corrupted subjects without any bespoke logic.
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+    branches: ["main", "release/*"]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  pull-requests: read
+
+jobs:
+  validate:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate against Conventional Commits
+        uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/update_vcpkg.py
+++ b/scripts/update_vcpkg.py
@@ -177,7 +177,7 @@ class VcpkgUpdater:
 
     def create_pull_request(self, current_version: str, new_version: str, commit_hash: str, branch_name: str) -> Optional[str]:
         """Create a pull request for the vcpkg update."""
-        title = f"🤖 Update vcpkg to latest tag {new_version}"
+        title = f"build: 🤖 Update vcpkg to latest tag {new_version}"
 
         body = f"""## 🔄 Manual vcpkg Update
 


### PR DESCRIPTION
## Summary

This repository squash-merges pull requests, so the **PR title** becomes the commit subject on the target branch. This adds a required-capable check that validates the PR title against the [Conventional Commits](https://www.conventionalcommits.org/) spec using [`amannn/action-semantic-pull-request`](https://github.com/amannn/action-semantic-pull-request) (SHA-pinned to v6.1.1).

A lone `@` is not a valid Conventional Commit type, so this **also rejects the historical `@`-corrupted subjects** (a PowerShell here-string, `@'...'@`, leaking into a POSIX `git commit`) — without any bespoke commit-message logic.

## Supersedes #432

This replaces #432's approach. That PR added a local (opt-in, unenforced) `commit-msg` hook plus a hand-rolled `awk` workflow that linted the **individual branch commits** — the wrong target for a squash-merge repo, where the PR title (or a single commit's subject) is what actually lands on `main`. This validates that exact string instead, using a maintained off-the-shelf action rather than custom code. **Please close #432 in favor of this.**

## Changes

- **`.github/workflows/lint-pr-title.yml`** — validates the PR title on `opened`/`edited`/`reopened`/`synchronize` for PRs into `main` and `release/*`. Uses `pull_request` (not `pull_request_target`) since only the title is read — no write token or PR-code checkout needed.
- **`scripts/update_vcpkg.py`** — prefix the automated vcpkg PR title with `build:` so it passes the lint.
- **`.github/dependabot.yml`** — emit `build(deps): ...` titles via `commit-message` so dependabot PRs pass the lint.

## Follow-up (manual, after merge)

- Mark **`Validate PR title`** as a **required status check** in branch protection for `main` (and `release/*`). Until then the check runs but does not gate merges.
- Dependabot reads `dependabot.yml` from the default branch only, so `build(deps):` titles take effect after this merges. Existing open dependabot PRs keep their old titles (retitle or `@dependabot rebase`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
