### PR TITLE
fix: Make XrefEntry_InUse report entry usage instead of lazy-load flag

### DIFF
--- a/include/vanillapdf/syntax/c_xref.h
+++ b/include/vanillapdf/syntax/c_xref.h
@@ -322,6 +322,11 @@ extern "C"
 
     /**
     * \brief Quick check, if the entry is used or compressed
+    *
+    * Returns VANILLAPDF_RV_TRUE for used and compressed entries and VANILLAPDF_RV_FALSE for free entries.
+    * The result is derived from the entry type, therefore the referenced object is not parsed.
+    *
+    * To tell used and compressed entries apart, use \ref XrefEntry_GetType.
     */
     VANILLAPDF_API error_type CALLING_CONVENTION XrefEntry_InUse(XrefEntryHandle* handle, boolean_type* result);
 

--- a/src/vanillapdf.unittest/CMakeLists.txt
+++ b/src/vanillapdf.unittest/CMakeLists.txt
@@ -49,6 +49,12 @@ set(VANILLAPDF_UNITTEST_SOURCES
     content_stream_test.cpp
 )
 
+# Tests are gradually being moved out of the flat list above
+# into folders mirroring the library layers - syntax, semantics, contents and utils
+set(VANILLAPDF_UNITTEST_SYNTAX_SOURCES
+    syntax/xref_test.cpp
+)
+
 set(VANILLAPDF_UNITTEST_HEADERS
     unittest.h
     test_data.h
@@ -69,9 +75,14 @@ source_group("Source Files" FILES
     ${VANILLAPDF_UNITTEST_SOURCES}
 )
 
+source_group("Source Files\\syntax" FILES
+    ${VANILLAPDF_UNITTEST_SYNTAX_SOURCES}
+)
+
 add_executable(vanillapdf.unittest
     ${VANILLAPDF_UNITTEST_HEADERS}
     ${VANILLAPDF_UNITTEST_SOURCES}
+    ${VANILLAPDF_UNITTEST_SYNTAX_SOURCES}
     ${VANILLAPDF_UNITTEST_RESOURCE_FILES}
 )
 

--- a/src/vanillapdf.unittest/main.cpp
+++ b/src/vanillapdf.unittest/main.cpp
@@ -344,69 +344,6 @@ TEST(MemoryBufferOutputStream, Flush) {
     EXPECT_EQ(MemoryBufferOutputStream_Flush(stream_ptr), VANILLAPDF_ERROR_SUCCESS);
 }
 
-namespace xref {
-
-TEST(Xref, CreateRelease) {
-    HandleGuard<XrefHandle, Xref_Release> xref_ptr;
-
-    ASSERT_EQ(Xref_Create(xref_ptr.out()), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_NE(xref_ptr.get(), nullptr);
-}
-
-TEST(Xref, NullCheck) {
-    EXPECT_EQ(Xref_Create(nullptr), VANILLAPDF_ERROR_PARAMETER_VALUE);
-    EXPECT_EQ(Xref_Release(nullptr), VANILLAPDF_ERROR_PARAMETER_VALUE);
-}
-
-TEST(Xref, AddRemoveEntry) {
-    HandleGuard<XrefHandle, Xref_Release> xref_ptr;
-
-    HandleGuard<XrefEntryHandle, XrefEntry_Release> xref_entry_ptr;
-    HandleGuard<XrefFreeEntryHandle, XrefFreeEntry_Release> xref_free_entry_ptr;
-
-    boolean_type remove_result = VANILLAPDF_RV_FALSE;
-    boolean_type contains_result = VANILLAPDF_RV_FALSE;
-
-    ASSERT_EQ(Xref_Create(xref_ptr.out()), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_NE(xref_ptr.get(), nullptr);
-
-    ASSERT_EQ(XrefFreeEntry_Create(1, 0, 65535, xref_free_entry_ptr.out()), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_NE(xref_free_entry_ptr.get(), nullptr);
-
-    ASSERT_EQ(XrefFreeEntry_ToEntry(xref_free_entry_ptr, xref_entry_ptr.out()), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_NE(xref_entry_ptr.get(), nullptr);
-
-    ASSERT_EQ(Xref_Insert(xref_ptr, xref_entry_ptr), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Xref_Contains(xref_ptr, 1, &contains_result), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Xref_Remove(xref_ptr, 1, &remove_result), VANILLAPDF_ERROR_SUCCESS);
-
-    EXPECT_EQ(contains_result, VANILLAPDF_RV_TRUE);
-    EXPECT_EQ(remove_result, VANILLAPDF_RV_TRUE);
-}
-
-TEST(XrefFreeEntry, CreateRelease) {
-    HandleGuard<XrefFreeEntryHandle, XrefFreeEntry_Release> xref_free_entry_ptr;
-
-    ASSERT_EQ(XrefFreeEntry_Create(0, 0, 0, xref_free_entry_ptr.out()), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_NE(xref_free_entry_ptr.get(), nullptr);
-}
-
-TEST(XrefUsedEntry, CreateRelease) {
-    HandleGuard<XrefUsedEntryHandle, XrefUsedEntry_Release> xref_used_entry_ptr;
-
-    ASSERT_EQ(XrefUsedEntry_Create(0, 0, 0, xref_used_entry_ptr.out()), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_NE(xref_used_entry_ptr.get(), nullptr);
-}
-
-TEST(XrefCompressedEntry, CreateRelease) {
-    HandleGuard<XrefCompressedEntryHandle, XrefCompressedEntry_Release> xref_compressed_entry_ptr;
-
-    ASSERT_EQ(XrefCompressedEntry_Create(0, 0, 0, 0, xref_compressed_entry_ptr.out()), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_NE(xref_compressed_entry_ptr.get(), nullptr);
-}
-
-} /* xref */
-
 int main(int argc, char *argv[]) {
 
     TestEnvironment* test_environment = new TestEnvironment();

--- a/src/vanillapdf.unittest/syntax/xref_test.cpp
+++ b/src/vanillapdf.unittest/syntax/xref_test.cpp
@@ -1,0 +1,169 @@
+#include "unittest.h"
+#include "handle_guard.h"
+
+#include <string>
+
+namespace xref {
+
+TEST(Xref, CreateRelease) {
+    HandleGuard<XrefHandle, Xref_Release> xref_ptr;
+
+    ASSERT_EQ(Xref_Create(xref_ptr.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_NE(xref_ptr.get(), nullptr);
+}
+
+TEST(Xref, NullCheck) {
+    EXPECT_EQ(Xref_Create(nullptr), VANILLAPDF_ERROR_PARAMETER_VALUE);
+    EXPECT_EQ(Xref_Release(nullptr), VANILLAPDF_ERROR_PARAMETER_VALUE);
+}
+
+TEST(Xref, AddRemoveEntry) {
+    HandleGuard<XrefHandle, Xref_Release> xref_ptr;
+
+    HandleGuard<XrefEntryHandle, XrefEntry_Release> xref_entry_ptr;
+    HandleGuard<XrefFreeEntryHandle, XrefFreeEntry_Release> xref_free_entry_ptr;
+
+    boolean_type remove_result = VANILLAPDF_RV_FALSE;
+    boolean_type contains_result = VANILLAPDF_RV_FALSE;
+
+    ASSERT_EQ(Xref_Create(xref_ptr.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_NE(xref_ptr.get(), nullptr);
+
+    ASSERT_EQ(XrefFreeEntry_Create(1, 0, 65535, xref_free_entry_ptr.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_NE(xref_free_entry_ptr.get(), nullptr);
+
+    ASSERT_EQ(XrefFreeEntry_ToEntry(xref_free_entry_ptr, xref_entry_ptr.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_NE(xref_entry_ptr.get(), nullptr);
+
+    ASSERT_EQ(Xref_Insert(xref_ptr, xref_entry_ptr), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Xref_Contains(xref_ptr, 1, &contains_result), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Xref_Remove(xref_ptr, 1, &remove_result), VANILLAPDF_ERROR_SUCCESS);
+
+    EXPECT_EQ(contains_result, VANILLAPDF_RV_TRUE);
+    EXPECT_EQ(remove_result, VANILLAPDF_RV_TRUE);
+}
+
+TEST(XrefFreeEntry, CreateRelease) {
+    HandleGuard<XrefFreeEntryHandle, XrefFreeEntry_Release> xref_free_entry_ptr;
+
+    ASSERT_EQ(XrefFreeEntry_Create(0, 0, 0, xref_free_entry_ptr.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_NE(xref_free_entry_ptr.get(), nullptr);
+}
+
+TEST(XrefUsedEntry, CreateRelease) {
+    HandleGuard<XrefUsedEntryHandle, XrefUsedEntry_Release> xref_used_entry_ptr;
+
+    ASSERT_EQ(XrefUsedEntry_Create(0, 0, 0, xref_used_entry_ptr.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_NE(xref_used_entry_ptr.get(), nullptr);
+}
+
+TEST(XrefCompressedEntry, CreateRelease) {
+    HandleGuard<XrefCompressedEntryHandle, XrefCompressedEntry_Release> xref_compressed_entry_ptr;
+
+    ASSERT_EQ(XrefCompressedEntry_Create(0, 0, 0, 0, xref_compressed_entry_ptr.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_NE(xref_compressed_entry_ptr.get(), nullptr);
+}
+
+typedef error_type (*EntryFactory)(XrefEntryHandle** result);
+
+static error_type CreateFreeEntry(XrefEntryHandle** result) {
+    HandleGuard<XrefFreeEntryHandle, XrefFreeEntry_Release> entry;
+
+    error_type error = XrefFreeEntry_Create(0, 65535, 0, entry.out());
+    if (error != VANILLAPDF_ERROR_SUCCESS) {
+        return error;
+    }
+
+    return XrefFreeEntry_ToEntry(entry, result);
+}
+
+static error_type CreateUsedEntry(XrefEntryHandle** result) {
+    HandleGuard<XrefUsedEntryHandle, XrefUsedEntry_Release> entry;
+
+    error_type error = XrefUsedEntry_Create(1, 0, 0, entry.out());
+    if (error != VANILLAPDF_ERROR_SUCCESS) {
+        return error;
+    }
+
+    return XrefUsedEntry_ToEntry(entry, result);
+}
+
+static error_type CreateCompressedEntry(XrefEntryHandle** result) {
+    HandleGuard<XrefCompressedEntryHandle, XrefCompressedEntry_Release> entry;
+
+    error_type error = XrefCompressedEntry_Create(2, 0, 1, 0, entry.out());
+    if (error != VANILLAPDF_ERROR_SUCCESS) {
+        return error;
+    }
+
+    return XrefCompressedEntry_ToEntry(entry, result);
+}
+
+struct InUseTestCase {
+    InUseTestCase(const char* name, EntryFactory factory, XrefEntryType type, boolean_type expected_in_use)
+        : name(name), factory(factory), type(type), expected_in_use(expected_in_use) {
+    }
+
+    const char* name;
+    EntryFactory factory;
+    XrefEntryType type;
+    boolean_type expected_in_use;
+};
+
+class XrefEntryInUse : public ::testing::TestWithParam<InUseTestCase> {};
+
+// XrefEntry_InUse is documented as a check whether the entry is used or compressed.
+// It used to report the internal lazy-load flag instead, which stays false until the
+// referenced object has been parsed. None of the entries below hold a reference,
+// therefore the value has to be derived purely from the entry type.
+TEST_P(XrefEntryInUse, ReflectsEntryTypeWithoutReference) {
+    const InUseTestCase& test_case = GetParam();
+
+    HandleGuard<XrefEntryHandle, XrefEntry_Release> entry;
+    ASSERT_EQ(test_case.factory(entry.out()), VANILLAPDF_ERROR_SUCCESS);
+
+    XrefEntryType type = XrefEntryType_Null;
+    ASSERT_EQ(XrefEntry_GetType(entry, &type), VANILLAPDF_ERROR_SUCCESS);
+    EXPECT_EQ(type, test_case.type);
+
+    boolean_type in_use = VANILLAPDF_RV_FALSE;
+    ASSERT_EQ(XrefEntry_InUse(entry, &in_use), VANILLAPDF_ERROR_SUCCESS);
+    EXPECT_EQ(in_use, test_case.expected_in_use);
+}
+
+INSTANTIATE_TEST_SUITE_P(EntryTypes, XrefEntryInUse,
+    ::testing::Values(
+        InUseTestCase("Free", CreateFreeEntry, XrefEntryType_Free, VANILLAPDF_RV_FALSE),
+        InUseTestCase("Used", CreateUsedEntry, XrefEntryType_Used, VANILLAPDF_RV_TRUE),
+        InUseTestCase("Compressed", CreateCompressedEntry, XrefEntryType_Compressed, VANILLAPDF_RV_TRUE)
+    ),
+    [](const ::testing::TestParamInfo<InUseTestCase>& info) {
+        return std::string(info.param.name);
+    }
+);
+
+// Attaching the object to the entry must not change the reported value
+TEST(XrefUsedEntry, InUseIsStableAfterMaterialization) {
+    HandleGuard<XrefUsedEntryHandle, XrefUsedEntry_Release> used_entry;
+    ASSERT_EQ(XrefUsedEntry_Create(1, 0, 0, used_entry.out()), VANILLAPDF_ERROR_SUCCESS);
+
+    HandleGuard<XrefEntryHandle, XrefEntry_Release> entry;
+    ASSERT_EQ(XrefUsedEntry_ToEntry(used_entry, entry.out()), VANILLAPDF_ERROR_SUCCESS);
+
+    boolean_type before = VANILLAPDF_RV_FALSE;
+    ASSERT_EQ(XrefEntry_InUse(entry, &before), VANILLAPDF_ERROR_SUCCESS);
+    EXPECT_EQ(before, VANILLAPDF_RV_TRUE);
+
+    HandleGuard<IntegerObjectHandle, IntegerObject_Release> integer;
+    ASSERT_EQ(IntegerObject_Create(integer.out()), VANILLAPDF_ERROR_SUCCESS);
+
+    HandleGuard<ObjectHandle, Object_Release> object;
+    ASSERT_EQ(IntegerObject_ToObject(integer, object.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(XrefUsedEntry_SetReference(used_entry, object), VANILLAPDF_ERROR_SUCCESS);
+
+    boolean_type after = VANILLAPDF_RV_FALSE;
+    ASSERT_EQ(XrefEntry_InUse(entry, &after), VANILLAPDF_ERROR_SUCCESS);
+    EXPECT_EQ(after, VANILLAPDF_RV_TRUE);
+}
+
+} /* xref */

--- a/src/vanillapdf/syntax/files/file_writer.cpp
+++ b/src/vanillapdf/syntax/files/file_writer.cpp
@@ -981,7 +981,7 @@ void FileWriter::WriteXrefObjects(IOutputStreamPtr output, XrefBasePtr source) {
         auto used_entry = ConvertUtils<XrefEntryBasePtr>::ConvertTo<XrefUsedEntryBasePtr>(entry);
 
         // Some used entries can be released, but they were not compacted
-        if (!used_entry->InUse()) {
+        if (!used_entry->HasReference()) {
             continue;
         }
 
@@ -1134,7 +1134,7 @@ XrefBasePtr FileWriter::CreateIncrementalXref(FilePtr source, FilePtr destinatio
                 auto used_entry = ConvertUtils<XrefEntryBasePtr>::ConvertTo<XrefUsedEntryPtr>(entry);
 
                 // Entry was released
-                if (!used_entry->InUse()) {
+                if (!used_entry->HasReference()) {
                     continue;
                 }
 
@@ -1477,7 +1477,7 @@ void FileWriter::WriteXrefTable(IOutputStreamPtr output, XrefTablePtr xref_table
                 auto used_entry = ConvertUtils<XrefEntryBasePtr>::ConvertTo<XrefUsedEntryPtr>(entry);
 
                 // Entry was released
-                if (!used_entry->InUse()) {
+                if (!used_entry->HasReference()) {
                     continue;
                 }
 

--- a/src/vanillapdf/syntax/files/xref_entry.cpp
+++ b/src/vanillapdf/syntax/files/xref_entry.cpp
@@ -109,14 +109,14 @@ void XrefUsedEntryBase::SetReference(ObjectPtr ref) {
 ObjectPtr XrefUsedEntryBase::GetReference(void) {
     Initialize();
 
-    if (!InUse()) {
+    if (!HasReference()) {
         return NullObject::GetInstance();
     }
 
     return _reference;
 }
 
-bool XrefUsedEntryBase::InUse(void) const noexcept {
+bool XrefUsedEntryBase::HasReference(void) const noexcept {
     if (!m_used) {
         assert(_reference.empty() && "Unused entry contains reference");
     }
@@ -125,8 +125,8 @@ bool XrefUsedEntryBase::InUse(void) const noexcept {
 }
 
 void XrefUsedEntryBase::ReleaseReference(bool check_object_xref) {
-    // Unused entries have nothing to release
-    if (!InUse()) {
+    // Entries without a materialized reference have nothing to release
+    if (!HasReference()) {
         return;
     }
 

--- a/src/vanillapdf/syntax/files/xref_entry.h
+++ b/src/vanillapdf/syntax/files/xref_entry.h
@@ -37,7 +37,12 @@ public:
 
     virtual Usage GetUsage(void) const noexcept = 0;
 
-    virtual bool InUse(void) const noexcept = 0;
+    // True if the entry occupies an object slot in the file - it is either used or compressed.
+    // This is derived from the entry usage, therefore it does not materialize the referenced object.
+    bool InUse(void) const noexcept {
+        Usage usage = GetUsage();
+        return (usage == Usage::Used) || (usage == Usage::Compressed);
+    }
 
     void SetFile(WeakReference<File> file) noexcept { _file = file; }
     WeakReference<File> GetFile() const noexcept { return _file; }
@@ -66,10 +71,6 @@ class XrefNullEntry : public XrefEntryBase {
 public:
     virtual Usage GetUsage(void) const noexcept override {
         return XrefEntryBase::Usage::Null;
-    }
-
-    virtual bool InUse(void) const noexcept override {
-        return false;
     }
 };
 
@@ -100,10 +101,6 @@ public:
         IncrementVersion();
     }
 
-    virtual bool InUse(void) const noexcept override {
-        return false;
-    }
-
 private:
     types::big_uint m_next_free_object = 0;
 };
@@ -123,7 +120,10 @@ public:
         return false;
     }
 
-    virtual bool InUse(void) const noexcept override;
+    // True if the entry currently holds a materialized object reference.
+    // Lazily loaded entries report false until the object has been parsed
+    // and released entries report false again afterwards.
+    bool HasReference(void) const noexcept;
 
     ~XrefUsedEntryBase();
 

--- a/src/vanillapdf/syntax/objects/object.cpp
+++ b/src/vanillapdf/syntax/objects/object.cpp
@@ -121,7 +121,7 @@ bool Object::IsIndirect(void) const {
 
         // Verify that the entry refers to this object
         auto entry = m_entry.GetReference();
-        if (entry->InUse()) {
+        if (entry->HasReference()) {
             bool identity = Identity(entry->GetReference());
             assert(identity && "Indirect entry does not reference to this object"); UNUSED(identity);
         }
@@ -145,7 +145,7 @@ void Object::ClearXrefEntry(bool check_xref_reference) {
 
         // Verify that the entry refers to this object
         auto entry = m_entry.GetReference();
-        if (entry->InUse()) {
+        if (entry->HasReference()) {
             assert(entry->GetReference()->Identity(this) && "Reference entry has changed");
             entry->ReleaseReference(false);
         }


### PR DESCRIPTION
## Problem

`XrefEntry_InUse` has always been documented as *"Quick check, if the entry is used or compressed"*, but it returned `XrefUsedEntryBase::m_used` — an internal flag that stays `false` until the referenced object has been materialized.

Because used and compressed entries are lazily loaded, **no object is parsed on a freshly opened file**, so every entry reported `false`. Used as documented — a filter for skipping free entries — the function silently matched nothing. The C++ internals used it correctly; only the documented contract was unmet.

The correct check for callers today is `XrefEntry_GetType()` against `XrefEntryType_Used` / `XrefEntryType_Compressed`, which is what `vanillapdf.tools/extract.c` already does.

## Fix

The two concepts are separated:

- **`XrefEntryBase::InUse()`** is now non-virtual and derived from `GetUsage()`. Since the value follows from the entry type, a subclass can no longer drift away from the type it reports, and answering the question does not parse the referenced object. This is what made the original bug possible: `InUse()` was virtual precisely so `XrefUsedEntryBase` could override it to return `m_used`.
- **`XrefUsedEntryBase::HasReference()`** keeps the previous `m_used` semantics for the five callers that genuinely ask whether a materialized reference is present — the file writer skipping released entries (`file_writer.cpp:984, 1137, 1480`) and `Object` guarding against dereferencing an absent reference (`object.cpp:124, 148`).

The three `FileWriter` call sites operating on base-typed entries (`1831, 1924, 1939`) keep calling `InUse()`. They run on the destination chain *after* `CloneXref()` has called `SetReference()` on every used and compressed entry, so `m_used` and "usage is not free" are equivalent there — and the usage check is what the surrounding comments and function names (`RemoveFreedObjects`, "Skip unused entries") already described.

## Compatibility

**No ABI change.** The four `*_InUse` functions keep their exact signatures, handles, and error-code contract; only the value written to `*result` changes. Nothing needs recompiling or relinking.

This is a bug fix, not a breaking change — semver protects the documented contract, which the header has promised since it was written. To be broken by this, a caller would have to be deliberately using `InUse()` as an undocumented probe for "has this entry been materialized yet", which the docs actively steer away from. Anyone using it as documented gets nothing today and starts getting correct results after the fix.

No backport: shipping a public API behavior change in a patch release of 2.2 would be a surprise for no benefit, since `XrefEntry_GetType()` already works there.

## Tests

Verified the tests are not vacuous — stashing the library changes and rebuilding, the `Used` and `Compressed` cases fail (`in_use` comes back `'\0'`) along with the stability test, while `Free` still passes.

- Parameterized `XrefEntryInUse` coverage asserting `InUse` follows the entry type for entries holding **no** reference (Free/Used/Compressed).
- `InUseIsStableAfterMaterialization` — attaching the object must not change the reported value.
- Full suite green: **668/668 in Release**, including the PDF write/save integration tests that exercise the touched writer paths.

## Note on test layout

The xref cases are lifted out of `main.cpp` into a new `src/vanillapdf.unittest/syntax/` folder. The unit tests will gradually adopt this structure to mirror the library layers (`syntax` / `semantics` / `contents` / `utils`); the remaining test files are untouched here to keep this PR focused.