### PR TITLE
[Backport release/2.2] fix: Correct PNG Average/Paeth predictor reconstruction in FlateDecode (#440)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,10 @@
 /build/
 /out/
 
+# Python bytecode caches (from scripts/*.py)
+__pycache__/
+*.py[cod]
+
 # Generated files (from .in templates by CMake)
 /vcpkg.json
 

--- a/include/vanillapdf/syntax/c_filter.h
+++ b/include/vanillapdf/syntax/c_filter.h
@@ -100,6 +100,11 @@ extern "C"
     VANILLAPDF_API error_type CALLING_CONVENTION FilterBase_Decode(FilterBaseHandle* handle, BufferHandle* data, BufferHandle** result);
 
     /**
+    * \brief Decodes source \p data with specified \p params and returns decoded \p result data
+    */
+    VANILLAPDF_API error_type CALLING_CONVENTION FilterBase_DecodeParams(FilterBaseHandle* handle, BufferHandle* data, DictionaryObjectHandle* parameters, BufferHandle** result);
+
+    /**
     * \copydoc IUnknown_Release
     * \see \ref IUnknown_Release
     */
@@ -134,6 +139,12 @@ extern "C"
     * \see \ref FilterBase_Decode
     */
     VANILLAPDF_API error_type CALLING_CONVENTION FlateDecodeFilter_Decode(FlateDecodeFilterHandle* handle, BufferHandle* data, BufferHandle** result);
+
+    /**
+    * \copydoc FilterBase_DecodeParams
+    * \see \ref FilterBase_DecodeParams
+    */
+    VANILLAPDF_API error_type CALLING_CONVENTION FlateDecodeFilter_DecodeParams(FlateDecodeFilterHandle* handle, BufferHandle* data, DictionaryObjectHandle* parameters, BufferHandle** result);
 
     /**
     * \copydoc FilterBase_Release

--- a/scripts/png_predictor_vectors.py
+++ b/scripts/png_predictor_vectors.py
@@ -1,0 +1,291 @@
+#!/usr/bin/env python3
+"""Generate PNG-predictor regression test vectors for the FlateDecode filter.
+
+When a PDF FlateDecode stream carries DecodeParms with ``Predictor >= 10`` the
+filter reconstructs each scanline using the PNG predictor algorithm
+(https://www.w3.org/TR/PNG-Filters.html).
+
+This tool runs offline (never in CI). It:
+
+  1. Forward-filters a known raw image with a chosen PNG filter type.
+  2. Compresses the filtered scanlines and lets MuPDF (PyMuPDF) -- an
+     independent PDF engine we did NOT write -- decode them back through a
+     FlateDecode+Predictor stream, asserting it reconstructs the original
+     image. MuPDF builds the PDF object from a declarative dictionary and the
+     stream bytes (no hand-assembled container) and applies the exact PDF
+     predictor under test. Crucially the check is byte-for-byte equality with
+     the source image, not mere decodability: a wrong predictor still decodes
+     cleanly, just to the wrong pixels, so equality is what certifies our
+     forward filters (including Paeth) against a third-party implementation.
+  3. Emits C arrays: the zlib-compressed filtered stream (the decoder input)
+     and the raw image (the expected output).
+
+Paste the emitted arrays into ``src/vanillapdf.unittest/filter_test.cpp``. To
+reproduce the exact arrays committed there, run
+``scripts/regenerate_filter_test_vectors.py``, which pins the parameters they
+were generated with.
+
+Sub-byte pixel depths (``colors * bits`` not a multiple of 8) are rejected:
+the byte stride this tool mirrors from ``flate_decode_filter.cpp`` floors,
+while the PNG specification (and MuPDF) round up, so such vectors can never
+certify (see GitHub issue #443).
+
+Requires PyMuPDF (``pip install pymupdf``).
+
+Run with no arguments to print one vector per PNG filter type::
+
+    python scripts/png_predictor_vectors.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import random
+import zlib
+from dataclasses import dataclass
+from typing import Dict, List, Sequence
+
+try:
+    import fitz  # PyMuPDF
+except ImportError as exc:  # pragma: no cover - environment guard
+    raise SystemExit("PyMuPDF is required: pip install pymupdf") from exc
+
+# PNG filter type codes (the leading byte of every encoded scanline).
+FILTER_CODES: Dict[str, int] = {
+    "none": 0,
+    "sub": 1,
+    "up": 2,
+    "average": 3,
+    "paeth": 4,
+}
+
+
+def paeth_predictor(left: int, above: int, above_left: int) -> int:
+    """Return the PNG Paeth prediction from the three neighbouring bytes.
+
+    The predictor is whichever neighbour is closest to the linear estimate
+    ``left + above - above_left``; ties prefer the left neighbour, then above.
+    """
+    estimate = left + above - above_left
+
+    distance_to_left = abs(estimate - left)
+    distance_to_above = abs(estimate - above)
+    distance_to_above_left = abs(estimate - above_left)
+
+    if distance_to_left <= distance_to_above and distance_to_left <= distance_to_above_left:
+        return left
+    if distance_to_above <= distance_to_above_left:
+        return above
+    return above_left
+
+
+def png_filtered_byte(filter_code: int, current: int, left: int, above: int, above_left: int) -> int:
+    """Return ``current`` minus the PNG prediction for the given filter.
+
+    Every PNG filter encodes a byte as the raw value minus a prediction from
+    already-known neighbours; the caller reduces the result modulo 256.
+    """
+    if filter_code == FILTER_CODES["none"]:
+        return current
+    if filter_code == FILTER_CODES["sub"]:
+        return current - left
+    if filter_code == FILTER_CODES["up"]:
+        return current - above
+    if filter_code == FILTER_CODES["average"]:
+        return current - (left + above) // 2
+    if filter_code == FILTER_CODES["paeth"]:
+        return current - paeth_predictor(left, above, above_left)
+    raise ValueError(f"unknown PNG filter code: {filter_code}")
+
+
+@dataclass(frozen=True)
+class Geometry:
+    """Image geometry, mirroring the FlateDecode DecodeParms of the same name."""
+
+    colors: int
+    bits_per_component: int
+    columns: int
+
+    @property
+    def bytes_per_pixel(self) -> int:
+        # Matches flate_decode_filter.cpp: colors * bits / 8 (integer division).
+        return self.colors * self.bits_per_component // 8
+
+    @property
+    def bytes_per_row(self) -> int:
+        # Matches flate_decode_filter.cpp: (colors * columns * bits + 7) / 8.
+        total_bits = self.colors * self.columns * self.bits_per_component
+        return (total_bits + 7) // 8
+
+
+def build_raw_rows(geometry: Geometry, rows: int, seed: int) -> List[List[int]]:
+    """Return a deterministic pseudo-random sample image of the given geometry."""
+    rng = random.Random(seed)
+    width = geometry.bytes_per_row
+
+    image = []
+    for _ in range(rows):
+        row = []
+        for _ in range(width):
+            row.append(rng.randrange(256))
+        image.append(row)
+    return image
+
+
+def encode_scanlines(geometry: Geometry, raw_rows: Sequence[Sequence[int]], filter_code: int) -> bytes:
+    """Forward-filter every scanline, prefixing each with its filter-code byte.
+
+    Forward filtering reads the raw (not reconstructed) neighbours, so there is
+    no left-to-right dependency within a row. Only encode lives here; the
+    library decodes, and the MuPDF oracle plus the unit test confirm the round
+    trip.
+    """
+    bytes_per_pixel = geometry.bytes_per_pixel
+    width = geometry.bytes_per_row
+
+    out = bytearray()
+    previous_row: Sequence[int] = [0] * width
+    for row in raw_rows:
+        out.append(filter_code)
+        for x in range(width):
+            # Off-image neighbours (past the left edge) are treated as zero.
+            if x >= bytes_per_pixel:
+                left = row[x - bytes_per_pixel]
+                above_left = previous_row[x - bytes_per_pixel]
+            else:
+                left = 0
+                above_left = 0
+            above = previous_row[x]
+
+            filtered = png_filtered_byte(filter_code, row[x], left, above, above_left)
+            out.append(filtered & 0xFF)
+        previous_row = row
+    return bytes(out)
+
+
+def flatten_rows(raw_rows: Sequence[Sequence[int]]) -> bytes:
+    """Concatenate the scanlines into one byte string (the expected image)."""
+    flat = bytearray()
+    for row in raw_rows:
+        flat.extend(row)
+    return bytes(flat)
+
+
+def decode_with_pdf_engine(compressed: bytes, geometry: Geometry) -> bytes:
+    """Decode a FlateDecode+Predictor stream with MuPDF (the independent oracle).
+
+    Builds a one-object PDF whose stream is the compressed, predictor-filtered
+    data and lets MuPDF apply the FlateDecode filter and PNG predictor, exactly
+    as a PDF reader would. Returns the reconstructed raw image bytes.
+    """
+    doc = fitz.open()
+    try:
+        xref = doc.get_new_xref()
+        # An empty dict must exist before a stream can be attached; the stream
+        # is stored verbatim (compress=False) and the filter is declared after.
+        doc.update_object(xref, "<< >>")
+        doc.update_stream(xref, compressed, new=True, compress=False)
+        # Predictor 15 = PNG "optimal": each scanline carries its own filter byte,
+        # which is what the encoder emits, so it is fixed rather than configurable.
+        doc.update_object(
+            xref,
+            "<< /Filter /FlateDecode /DecodeParms << /Predictor 15 "
+            f"/Colors {geometry.colors} /BitsPerComponent {geometry.bits_per_component} "
+            f"/Columns {geometry.columns} >> /Length {len(compressed)} >>")
+        return doc.xref_stream(xref)
+    finally:
+        doc.close()
+
+
+def certify_vector(compressed: bytes, geometry: Geometry, expected: bytes, filter_name: str) -> None:
+    """Abort unless MuPDF reconstructs ``expected`` from the compressed stream."""
+    if decode_with_pdf_engine(compressed, geometry) != expected:
+        raise SystemExit(f"MuPDF disagreed on the '{filter_name}' filter; "
+                         "the generated vector is NOT trustworthy")
+
+
+def format_c_array(name: str, data: bytes, bytes_per_line: int) -> str:
+    """Render ``data`` as a C ``static const unsigned char[]`` definition."""
+    lines = []
+    lines.append("static const unsigned char " + name + "[] = {")
+    for start in range(0, len(data), bytes_per_line):
+        hex_values = []
+        for byte in data[start:start + bytes_per_line]:
+            hex_values.append(f"0x{byte:02X}")
+        lines.append("    " + ", ".join(hex_values) + ",")
+    lines.append("};")
+    return "\n".join(lines)
+
+
+def positive_int(value: str) -> int:
+    """argparse ``type`` for a strictly positive integer."""
+    parsed = int(value)
+    if parsed < 1:
+        raise argparse.ArgumentTypeError(f"must be a positive integer, got {value!r}")
+    return parsed
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    """Parse and validate command-line arguments."""
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--colors", type=positive_int, default=3,
+                        help="samples per pixel (/Colors, default 3)")
+    parser.add_argument("--bits", type=int, default=8, dest="bits_per_component",
+                        choices=(1, 2, 4, 8, 16),
+                        help="bits per component (/BitsPerComponent, default 8)")
+    parser.add_argument("--columns", type=positive_int, default=4,
+                        help="pixels per row (/Columns, default 4)")
+    parser.add_argument("--rows", type=positive_int, default=3,
+                        help="number of scanlines (default 3)")
+    parser.add_argument("--seed", type=int, default=0,
+                        help="seed for the pseudo-random sample image (default 0)")
+    parser.add_argument("--compression-level", type=int, default=9, choices=range(0, 10),
+                        dest="compression_level",
+                        help="zlib compression level (default 9)")
+    parser.add_argument("--bytes-per-line", type=positive_int, default=12,
+                        dest="bytes_per_line",
+                        help="bytes per line in the emitted C arrays (default 12)")
+
+    args = parser.parse_args(argv)
+    if (args.colors * args.bits_per_component) % 8 != 0:
+        parser.error("colors * bits must be a multiple of 8 (whole-byte pixels); "
+                     "sub-byte pixel depths cannot certify against MuPDF "
+                     "(see GitHub issue #443)")
+    return args
+
+
+def render_vectors(geometry: Geometry, raw_rows: Sequence[Sequence[int]],
+                   compression_level: int, bytes_per_line: int) -> str:
+    """Encode, certify and render one vector per PNG filter as a C source block."""
+    expected = flatten_rows(raw_rows)
+
+    blocks = []
+    for name, filter_code in FILTER_CODES.items():
+        filtered = encode_scanlines(geometry, raw_rows, filter_code)
+        compressed = zlib.compress(filtered, compression_level)
+        certify_vector(compressed, geometry, expected, name)
+        blocks.append(format_c_array("INPUT_" + name.upper(), compressed, bytes_per_line))
+
+    blocks.append(format_c_array("EXPECTED_RAW", expected, bytes_per_line))
+
+    geometry_comment = (
+        f"// geometry: Colors={geometry.colors} "
+        f"BitsPerComponent={geometry.bits_per_component} "
+        f"Columns={geometry.columns} rows={len(raw_rows)} "
+        f"bytes_per_row={geometry.bytes_per_row}\n"
+        "// verified against MuPDF (PyMuPDF) before emission")
+    blocks.append(geometry_comment)
+    return "\n\n".join(blocks)
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    args = parse_args(argv)
+    geometry = Geometry(args.colors, args.bits_per_component, args.columns)
+    raw_rows = build_raw_rows(geometry, args.rows, args.seed)
+    output = render_vectors(geometry, raw_rows, args.compression_level, args.bytes_per_line)
+    print(output)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/regenerate_filter_test_vectors.py
+++ b/scripts/regenerate_filter_test_vectors.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+"""Reproduce the FlateDecode predictor vectors committed in filter_test.cpp.
+
+``png_predictor_vectors.py`` is the general, parametrised tool. This wrapper
+pins the exact parameters that produced the ``INPUT_*`` / ``EXPECTED_RAW`` arrays
+in ``src/vanillapdf.unittest/filter_test.cpp``, so running it always reproduces
+those bytes regardless of the tool's default values. Paste its output over the
+arrays in that file whenever they need to be regenerated.
+
+Usage::
+
+    python scripts/regenerate_filter_test_vectors.py
+"""
+
+from png_predictor_vectors import main
+
+# Exact parameters behind the committed vectors: a 4x3 RGB (8-bit) image with a
+# fixed random seed, zlib level 9, wrapped at 12 bytes per emitted C line.
+PINNED_ARGUMENTS = [
+    "--colors", "3",
+    "--bits", "8",
+    "--columns", "4",
+    "--rows", "3",
+    "--seed", "0",
+    "--compression-level", "9",
+    "--bytes-per-line", "12",
+]
+
+
+if __name__ == "__main__":
+    main(PINNED_ARGUMENTS)

--- a/src/vanillapdf.unittest/CMakeLists.txt
+++ b/src/vanillapdf.unittest/CMakeLists.txt
@@ -38,6 +38,7 @@ set(VANILLAPDF_UNITTEST_SOURCES
 set(VANILLAPDF_UNITTEST_HEADERS
     unittest.h
     test_data.h
+    handle_guard.h
 )
 
 # Resource files

--- a/src/vanillapdf.unittest/filter_test.cpp
+++ b/src/vanillapdf.unittest/filter_test.cpp
@@ -1,4 +1,5 @@
 #include "unittest.h"
+#include "handle_guard.h"
 
 #include <cstring>
 #include <string_view>

--- a/src/vanillapdf.unittest/filter_test.cpp
+++ b/src/vanillapdf.unittest/filter_test.cpp
@@ -81,6 +81,135 @@ TEST(FlateDecodeFilter, InvalidDataDecodeError) {
     ASSERT_EQ(FlateDecodeFilter_Release(filter_handle), VANILLAPDF_ERROR_SUCCESS);
 }
 
+// --- PNG predictor reconstruction regression -----------------------------
+//
+// Regenerate with scripts/regenerate_filter_test_vectors.py, which pins the
+// parameters and prints these arrays. The underlying tool
+// (scripts/png_predictor_vectors.py) certifies every vector against MuPDF
+// (PyMuPDF), an independent PDF engine, before emitting it. Each INPUT_* array
+// is a zlib-compressed, PNG-filtered RGB image (Colors=3, BitsPerComponent=8,
+// Columns=4, 3 rows); decoding it with the matching DecodeParms must yield
+// EXPECTED_RAW. Average and Paeth carry the historical bug (the reconstructed
+// byte was written to current[i] instead of current[bytes_per_pixel + i]);
+// None/Sub/Up are covered too so every filter branch is guarded.
+
+static const unsigned char INPUT_NONE[] = {
+    0x78, 0xDA, 0x01, 0x27, 0x00, 0xD8, 0xFF, 0x00, 0xC5, 0xD7, 0x14, 0x84,
+    0xF8, 0xCF, 0x9B, 0xF4, 0xB7, 0x6F, 0x47, 0x90, 0x00, 0x47, 0x30, 0x80,
+    0x4B, 0x9E, 0x32, 0x25, 0xA9, 0xF1, 0x33, 0xB5, 0xDE, 0x00, 0xA1, 0x68,
+    0xF4, 0xE2, 0x85, 0x1F, 0x07, 0x2F, 0xCC, 0x00, 0xFC, 0xAA, 0x87, 0x1D,
+    0x13, 0x4A,
+};
+
+static const unsigned char INPUT_SUB[] = {
+    0x78, 0xDA, 0x01, 0x27, 0x00, 0xD8, 0xFF, 0x01, 0xC5, 0xD7, 0x14, 0xBF,
+    0x21, 0xBB, 0x17, 0xFC, 0xE8, 0xD4, 0x53, 0xD9, 0x01, 0x47, 0x30, 0x80,
+    0x04, 0x6E, 0xB2, 0xDA, 0x0B, 0xBF, 0x0E, 0x0C, 0xED, 0x01, 0xA1, 0x68,
+    0xF4, 0x41, 0x1D, 0x2B, 0x25, 0xAA, 0xAD, 0xF9, 0xCD, 0xDE, 0x6B, 0x61,
+    0x12, 0xB6,
+};
+
+static const unsigned char INPUT_UP[] = {
+    0x78, 0xDA, 0x01, 0x27, 0x00, 0xD8, 0xFF, 0x02, 0xC5, 0xD7, 0x14, 0x84,
+    0xF8, 0xCF, 0x9B, 0xF4, 0xB7, 0x6F, 0x47, 0x90, 0x02, 0x82, 0x59, 0x6C,
+    0xC7, 0xA6, 0x63, 0x8A, 0xB5, 0x3A, 0xC4, 0x6E, 0x4E, 0x02, 0x5A, 0x38,
+    0x74, 0x97, 0xE7, 0xED, 0xE2, 0x86, 0xDB, 0xCD, 0x47, 0xCC, 0x9B, 0xBE,
+    0x15, 0x32,
+};
+
+static const unsigned char INPUT_AVERAGE[] = {
+    0x78, 0xDA, 0x63, 0x3E, 0x7A, 0x5D, 0x44, 0xA9, 0xF7, 0x68, 0x64, 0x45,
+    0x80, 0xD2, 0x59, 0x53, 0xE6, 0xA7, 0x47, 0xCB, 0x9E, 0x71, 0x75, 0x6F,
+    0x7A, 0x50, 0xFB, 0xD2, 0x56, 0x8E, 0xB9, 0x2E, 0x60, 0x4B, 0x0E, 0x53,
+    0x4F, 0xCB, 0x0C, 0x97, 0xC7, 0x5D, 0x57, 0x01, 0x63, 0x98, 0x12, 0x7F,
+};
+
+static const unsigned char INPUT_PAETH[] = {
+    0x78, 0xDA, 0x01, 0x27, 0x00, 0xD8, 0xFF, 0x04, 0xC5, 0xD7, 0x14, 0xBF,
+    0x21, 0xBB, 0x17, 0xFC, 0xE8, 0xD4, 0x53, 0xD9, 0x04, 0x82, 0x59, 0x6C,
+    0x04, 0x6E, 0x63, 0xDA, 0x0B, 0xBF, 0x0E, 0x6E, 0x27, 0x04, 0x5A, 0x38,
+    0x74, 0x41, 0xE7, 0x9F, 0x25, 0xAA, 0xDB, 0xF9, 0xCD, 0xDE, 0x68, 0xA8,
+    0x12, 0xD1,
+};
+
+static const unsigned char EXPECTED_RAW[] = {
+    0xC5, 0xD7, 0x14, 0x84, 0xF8, 0xCF, 0x9B, 0xF4, 0xB7, 0x6F, 0x47, 0x90,
+    0x47, 0x30, 0x80, 0x4B, 0x9E, 0x32, 0x25, 0xA9, 0xF1, 0x33, 0xB5, 0xDE,
+    0xA1, 0x68, 0xF4, 0xE2, 0x85, 0x1F, 0x07, 0x2F, 0xCC, 0x00, 0xFC, 0xAA,
+};
+
+static void InsertIntegerEntry(DictionaryObjectHandle* dict, string_type key, bigint_type value) {
+    HandleGuard<NameObjectHandle, NameObject_Release> name;
+    HandleGuard<IntegerObjectHandle, IntegerObject_Release> integer;
+    HandleGuard<ObjectHandle, Object_Release> object;
+
+    ASSERT_EQ(NameObject_CreateFromDecodedString(key, name.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(IntegerObject_CreateFromIntegerValue(value, integer.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(IntegerObject_ToObject(integer, object.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(DictionaryObject_Insert(dict, name, object, VANILLAPDF_RV_TRUE), VANILLAPDF_ERROR_SUCCESS);
+}
+
+static void DecodePngPredictorAndCompare(
+    const unsigned char* input, size_type input_len,
+    const unsigned char* expected, size_type expected_len) {
+
+    HandleGuard<FlateDecodeFilterHandle, FlateDecodeFilter_Release> filter;
+    HandleGuard<BufferHandle, Buffer_Release> input_buffer;
+    HandleGuard<DictionaryObjectHandle, DictionaryObject_Release> params;
+    HandleGuard<BufferHandle, Buffer_Release> decoded_buffer;
+
+    ASSERT_EQ(FlateDecodeFilter_Create(filter.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Buffer_CreateFromData(reinterpret_cast<string_type>(input), input_len, input_buffer.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(DictionaryObject_Create(params.out()), VANILLAPDF_ERROR_SUCCESS);
+
+    // DecodeParms for a PNG-predicted (Predictor >= 10) RGB image.
+    InsertIntegerEntry(params, "Predictor", 15);
+    InsertIntegerEntry(params, "Colors", 3);
+    InsertIntegerEntry(params, "BitsPerComponent", 8);
+    InsertIntegerEntry(params, "Columns", 4);
+
+    ASSERT_EQ(FlateDecodeFilter_DecodeParams(filter, input_buffer, params, decoded_buffer.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_NE(decoded_buffer.get(), nullptr);
+
+    string_type decoded_data = nullptr;
+    size_type decoded_len = 0;
+    ASSERT_EQ(Buffer_GetData(decoded_buffer, &decoded_data, &decoded_len), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_NE(decoded_data, nullptr);
+
+    ASSERT_EQ(decoded_len, expected_len);
+    for (size_type i = 0; i < expected_len; ++i) {
+        EXPECT_EQ(static_cast<unsigned char>(decoded_data[i]), expected[i]);
+    }
+}
+
+struct PngPredictorCase {
+    std::string_view name;
+    const unsigned char* input;
+    size_type input_len;
+};
+
+class PngPredictorReconstructionTest : public ::testing::TestWithParam<PngPredictorCase> {};
+
+TEST_P(PngPredictorReconstructionTest, ReconstructsExpectedImage) {
+    const auto& param = GetParam();
+    DecodePngPredictorAndCompare(param.input, param.input_len, EXPECTED_RAW, sizeof(EXPECTED_RAW));
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    FlateDecodeFilter,
+    PngPredictorReconstructionTest,
+    ::testing::Values(
+        PngPredictorCase{ "None", INPUT_NONE, sizeof(INPUT_NONE) },
+        PngPredictorCase{ "Sub", INPUT_SUB, sizeof(INPUT_SUB) },
+        PngPredictorCase{ "Up", INPUT_UP, sizeof(INPUT_UP) },
+        PngPredictorCase{ "Average", INPUT_AVERAGE, sizeof(INPUT_AVERAGE) },
+        PngPredictorCase{ "Paeth", INPUT_PAETH, sizeof(INPUT_PAETH) }
+    ),
+    [](const ::testing::TestParamInfo<PngPredictorCase>& info) {
+        return std::string(info.param.name);
+    }
+);
+
 TEST(DCTDecodeFilter, Decode) {
 
     const unsigned char INPUT_DATA[] = {

--- a/src/vanillapdf.unittest/handle_guard.h
+++ b/src/vanillapdf.unittest/handle_guard.h
@@ -1,0 +1,77 @@
+#ifndef _VANILLAPDF_UNITTEST_HANDLE_GUARD_H
+#define _VANILLAPDF_UNITTEST_HANDLE_GUARD_H
+
+#include "vanillapdf/c_vanillapdf_api.h"
+
+#include <utility>
+
+/**
+ * RAII wrapper for C API handle lifetime management in tests.
+ *
+ * Automatically calls the release function when the guard goes out of scope.
+ * Eliminates manual cleanup blocks and ensures handles are released even when
+ * assertions fail mid-test.
+ *
+ * Usage:
+ *   HandleGuard<BufferHandle, Buffer_Release> buffer;
+ *   ASSERT_EQ(Buffer_Create(buffer.out()), VANILLAPDF_ERROR_SUCCESS);
+ *   // buffer is automatically released at scope exit
+ */
+template<typename Handle, error_type (CALLING_CONVENTION *ReleaseFn)(Handle*)>
+class HandleGuard {
+    Handle* handle_ = nullptr;
+
+public:
+    HandleGuard() = default;
+    explicit HandleGuard(Handle* h) : handle_(h) {}
+
+    ~HandleGuard() {
+        if (handle_) {
+            ReleaseFn(handle_);
+        }
+    }
+
+    // Move-only semantics to prevent double-release
+    HandleGuard(HandleGuard&& other) noexcept : handle_(other.handle_) {
+        other.handle_ = nullptr;
+    }
+
+    HandleGuard& operator=(HandleGuard&& other) noexcept {
+        if (this != &other) {
+            if (handle_) {
+                ReleaseFn(handle_);
+            }
+            handle_ = other.handle_;
+            other.handle_ = nullptr;
+        }
+        return *this;
+    }
+
+    HandleGuard(const HandleGuard&) = delete;
+    HandleGuard& operator=(const HandleGuard&) = delete;
+
+    /**
+     * Returns a pointer to the internal handle pointer.
+     * Used with C API Create functions: Create(guard.out())
+     */
+    Handle** out() { return &handle_; }
+
+    /**
+     * Returns the raw handle pointer.
+     * Used when passing to C API functions that take Handle*.
+     */
+    Handle* get() const { return handle_; }
+
+    /**
+     * Implicit conversion to raw handle pointer.
+     * Allows passing directly to C API functions.
+     */
+    operator Handle*() const { return handle_; }
+
+    /**
+     * Explicit bool conversion for null checks.
+     */
+    explicit operator bool() const { return handle_ != nullptr; }
+};
+
+#endif /* _VANILLAPDF_UNITTEST_HANDLE_GUARD_H */

--- a/src/vanillapdf/implementation/syntax/c_filter.cpp
+++ b/src/vanillapdf/implementation/syntax/c_filter.cpp
@@ -66,6 +66,24 @@ VANILLAPDF_API error_type CALLING_CONVENTION FilterBase_Decode(FilterBaseHandle*
     } CATCH_VANILLAPDF_EXCEPTIONS
 }
 
