### PR TITLE
ci: Add job timeouts to prevent 6-hour runner hangs

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -13,6 +13,7 @@ jobs:
   create-backport:
     name: Create Backport PR
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     if: |
       github.event.pull_request.merged == true &&
       !startsWith(github.event.pull_request.title, '[Backport')
@@ -65,6 +66,7 @@ jobs:
   update-labels:
     name: Update Backport Labels
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     if: |
       github.event.pull_request.merged == true &&
       startsWith(github.event.pull_request.title, '[Backport')

--- a/.github/workflows/build-brew-package.yml
+++ b/.github/workflows/build-brew-package.yml
@@ -18,6 +18,7 @@ jobs:
   build-package:
     name: Build package
     runs-on: macos-26
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 

--- a/.github/workflows/build-deb-package.yml
+++ b/.github/workflows/build-deb-package.yml
@@ -18,6 +18,7 @@ jobs:
   build-package:
     name: Build package
     runs-on: ubuntu-latest
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
@@ -61,6 +62,7 @@ jobs:
   install-package:
     name: Install package
     runs-on: ubuntu-latest
+    timeout-minutes: 90
     needs: build-package
     steps:
       - name: Download Artifact

--- a/.github/workflows/build-nuget.yml
+++ b/.github/workflows/build-nuget.yml
@@ -67,6 +67,7 @@ jobs:
   build-linux:
     name: ${{ matrix.config.name }}
     runs-on: ${{ matrix.config.os }}
+    timeout-minutes: 90
 
     strategy:
       fail-fast: false
@@ -153,6 +154,7 @@ jobs:
   build-windows:
     name: ${{ matrix.config.name }}
     runs-on: ${{ matrix.config.os }}
+    timeout-minutes: 90
 
     strategy:
       fail-fast: false
@@ -236,6 +238,7 @@ jobs:
   build-macos:
     name: ${{ matrix.config.name }}
     runs-on: ${{ matrix.config.runner }}
+    timeout-minutes: 90
 
     strategy:
       fail-fast: false
@@ -321,6 +324,7 @@ jobs:
   build-vanillapdf-core:
     name: vanillapdf core
     runs-on: ubuntu-latest
+    timeout-minutes: 90
 
     needs:
       - build-linux

--- a/.github/workflows/build-rpm-package.yml
+++ b/.github/workflows/build-rpm-package.yml
@@ -18,6 +18,7 @@ jobs:
   build-package:
     name: Build package
     runs-on: ubuntu-latest
+    timeout-minutes: 90
     container: rockylinux/rockylinux:10
     steps:
       - name: Install build tools and system dependencies
@@ -69,6 +70,7 @@ jobs:
   install-package:
     name: Install package
     runs-on: ubuntu-latest
+    timeout-minutes: 90
     needs: build-package
     container: rockylinux/rockylinux:10
     steps:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -45,6 +45,7 @@ jobs:
     #   - https://gh.io/using-larger-runners (GitHub.com only)
     # Consider using larger runners or machines with greater resources for possible analysis time improvements.
     runs-on: ${{ (matrix.language == 'swift' && 'macos-26') || 'ubuntu-24.04' }}
+    timeout-minutes: 90
     permissions:
       # required for all workflows
       security-events: write

--- a/.github/workflows/conformance-check.yml
+++ b/.github/workflows/conformance-check.yml
@@ -33,6 +33,7 @@ jobs:
   linux:
     name: ubuntu.26.04-x64
     runs-on: ubuntu-24.04
+    timeout-minutes: 90
     container:
       image: ghcr.io/vanillapdf/vanillapdf-ubuntu:26.04
       options: --platform=linux/amd64
@@ -80,6 +81,7 @@ jobs:
   windows:
     name: win.2025-x64-static
     runs-on: windows-2025
+    timeout-minutes: 90
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
@@ -119,6 +121,7 @@ jobs:
   macos:
     name: osx.26-arm64
     runs-on: macos-26
