### PR TITLE
chore: Tighten code coverage thresholds ahead of 2.3.0

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -5,22 +5,22 @@
 # - Sets pass/fail status checks for project and patch coverage
 # - Helps enforce or improve test coverage over time
 #
-# Current coverage is around 50%, so the configuration is relaxed:
-# - Requires no regression on overall project coverage
-# - Encourages testing of new code, but tolerates moderate gaps
+# Current coverage is around 58%, so the thresholds are tightened modestly:
+# - Holds overall project coverage near its current level (with a small buffer)
+# - Enforces testing of new code with only a small tolerance for gaps
 #
-# Once test coverage improves, you can tighten thresholds.
+# Once test coverage improves further, you can tighten these thresholds again.
 
 coverage:
   status:
     project:
       default:
-        target: 50%        # Current overall coverage goal
+        target: 55%        # Overall coverage goal (actual ~58%, leaves a buffer)
         threshold: 5%      # Allow up to 5% drop without failing
     patch:
       default:
         target: auto       # Enforce coverage for new/changed lines
-        threshold: 10%     # Allow up to 10% drop on new code
+        threshold: 5%      # Allow up to 5% drop on new code
 
 comment:
   layout: "reach,diff,flags,files,footer"


### PR DESCRIPTION
## Summary

Tightens the Codecov thresholds in `.codecov.yml` as part of 2.3.0 release prep. Actual overall coverage is currently ~58% (per Codecov), so both changes leave a comfortable buffer and should not cause existing PRs to start failing.

## Changes

| Check | target | threshold | Before |
|---|---|---|---|
| **project** | 50% → **55%** | 5% (unchanged) | floor ~45% → ~50% |
| **patch** (new/changed code) | auto (unchanged) | 10% → **5%** | new-code floor ~48% → ~53% |

- **project 55/5** — overall coverage goal raised to 55%; a PR only fails if it drags total coverage below ~50%.
- **patch auto/5** — new/changed lines must stay within 5 points of the codebase average (~58%), i.e. ~53%+, down from a lax 10-point allowance.

Modest nudges chosen deliberately over larger jumps so the gate ratchets upward without becoming noisy.

## Notes

- Config-only change; takes effect once merged to the branch Codecov compares against.
- Context: reviewed alongside two OpenSSF Scorecard findings during release prep — Signed-Releases (already resolved post-`v2.3.0-beta.1` by the provenance-signing pipeline) and Pinned-Dependencies (a first-party local-NuGet false positive), neither of which needed changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