+VANILLAPDF_API error_type CALLING_CONVENTION FilterBase_DecodeParams(FilterBaseHandle* handle, BufferHandle* data_handle, DictionaryObjectHandle* parameters_handle, BufferHandle** result) {
+    FilterBase* filter = reinterpret_cast<FilterBase*>(handle);
+    DictionaryObject* params = reinterpret_cast<DictionaryObject*>(parameters_handle);
+    Buffer* data = reinterpret_cast<Buffer*>(data_handle);
+
+    RETURN_ERROR_PARAM_VALUE_IF_NULL(filter);
+    RETURN_ERROR_PARAM_VALUE_IF_NULL(params);
+    RETURN_ERROR_PARAM_VALUE_IF_NULL(data);
+    RETURN_ERROR_PARAM_VALUE_IF_NULL(result);
+
+    try {
+        auto decoded = filter->Decode(data, params);
+        auto ptr = decoded.AddRefGet();
+        *result = reinterpret_cast<BufferHandle*>(ptr);
+        return VANILLAPDF_ERROR_SUCCESS;
+    } CATCH_VANILLAPDF_EXCEPTIONS
+}
+
 VANILLAPDF_API error_type CALLING_CONVENTION FilterBase_Release(FilterBaseHandle* handle) {
     return ObjectRelease<FilterBase, FilterBaseHandle>(handle);
 }