+    timeout-minutes: 90
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -44,6 +44,7 @@ concurrency:
 jobs:
   coverage:
     runs-on: ubuntu-24.04
+    timeout-minutes: 90
     permissions:
       contents: read        # Download the repository source code
       statuses: write       # Required for Codecov to post coverage status

--- a/.github/workflows/create-conan-pr.yml
+++ b/.github/workflows/create-conan-pr.yml
@@ -30,6 +30,7 @@ jobs:
   prepare-conan-changes:
     name: Prepare Conan Center update
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     outputs:
       branch-name: vanillapdf-${{ steps.version.outputs.version }}
       pr-url: ${{ steps.pr-info.outputs.pr-url }}
@@ -158,6 +159,7 @@ jobs:
   create-official-pr:
     name: Create PR to Conan Center Index
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     needs: prepare-conan-changes
     if: ${{ !inputs.dry_run && needs.prepare-conan-changes.outputs.is_latest == 'true' }}
     environment: production

--- a/.github/workflows/create-vcpkg-pr.yml
+++ b/.github/workflows/create-vcpkg-pr.yml
@@ -30,6 +30,7 @@ jobs:
   prepare-vcpkg-changes:
     name: Prepare vcpkg update changes
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     outputs:
       branch-name: update-vanillapdf-${{ inputs.tag }}
       pr-url: ${{ steps.pr-info.outputs.pr-url }}
@@ -148,6 +149,7 @@ jobs:
   create-official-pr:
     name: Create PR to official vcpkg repo
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     needs: prepare-vcpkg-changes
     if: ${{ !inputs.dry_run }}
     environment: production

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -11,6 +11,7 @@ permissions:
 jobs:
   dependency-review:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0

--- a/.github/workflows/encryption-interop-check.yml
+++ b/.github/workflows/encryption-interop-check.yml
@@ -33,6 +33,7 @@ jobs:
   pyhanko:
     name: pyhanko / ubuntu.26.04-x64
     runs-on: ubuntu-24.04
+    timeout-minutes: 90
     container:
       image: ghcr.io/vanillapdf/vanillapdf-ubuntu:26.04
       options: --platform=linux/amd64
@@ -80,6 +81,7 @@ jobs:
   qpdf:
     name: qpdf / ubuntu.26.04-x64
     runs-on: ubuntu-24.04
+    timeout-minutes: 90
     container:
       image: ghcr.io/vanillapdf/vanillapdf-ubuntu:26.04
       options: --platform=linux/amd64

--- a/.github/workflows/examples-integration.yml
+++ b/.github/workflows/examples-integration.yml
@@ -46,6 +46,7 @@ jobs:
   setup:
     name: Setup Git Reference
     runs-on: ubuntu-latest
+    timeout-minutes: 90
     outputs:
       git_tag: ${{ steps.git_ref.outputs.git_tag }}
       version: ${{ steps.version.outputs.version }}
@@ -87,6 +88,7 @@ jobs:
   fetchcontent-linux:
     name: FetchContent - Linux ${{ matrix.preset }}
     runs-on: ubuntu-latest
+    timeout-minutes: 90
     needs: setup
 
     strategy:
@@ -125,6 +127,7 @@ jobs:
   fetchcontent-windows:
     name: FetchContent - Windows ${{ matrix.preset }}
     runs-on: windows-latest
+    timeout-minutes: 90
     needs: setup
 
     strategy:
@@ -163,6 +166,7 @@ jobs:
   fetchcontent-macos:
     name: FetchContent - macOS ${{ matrix.preset }}
     runs-on: macos-26
+    timeout-minutes: 90
     needs: setup
 
     strategy:
@@ -203,6 +207,7 @@ jobs:
   vcpkg-port-linux:
     name: vcpkg Port - Linux ${{ matrix.preset }}
     runs-on: ubuntu-latest
+    timeout-minutes: 90
 
     strategy:
       fail-fast: false
