### PR TITLE
ci: Harden release publish path (GITHUB_TOKEN + publish by id)

### DIFF
--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -18,6 +18,10 @@ on:
         required: false
         type: string
         default: ''
+    outputs:
+      release_id:
+        description: "Numeric id of the draft release. Later jobs must address the draft by id, not tag: the tag does not exist as a ref until the draft is published, and an API edit to the draft body that omits tag_name resets it, after which tag-based lookup fails."
+        value: ${{ jobs.github-release.outputs.release_id }}
   workflow_dispatch:
     inputs:
       tag:
@@ -45,6 +49,8 @@ jobs:
     name: Create GitHub Release
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    outputs:
+      release_id: ${{ steps.create.outputs.release_id }}
     permissions:
       contents: write       # Required to create a release and upload assets
       id-token: write       # Required for Sigstore keyless signing
@@ -56,48 +62,63 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Create release from tag
+      - name: Create draft release
+        id: create
         env:
           TAG: ${{ inputs.tag }}
           PRERELEASE: ${{ inputs.prerelease }}
+          LATEST: ${{ inputs.latest }}
           TARGET: ${{ inputs.target }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
         run: |
-          echo "Creating draft release for tag: $TAG"
-          if gh release view "$TAG" &>/dev/null; then
-            echo "Release $TAG already exists. Skipping."
-            exit 0
-          fi
-          LATEST_FLAG=""
-          if [ "${{ inputs.latest }}" = "false" ]; then
-            LATEST_FLAG="--latest=false"
-          fi
+          # Reuse the draft from an earlier attempt rather than creating a second
+          # release for the same tag. A draft from a previous run has long since
+          # propagated, so the list endpoint is safe to consult here - which is NOT
+          # true of a draft created milliseconds ago (see below).
+          RELEASE_ID=$(gh api "repos/${GH_REPO}/releases" \
+            --jq ".[] | select(.tag_name == \"$TAG\") | .id" | head -n 1)
 
-          # The tag must NOT exist yet: publishing this draft is what creates the
-          # tag (at TARGET) and binds the release to it. Pre-creating the tag would
-          # leave the published release stuck on its untagged-* placeholder.
-          TARGET_FLAG=""
-          if [ -n "$TARGET" ]; then
-            TARGET_FLAG="--target $TARGET"
-          fi
-
-          if [ "$PRERELEASE" = "true" ]; then
-            gh release create "$TAG" \
-              --title "vanillapdf $TAG" \
-              --generate-notes \
-              --draft \
-              --prerelease \
-              $TARGET_FLAG \
-              $LATEST_FLAG
+          if [ -n "$RELEASE_ID" ]; then
+            echo "Release $TAG already exists (id $RELEASE_ID). Skipping create."
           else
-            gh release create "$TAG" \
-              --title "vanillapdf $TAG" \
-              --generate-notes \
-              --draft \
-              $TARGET_FLAG \
-              $LATEST_FLAG
+            echo "Creating draft release for tag: $TAG"
+
+            MAKE_LATEST=true
+            if [ "$LATEST" = "false" ]; then
+              MAKE_LATEST=false
+            fi
+
+            TARGET_ARG=()
+            if [ -n "$TARGET" ]; then
+              TARGET_ARG=(-f target_commitish="$TARGET")
+            fi
+
+            # Create through the REST API, not `gh release create`, because the POST
+            # response carries the new release's id. Re-reading the releases list to
+            # find the id of a release created milliseconds earlier is a race: that
+            # endpoint is eventually consistent and can return a stale page.
+            #
+            # The tag must NOT exist yet: publishing this draft is what creates the
+            # tag (at TARGET) and binds the release to it. Pre-creating the tag would
+            # leave the published release stuck on its untagged-* placeholder.
+            RELEASE_ID=$(gh api --method POST "repos/${GH_REPO}/releases" \
+              -f tag_name="$TAG" \
+              -f name="vanillapdf $TAG" \
+              -F draft=true \
+              -F prerelease="$PRERELEASE" \
+              -F generate_release_notes=true \
+              -f make_latest="$MAKE_LATEST" \
+              "${TARGET_ARG[@]}" \
+              --jq .id)
           fi
+
+          if [ -z "$RELEASE_ID" ]; then
+            echo "::error::Could not resolve release id for $TAG"
+            exit 1
+          fi
+          echo "Resolved release id: $RELEASE_ID"
+          echo "release_id=$RELEASE_ID" >> "$GITHUB_OUTPUT"
 
       - name: Download DEB package
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -306,8 +306,9 @@ jobs:
       latest_tag: ${{ needs.prepare.outputs.latest_tag }}
       is_latest: ${{ needs.prepare.outputs.is_latest }}
       prerelease: ${{ needs.prepare.outputs.prerelease }}
+      release_id: ${{ needs.create-draft-release.outputs.release_id }}
     steps:
-      - run: echo "Draft release created. Edit the release body in the UI, then approve to publish."
+      - run: echo "Draft release created. Review and edit the release body, then approve to publish."
 
   # Flip the reviewed draft to a published release. Publishing creates the tag at
   # the draft's target commit and binds the release to it. This uses GITHUB_TOKEN,
@@ -317,6 +318,12 @@ jobs:
   # creation - with no bypass actors, so no bot identity is needed. A token without
   # push access cannot even see a draft release (GitHub answers 404, not 403), so a
   # bot PAT here would only add a failure mode, not remove one.
+  #
+  # The draft is addressed by its numeric id, never by tag: the tag does not exist
+  # as a ref until this step, and an API edit to the draft body that omits tag_name
+  # resets it, so tag-based lookup can fail with "release not found". Re-asserting
+  # tag_name in the same PATCH that flips draft=false makes the publish immune to
+  # that quirk, however the body was edited during the gate.
   publish-release:
     runs-on: ubuntu-latest
     timeout-minutes: 90
@@ -331,16 +338,20 @@ jobs:
     steps:
       - name: Publish draft release
         env:
+          RELEASE_ID: ${{ needs.production-gate.outputs.release_id }}
           TAG: ${{ needs.production-gate.outputs.tag }}
           IS_LATEST: ${{ needs.production-gate.outputs.is_latest }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
         run: |
-          LATEST_FLAG=""
-          if [ "$IS_LATEST" = "false" ]; then
-            LATEST_FLAG="--latest=false"
+          MAKE_LATEST=false
+          if [ "$IS_LATEST" = "true" ]; then
+            MAKE_LATEST=true
           fi
-          gh release edit "$TAG" --draft=false $LATEST_FLAG
+          gh api --method PATCH "repos/${GH_REPO}/releases/${RELEASE_ID}" \
+            -f tag_name="$TAG" \
+            -F draft=false \
+            -f make_latest="$MAKE_LATEST"
 
   publish-nuget:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -310,8 +310,13 @@ jobs:
       - run: echo "Draft release created. Edit the release body in the UI, then approve to publish."
 
   # Flip the reviewed draft to a published release. Publishing creates the tag at
-  # the draft's target commit and binds the release to it. BOT_TOKEN is used so
-  # the tag can be created under any tag protection rulesets.
+  # the draft's target commit and binds the release to it. This uses GITHUB_TOKEN,
+  # the same token that created the draft: the job has contents: write so it can
+  # always see and publish its own draft, and the "Protected release tags" ruleset
+  # (refs/tags/v*.*.*) restricts only deletion, non_fast_forward and update - never
+  # creation - with no bypass actors, so no bot identity is needed. A token without
+  # push access cannot even see a draft release (GitHub answers 404, not 403), so a
+  # bot PAT here would only add a failure mode, not remove one.
   publish-release:
     runs-on: ubuntu-latest
     timeout-minutes: 90
@@ -328,7 +333,7 @@ jobs:
         env:
           TAG: ${{ needs.production-gate.outputs.tag }}
           IS_LATEST: ${{ needs.production-gate.outputs.is_latest }}
-          GH_TOKEN: ${{ secrets.BOT_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
         run: |
           LATEST_FLAG=""


### PR DESCRIPTION
## Summary

Hardens the release publish path by porting the two publish-path fixes the sibling [vanillapdf.net](https://github.com/vanillapdf/vanillapdf.net) repo landed after they broke its release (its #133 and the by-id half of #130). This repo carries the same latent shape and has only avoided the failures by luck of configuration and editing habit. Convergence is deliberately **upward** — onto the fixed model — not a wholesale copy of the .net workflow, which builds different artifacts.

Two commits, reviewable independently:

### 1. Publish with `GITHUB_TOKEN`, not `BOT_TOKEN`

`publish-release` used `BOT_TOKEN` to flip the draft to published, on the belief that the `Protected release tags` ruleset needed a bot identity to create the tag. It does not — that ruleset (`refs/tags/v*.*.*`) enforces only `deletion`, `non_fast_forward` and `update`, none of which restrict *creating* a tag, and it has **no bypass actors**. Verified identical to .net's ruleset.

`BOT_TOKEN` works here today only because that identity happens to have push access to this repo. If it ever lost it, GitHub hides draft releases from tokens without push access behind a **404**, and every publish would fail with "release not found" against a draft that plainly exists — exactly what broke .net's release. `publish-release` already declares `contents: write`, so `GITHUB_TOKEN` can always see and publish its own draft.

`BOT_TOKEN` stays where it is genuinely a cross-repo PAT (Homebrew / vcpkg / Conan PRs, backports).

### 2. Address the draft by id, not by tag

`publish-release` looked the release up by tag (`gh release edit "$TAG"`). While a release is a draft the tag does not exist as a ref, and an API edit to the body that omits `tag_name` resets it, after which tag lookup fails. This repo has dodged it only because drafts were edited in the UI — but editing via `gh release edit` from the console (without `--tag`) can trip it.

- `github-release.yml` now creates the draft via `gh api POST /releases` (the response carries the id; re-reading the list for a just-created id races an eventually-consistent endpoint) and exposes `release_id` as an output, threaded through `production-gate` to `publish-release`.
- `publish-release` publishes with `gh api PATCH /releases/{id}`, re-asserting `tag_name` in the same call that flips `draft=false` — immune to the reset however the body was edited.

The pre-gate asset uploads (deb/rpm/dmg/SBOM/provenance) stay by tag: they run right after creation while `tag_name` is intact.

## Scope notes

- The `publish-release` / `publish-nuget` split that .net's #130 also introduced already exists here — not touched.
- Purely CI. No library, ABI, or artifact change. rc.2 published on the old path; the next real use of this path is 2.3.0 GA (or an rc.3), giving it a full cycle of exposure first.

## Validation

Both workflows parse (`yaml.safe_load`) and both edited run blocks pass `bash -n`. Opening this PR touches the release workflows, so it triggers `release.yml`'s `pull_request` dry-run path, exercising the build/verify/draft-creation legs without tagging or publishing.
