### PR TITLE
ci: Flag failed auto-backports with a backport-failed label

### DIFF
--- a/.claude/rules/ci-cd.md
+++ b/.claude/rules/ci-cd.md
@@ -34,7 +34,33 @@ Windows 2022/2025 (x86/x64), Linux Ubuntu 22.04/24.04, Rocky 8/9, Fedora 41/42 (
 
 ## Backporting
 
-Add label `backport release/X.Y` to a PR before merging. The workflow cherry-picks and creates a backport PR automatically. If cherry-pick fails, manually create the backport.
+Add label `backport release/X.Y` to a PR **before merging**. On merge, `backport.yml` cherry-picks the squash commit onto `release/X.Y` and opens a backport PR automatically.
+
+**Label lifecycle** (driven by `backport.yml` + `.github/scripts/backport.sh`):
+- `backport release/X.Y` — request: backport this PR to that branch.
+- `backported release/X.Y` — applied automatically when the backport PR **merges** (removes the `backport` label). Only fires when the backport PR title is `[Backport release/X.Y] …` and its body contains `Backport of #<original>` — keep that format so the automation runs.
+- `backport-failed release/X.Y` — applied automatically when the auto cherry-pick **fails**. This is the queryable signal that a manual backport is owed.
+
+**Find backports that still need attention:**
+```bash
+gh pr list --state all --label "backport-failed release/2.2"
+```
+The label is not auto-cleared, so remove it by hand once the manual backport is done (or as part of doing it).
+
+**Manual backport** (when the auto cherry-pick conflicts — common when the release branch predates a feature the PR was built on):
+```bash
+git fetch origin
+git checkout -b backport/<PR>-release-2.2 origin/release/2.2
+git cherry-pick -x <squash-merge-commit-of-original-PR>   # resolve conflicts
+# Drop parts that don't belong on the older branch (e.g. code for features not on release/X.Y).
+git push origin backport/<PR>-release-2.2
+gh pr create --base release/2.2 \
+  --title "[Backport release/2.2] <original title> (#<PR>)" \
+  --body-file <body>   # body must contain: Backport of #<PR> to `release/2.2`
+```
+Build and run the affected tests against the release branch before opening the PR — release branches diverge from `main`.
+
+**When creating a new `release/X.Y` branch**, also create its three labels (`backport release/X.Y`, `backported release/X.Y`, `backport-failed release/X.Y`) — they are created manually, and `backport.sh` applies `backport-failed` with a bare `gh` call that assumes the label exists.
 
 ## Homebrew
 

--- a/.github/scripts/backport.sh
+++ b/.github/scripts/backport.sh
@@ -144,6 +144,7 @@ process_target() {
     # Check if target branch exists
     if ! check_target_branch "$target"; then
         gh pr comment "$PR_NUMBER" --body "❌ Backport to \`$target\` failed: branch does not exist."
+        gh pr edit "$PR_NUMBER" --add-label "backport-failed $target"
         echo "::endgroup::"
         return 1
     fi
@@ -158,6 +159,7 @@ process_target() {
         else
             echo "::error::Push or PR creation failed for $target"
             post_push_failure_comment "$target" "$branch_name"
+            gh pr edit "$PR_NUMBER" --add-label "backport-failed $target"
             result=1
         fi
     else
@@ -165,6 +167,7 @@ process_target() {
         git cherry-pick --abort 2>/dev/null || true
         echo "::error::Cherry-pick failed for $target (likely conflicts)"
         post_failure_comment "$target" "$branch_name"
+        gh pr edit "$PR_NUMBER" --add-label "backport-failed $target"
         result=1
     fi
 


### PR DESCRIPTION
## Summary

When the automated backport (`backport.yml` → `backport.sh`) can't cherry-pick a merged PR onto a release branch, the only signal today is a **comment** on the original PR — which is easy to miss and not filterable. This adds a queryable **`backport-failed <branch>`** label on each failure path, so outstanding backports can always be found:

```bash
gh pr list --label "backport-failed release/2.2"
```

## Change

Three lines in `backport.sh`, one per failure path (branch missing, cherry-pick conflict, push/PR-creation error):

```bash
gh pr edit "$PR_NUMBER" --add-label "backport-failed $target"
```

Applied in the same bare style as the adjacent `gh pr comment` calls (no new helpers, no behavior change to the happy path). The `backport-failed release/2.1` and `backport-failed release/2.2` labels have been pre-created in the repo, matching how the sibling `backport` / `backported` labels already exist.

## Documentation

Expands the **Backporting** section of `.claude/rules/ci-cd.md` with the label lifecycle (`backport` → `backported` / `backport-failed`), how to find backports still owed (`gh pr list --label "backport-failed release/X.Y"`), the manual-backport steps, and the label setup needed when creating a new release branch.

## Notes / follow-ups (not in this PR)

- **Auto-clearing** the label when a backport is later completed is intentionally left out to keep this minimal. For now the label is removed manually (or as part of doing the manual backport). Can be added to the workflow's label step later if wanted.
- Retroactive scan surfaced one genuine miss that predates this label: **#419** ("Overwrite stale Limits key on TreeBase::Rebuild") — its backport #426 was closed, not merged, so it's not on `release/2.2`. Worth deciding whether to re-backport or confirm it was intentional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