@@ -250,6 +255,7 @@ jobs:
   vcpkg-port-windows:
     name: vcpkg Port - Windows ${{ matrix.preset }}
     runs-on: windows-latest
+    timeout-minutes: 90
 
     strategy:
       fail-fast: false
@@ -301,6 +307,7 @@ jobs:
   vcpkg-port-macos:
     name: vcpkg Port - macOS ${{ matrix.preset }}
     runs-on: macos-26
+    timeout-minutes: 90
 
     strategy:
       fail-fast: false
@@ -350,6 +357,7 @@ jobs:
   homebrew-macos:
     name: Homebrew - macOS ${{ matrix.preset }}
     runs-on: ${{ matrix.runner }}
+    timeout-minutes: 90
 
     strategy:
       fail-fast: false
@@ -410,6 +418,7 @@ jobs:
   conan-linux:
     name: Conan - Linux ${{ matrix.build_type }}
     runs-on: ubuntu-24.04
+    timeout-minutes: 90
     needs: setup
     permissions:
       contents: read
@@ -460,6 +469,7 @@ jobs:
   conan-windows:
     name: Conan - Windows ${{ matrix.build_type }}
     runs-on: windows-latest
+    timeout-minutes: 90
     needs: setup
 
     strategy:
@@ -513,6 +523,7 @@ jobs:
   conan-macos:
     name: Conan - macOS ${{ matrix.build_type }}
     runs-on: macos-26
+    timeout-minutes: 90
     needs: setup
 
     strategy:

--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -32,6 +32,7 @@ env:
 jobs:
   fuzz:
     runs-on: ubuntu-24.04
+    timeout-minutes: 90
     name: fuzz (${{ matrix.name }})
     strategy:
       fail-fast: false

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -45,6 +45,7 @@ jobs:
   # Build job
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
@@ -78,6 +79,7 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
 
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     needs: build
     steps:
       - name: Deploy to GitHub Pages

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -44,6 +44,7 @@ jobs:
   github-release:
     name: Create GitHub Release
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     permissions:
       contents: write       # Required to create a release and upload assets
       id-token: write       # Required for Sigstore keyless signing

--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -22,6 +22,7 @@ jobs:
   validate:
     name: Validate PR title
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - name: Validate against Conventional Commits
         uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1

--- a/.github/workflows/nightly-check.yml
+++ b/.github/workflows/nightly-check.yml
@@ -46,6 +46,7 @@ jobs:
   linux:
     name: ${{ matrix.config.name }} - ${{ matrix.build_type }}
     runs-on: ${{ matrix.config.os }}
+    timeout-minutes: 90
 
     strategy:
       fail-fast: false
@@ -194,6 +195,7 @@ jobs:
   windows:
     name: ${{ matrix.config.name }} - ${{ matrix.build_type }}
     runs-on: ${{ matrix.config.os }}
+    timeout-minutes: 90
 
     strategy:
       fail-fast: false
@@ -249,6 +251,7 @@ jobs:
   macos:
     name: ${{ matrix.config.name }} - ${{ matrix.build_type }}
     runs-on: ${{ matrix.config.runner }}
+    timeout-minutes: 90
 
     strategy:
       fail-fast: false

--- a/.github/workflows/nightly-nuget.yml
+++ b/.github/workflows/nightly-nuget.yml
@@ -30,6 +30,7 @@ jobs:
 
   check-changes:
     runs-on: ubuntu-latest
+    timeout-minutes: 90
     permissions:
       contents: read
     outputs:
@@ -66,6 +67,7 @@ jobs:
     needs: check-changes
     if: needs.check-changes.outputs.has_changes == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 90
     outputs:
       nightly_suffix: ${{ steps.set-suffix.outputs.nightly_suffix }}
       build_date: ${{ steps.set-suffix.outputs.build_date }}
@@ -100,6 +102,7 @@ jobs:
   push-nuget-staging:
     name: Push NuGet Packages
     runs-on: ubuntu-latest