@@ -106,6 +124,14 @@ VANILLAPDF_API error_type CALLING_CONVENTION FlateDecodeFilter_Decode(FlateDecod
     FilterBaseHandle* base_filter_handle = reinterpret_cast<FilterBaseHandle*>(base_filter);
 
     return FilterBase_Decode(base_filter_handle, data_handle, result);
+}
+
+VANILLAPDF_API error_type CALLING_CONVENTION FlateDecodeFilter_DecodeParams(FlateDecodeFilterHandle* handle, BufferHandle* data_handle, DictionaryObjectHandle* parameters_handle, BufferHandle** result) {
+    FlateDecodeFilter* filter = reinterpret_cast<FlateDecodeFilter*>(handle);
+    FilterBase* base_filter = static_cast<FilterBase*>(filter);
+    FilterBaseHandle* base_filter_handle = reinterpret_cast<FilterBaseHandle*>(base_filter);
+
+    return FilterBase_DecodeParams(base_filter_handle, data_handle, parameters_handle, result);
 }
 
 VANILLAPDF_API error_type CALLING_CONVENTION FlateDecodeFilter_Release(FlateDecodeFilterHandle* handle) {

--- a/src/vanillapdf/syntax/filters/flate_decode_filter.cpp
+++ b/src/vanillapdf/syntax/filters/flate_decode_filter.cpp
@@ -67,7 +67,8 @@ BufferPtr FlateDecodeFilter::ApplyPredictor(IInputStreamPtr src, types::stream_s
     syntax::IntegerObjectPtr bits = make_deferred<IntegerObject>(8);
     if (parameters->Contains(constant::Name::BitsPerComponent)) {
         bits = parameters->FindAs<IntegerObjectPtr>(constant::Name::BitsPerComponent);
-        assert(*bits == 1 || *bits == 2 || *bits == 4 || *bits == 8);
+        // PDF 32000-1 Table 8: valid values are 1, 2, 4, 8 and (PDF 1.5) 16
+        assert(*bits == 1 || *bits == 2 || *bits == 4 || *bits == 8 || *bits == 16);
     }
 
     IntegerObjectPtr columns = make_deferred<IntegerObject>(1);
@@ -146,7 +147,7 @@ BufferPtr FlateDecodeFilter::ApplyPredictor(IInputStreamPtr src, types::stream_s
                     uint32_t added_value = (current_byte + prior_byte);
                     auto divided_value = (added_value / 2.0f);
                     auto rounded_value = std::floor(divided_value);
-                    current[i] += static_cast<uint8_t>(rounded_value);
+                    current[bytes_per_pixel + i] += static_cast<uint8_t>(rounded_value);
                 }
 
                 break;
@@ -178,7 +179,7 @@ BufferPtr FlateDecodeFilter::ApplyPredictor(IInputStreamPtr src, types::stream_s
                         value = c;
                     }
 
-                    current[i] += value;
+                    current[bytes_per_pixel + i] += value;
                 }
 
                 break;


### PR DESCRIPTION
Manual backport of #440 to `release/2.2`. The automated backport workflow failed (run [29279999159](https://github.com/vanillapdf/vanillapdf/actions/runs/29279999159)) because the cherry-pick conflicted.

## Why the automated cherry-pick failed

Both conflicts were context-only, not semantic — `release/2.2` simply predates two unrelated changes that exist on `main`:

1. `include/vanillapdf/syntax/c_filter.h` and `src/vanillapdf/implementation/syntax/c_filter.cpp` — the new `FilterBase_DecodeParams` declaration/definition sits next to `FilterBase_ToUnknown` / `FilterBase_FromUnknown`, which do not exist on `release/2.2`. Git pulled those neighbours in as context. Resolved by taking only the `DecodeParams` additions; `ToUnknown` / `FromUnknown` are **not** backported.
2. `src/vanillapdf.unittest/filter_test.cpp` — auto-merged textually but did not compile, because the test uses the `HandleGuard` RAII wrapper introduced on `main` by a later test-infrastructure refactor. `#include "handle_guard.h"` was pre-existing context on `main`, so the cherry-pick never carried it.

## Contents

- `fix: Correct PNG Average/Paeth predictor reconstruction in FlateDecode (#440)` — the cherry-picked upstream commit, conflicts resolved as above. The library fix, the `FilterBase_DecodeParams` / `FlateDecodeFilter_DecodeParams` C API addition (additive, non-breaking), and the `PngPredictorReconstructionTest` vectors are all identical to `main`.
- `test: Add HandleGuard RAII helper required by backported filter tests` — adds `src/vanillapdf.unittest/handle_guard.h` (and registers it in the unittest CMake list) so the backported test compiles unchanged. Only the header is added; the wider refactor of the other test files is deliberately left out to keep the release branch minimal. Test-only, no shipping code.

## Verification on this branch (windows-x64-msvc-18, Debug)

- Builds clean.
- `ctest -R "Filter|Predictor"` — 16/16 pass, including all five PNG filter cases (None/Sub/Up/Average/Paeth).
- **Negative check:** with the `flate_decode_filter.cpp` fix reverted and rebuilt against this branch, exactly the Average and Paeth cases fail while None/Sub/Up still pass — confirming the backported test actually detects the defect on the 2.2 codebase, not merely that it is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)