### PR TITLE
ci: Migrate SBOM attestation to actions/attest

### DIFF
--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -164,7 +164,7 @@ jobs:
           gh release upload ${{ inputs.tag }} vanillapdf-${{ inputs.tag }}-sbom.spdx.json
 
       - name: Attest SBOM
-        uses: actions/attest-sbom@c604332985a26aa8cf1bdc465b92731239ec6b9e  # v4.1.0
+        uses: actions/attest@a1948c3f048ba23858d222213b7c278aabede763  # v4.1.1
         with:
           subject-path: vanillapdf-${{ inputs.tag }}-sbom.spdx.json
           sbom-path: vanillapdf-${{ inputs.tag }}-sbom.spdx.json


### PR DESCRIPTION
## Summary

`actions/attest-sbom` is deprecated in favor of `actions/attest`, which emits a warning on every release run:

> actions/attest-sbom has been deprecated, please use actions/attest instead

This swaps the deprecated action for `actions/attest` in the **Attest SBOM** step of `github-release.yml`.

## Details

- `actions/attest` natively accepts the `sbom-path` input (auto-detects SPDX/CycloneDX and sets the SBOM predicate type), so `subject-path` and `sbom-path` carry over unchanged — only the action name and pin change.
- Pinned to `actions/attest@a1948c3f048ba23858d222213b7c278aabede763  # v4.1.1`, matching the `actions/attest-build-provenance@…v4.1.1` already used in the same job (SHA-pinned per repo policy).
- This is the only `attest-sbom` usage in the repo; `release.yml` uses `attest-build-provenance`, which is not deprecated.

## Notes

This step only runs at release time, so it is not exercised by per-PR CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