+    timeout-minutes: 90
     permissions:
       packages: write
     environment:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,7 @@ permissions: {}
 jobs:
   prepare:
     runs-on: ubuntu-latest
+    timeout-minutes: 90
     permissions:
       contents: read
     outputs:
@@ -116,6 +117,7 @@ jobs:
 
   verify:
     runs-on: ubuntu-latest
+    timeout-minutes: 90
     permissions:
       contents: read
     needs: prepare
@@ -177,6 +179,7 @@ jobs:
 
   nuget-staging:
     runs-on: ubuntu-latest
+    timeout-minutes: 90
     permissions:
       packages: write
     environment: staging
@@ -230,6 +233,7 @@ jobs:
 
   dry-run-report:
     runs-on: ubuntu-latest
+    timeout-minutes: 90
     permissions: {}
     needs: [build-nuget, build-deb, build-rpm, build-dmg, dry-run-pages, dry-run-vcpkg, dry-run-conan, prepare]
     if: always() && needs.prepare.outputs.dry_run == 'true'
@@ -293,6 +297,7 @@ jobs:
 
   production-gate:
     runs-on: ubuntu-latest
+    timeout-minutes: 90
     permissions: {}
     needs: [create-draft-release, prepare]
     environment: production
@@ -309,6 +314,7 @@ jobs:
   # the tag can be created under any tag protection rulesets.
   publish-release:
     runs-on: ubuntu-latest
+    timeout-minutes: 90
     permissions:
       contents: write
     needs: production-gate
@@ -333,6 +339,7 @@ jobs:
 
   publish-nuget:
     runs-on: ubuntu-latest
+    timeout-minutes: 90
     permissions:
       id-token: write  # Enable GitHub OIDC token issuance for NuGet trusted publishing
     needs: publish-release
@@ -412,6 +419,7 @@ jobs:
   attest:
     name: Attest Release Artifacts
     runs-on: ubuntu-latest
+    timeout-minutes: 90
     permissions:
       id-token: write
       attestations: write
@@ -453,6 +461,7 @@ jobs:
   verify-attest:
     name: Verify Artifact Attestations
     runs-on: ubuntu-latest
+    timeout-minutes: 90
     permissions:
       contents: read
     needs: attest
@@ -497,6 +506,7 @@ jobs:
   update-port:
     name: Update Local Port
     runs-on: ubuntu-latest
+    timeout-minutes: 90
     permissions:
       contents: read
     needs: publish-release

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -31,6 +31,7 @@ jobs:
   vcpkg-setup:
     name: Install vcpkg dependencies
     runs-on: ubuntu-24.04
+    timeout-minutes: 90
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
@@ -68,6 +69,7 @@ jobs:
     name: ${{ matrix.name }}
     needs: vcpkg-setup
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 90
 
     strategy:
       fail-fast: false

--- a/.github/workflows/sanity-check.yml
+++ b/.github/workflows/sanity-check.yml
@@ -54,6 +54,7 @@ jobs:
   linux:
     name: ${{ matrix.config.name }} - ${{ matrix.build_type }}
     runs-on: ${{ matrix.config.os }}
+    timeout-minutes: 90
 
     strategy:
       fail-fast: false # We would like to see the results of all jobs even in case one of them fails
@@ -124,6 +125,7 @@ jobs:
   windows:
     name: ${{ matrix.config.name }} - ${{ matrix.build_type }}
     runs-on: windows-2025
+    timeout-minutes: 90
 
     strategy:
       fail-fast: false # We would like to see the results of all jobs even in case one of them fails
@@ -172,6 +174,7 @@ jobs:
   macos:
     name: ${{ matrix.config.name }} - ${{ matrix.build_type }}
     runs-on: ${{ matrix.config.runner }}
+    timeout-minutes: 90
 
     strategy:
       fail-fast: false # We would like to see the results of all jobs even in case one of them fails

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -21,6 +21,7 @@ jobs:
   scorecard:
     name: Scorecard analysis
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     permissions:
       security-events: write
       id-token: write

--- a/.github/workflows/signature-interop-check.yml
+++ b/.github/workflows/signature-interop-check.yml
@@ -33,6 +33,7 @@ jobs:
   interop:
     name: ubuntu.26.04-x64
     runs-on: ubuntu-24.04
+    timeout-minutes: 90
     container:
       image: ghcr.io/vanillapdf/vanillapdf-ubuntu:26.04
       options: --platform=linux/amd64

--- a/.github/workflows/update-homebrew.yml
+++ b/.github/workflows/update-homebrew.yml
@@ -30,6 +30,7 @@ jobs:
   prepare-homebrew-changes:
     name: Prepare Homebrew formula update
     runs-on: macos-26
+    timeout-minutes: 60
     outputs:
       branch-name: vanillapdf-${{ steps.version.outputs.version }}
       pr-url: ${{ steps.pr-info.outputs.pr-url }}
@@ -179,6 +180,7 @@ jobs:
   create-official-pr:
     name: Create PR to official Homebrew repo
     runs-on: macos-26
+    timeout-minutes: 60
     needs: prepare-homebrew-changes
     if: ${{ !inputs.dry_run && needs.prepare-homebrew-changes.outputs.is-latest == 'true' }}
     environment: production

--- a/.github/workflows/update-vcpkg.yml
+++ b/.github/workflows/update-vcpkg.yml
@@ -32,6 +32,7 @@ jobs:
   update-vcpkg:
     name: Check and update vcpkg
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0

--- a/.github/workflows/validate-workflows.yml
+++ b/.github/workflows/validate-workflows.yml
@@ -16,6 +16,7 @@ jobs:
   yaml-lint:
     name: YAML syntax
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     permissions:
       contents: read
 


### PR DESCRIPTION
## Problem

No workflow in the repo sets `timeout-minutes` on any job, so all 79 jobs inherit GitHub's **360-minute default**.

In nightly run [29226114437](https://github.com/vanillapdf/vanillapdf/actions/runs/29226114437), the `osx.26-x64 - Debug` job hung for the full six hours before being cancelled, while all 59 sibling jobs in the same matrix finished within 20 minutes. macOS runners bill at 10x, so a single hang like this burns ~3,600 billable minutes.

## Change

Adds `timeout-minutes` to every job, in two tiers. Purely additive — 66 insertions, 0 deletions.

| Tier | Applies to | Cap |
|---|---|---|
| Heavy | Workflows that compile the library or run test matrices | **90m** |
| Light | Lint, metadata, release-admin jobs | **60m** |

## Sizing

Caps are derived from per-job durations measured over the last 30 runs of each workflow, not guessed:

| Workflow | Median | Worst observed |
|---|---|---|
| sanitizers (TSan) | 13m | **48m** |
| coverage | 9m | **40m** |
| nightly-check (osx) | 9m | **40m** |
| examples-integration | 5m | 33m |
| sanity-check | 8m | 27m |
| build-nuget | 7m | 23m |
| fuzzing | 12m | 14m |
| lint / scorecard / validate | <1m | 1m |

90m gives the heavy tier roughly 2x its worst observed job.

### Cold vcpkg cache fits

The cache key is `hashFiles('vcpkg.json.in')`, so a baseline bump rebuilds all dependencies from source. Checked against the 2026.06.24 bump (#412), which invalidated it: the slowest job there was **30m** (`Conan - Windows Debug`), with the rest at 12–20m. Rebuilding dependencies is comfortably inside the 90m cap — the binding constraint is slow-runner outliers on a warm cache, not cold-cache rebuilds.

## Notes

13 jobs invoke a reusable workflow via `uses:`. `timeout-minutes` cannot be set at the call site, but those jobs are covered transitively by the timeouts now present on the called workflow's own jobs.

Verified with the repo's own linter: `python scripts/validate_workflows.py .github/workflows/*.yml` → `All 27 workflow files are valid YAML`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
