### PR TITLE
fix: Emit /V 4 with /AESV2 for AES-128 instead of silently producing RC4

### DIFF
--- a/scripts/verify_encryption_interop_pyhanko.py
+++ b/scripts/verify_encryption_interop_pyhanko.py
@@ -3,18 +3,23 @@
 
 Encrypts a PDF with the vanillapdf command-line tool using the requested
 algorithm and key length, then verifies that an independent implementation
-(pyHanko) can authenticate both the user and owner passwords, reject a wrong
-password, and decrypt the document content.
+(pyHanko) reports the algorithm we actually asked for, can authenticate both
+the user and owner passwords, reject a wrong password, and decrypt the document
+content.
 
 This guards against key-derivation bugs that a self round-trip cannot catch: a
 scheme that is wrong but internally consistent decrypts fine against itself
 while being rejected by every third-party reader. It applies to every standard
 security handler:
 
-    RC4  40  -> V=1/V=2, R=2/R=3
-    RC4 128  -> V=2,     R=3
-    AES 128  -> V=4,     R=4  (AESV2)
-    AES 256  -> V=5,     R=6  (AESV3, ISO 32000-2 Algorithm 2.B)
+    RC4  40  -> V=1/V=2, R=2/R=3         (/V2,    5-byte key)
+    RC4 128  -> V=2,     R=3             (/V2,   16-byte key)
+    AES 128  -> V=4,     R=4             (/AESV2, 16-byte key)
+    AES 256  -> V=5,     R=6             (/AESV3, 32-byte key, ISO 32000-2 Algorithm 2.B)
+
+The algorithm check is deliberately independent of authentication. Requesting
+AES and receiving RC4 still authenticates, still decrypts, and still round-trips
+against ourselves -- the crypt filter method is the only thing that reveals it.
 
 Usage:
     verify_encryption_interop_pyhanko.py <tools_exe> <source_pdf> <output_dir> \
@@ -31,6 +36,16 @@ import sys
 OWNER_PASSWORD = "owner-secret"
 USER_PASSWORD = "user-secret"
 WRONG_PASSWORD = "definitely-not-the-password"
+
+# Crypt filter method and file encryption key length (in bytes) that each
+# requested algorithm/key length combination must produce. The method name is
+# the authoritative signal: /V2 is RC4, /AESV2 is AES-128, /AESV3 is AES-256.
+EXPECTED_CRYPT_FILTER = {
+    ("RC4", "40"): ("/V2", 5),
+    ("RC4", "128"): ("/V2", 16),
+    ("AES", "128"): ("/AESV2", 16),
+    ("AES", "256"): ("/AESV3", 32),
+}
 
 
 def main():
@@ -64,6 +79,71 @@ def main():
 
     from pyhanko.pdf_utils.reader import PdfFileReader
     from pyhanko.pdf_utils.crypt import AuthStatus
+
+    def verify_algorithm():
+        """Check that the file really uses the algorithm we requested.
+
+        Returns an error string, or None when the file matches expectations.
+        """
+
+        expected = EXPECTED_CRYPT_FILTER.get((algorithm.upper(), key_length))
+        if expected is None:
+            return "no expected crypt filter recorded for {} {}".format(
+                algorithm, key_length
+            )
+
+        expected_method, expected_keylen = expected
+
+        with open(destination, "rb") as handle:
+            reader = PdfFileReader(handle, strict=False)
+            if not reader.encrypted:
+                return "output document is not encrypted"
+
+            reader.decrypt(OWNER_PASSWORD)
+            handler = reader.security_handler
+
+            crypt_filter_config = handler.crypt_filter_config
+            stream_filter = crypt_filter_config.get_for_stream()
+            string_filter = crypt_filter_config.get_for_string()
+
+            # SecurityHandlerVersion and StandardSecuritySettingsRevision are
+            # plain Enums, not IntEnums -- int() on them raises.
+            print(
+                "pyHanko: V={} R={} keylen={} stream={} string={}".format(
+                    handler.version.value,
+                    handler.revision.value,
+                    handler.keylen,
+                    stream_filter.method,
+                    string_filter.method,
+                )
+            )
+
+            # Streams and strings are checked separately: a writer can get the
+            # /StmF and /StrF crypt filters out of step with each other.
+            if stream_filter.method != expected_method:
+                return "stream crypt filter is {}, expected {}".format(
+                    stream_filter.method, expected_method
+                )
+
+            if string_filter.method != expected_method:
+                return "string crypt filter is {}, expected {}".format(
+                    string_filter.method, expected_method
+                )
+
+            if handler.keylen != expected_keylen:
+                return "file encryption key is {} bytes, expected {}".format(
+                    handler.keylen, expected_keylen
+                )
+
+        return None
+
+    algorithm_error = verify_algorithm()
+    if algorithm_error is not None:
+        print("FAILED: requested {} {} but {}".format(
+            algorithm, key_length, algorithm_error
+        ))
+        return 1
+    print("pyHanko: algorithm matches the requested {} {}".format(algorithm, key_length))
 
     def open_and_authenticate(password):
         with open(destination, "rb") as handle:

--- a/scripts/verify_encryption_interop_pyhanko.py
+++ b/scripts/verify_encryption_interop_pyhanko.py
@@ -29,6 +29,7 @@ Usage:
     key_length  : 40 | 128 | 256
 """
 
+import collections
 import os
 import subprocess
 import sys
@@ -37,15 +38,49 @@ OWNER_PASSWORD = "owner-secret"
 USER_PASSWORD = "user-secret"
 WRONG_PASSWORD = "definitely-not-the-password"
 
-# Crypt filter method and file encryption key length (in bytes) that each
-# requested algorithm/key length combination must produce. The method name is
-# the authoritative signal: /V2 is RC4, /AESV2 is AES-128, /AESV3 is AES-256.
-EXPECTED_CRYPT_FILTER = {
-    ("RC4", "40"): ("/V2", 5),
-    ("RC4", "128"): ("/V2", 16),
-    ("AES", "128"): ("/AESV2", 16),
-    ("AES", "256"): ("/AESV3", 32),
-}
+ExpectedEncryption = collections.namedtuple(
+    "ExpectedEncryption", "method key_length_bytes revision"
+)
+
+
+def expected_encryption(algorithm, key_length):
+    """What pyHanko must report for a requested algorithm and key length.
+
+    Mirrors the selection in EncryptionUtils::CreateEncryptionDictionary rather than
+    enumerating key lengths, so every valid RC4 length is covered. The crypt filter method
+    is the authoritative signal: /V2 is RC4, /AESV2 is AES-128, /AESV3 is AES-256.
+
+    Returns None for combinations the standard security handler cannot express.
+    """
+
+    if algorithm == "AES":
+        if key_length == 128:
+            return ExpectedEncryption(method="/AESV2", key_length_bytes=16, revision=4)
+
+        if key_length == 256:
+            return ExpectedEncryption(method="/AESV3", key_length_bytes=32, revision=6)
+
+        return None
+
+    if algorithm == "RC4":
+        if 40 <= key_length <= 128 and key_length % 8 == 0:
+            # Revision 2 only carries 40-bit keys; anything longer moves to revision 3.
+            return ExpectedEncryption(
+                method="/V2",
+                key_length_bytes=key_length // 8,
+                revision=(2 if key_length == 40 else 3),
+            )
+
+        return None
+
+    return None
+
+
+# Only RC4-40 and RC4-128 are exercised against pyHanko, even though the library writes any
+# length from 40 to 128. Algorithm 1 makes the object key min(file key + 5, 16) bytes, so
+# RC4-56 needs a 96-bit and RC4-80 a 120-bit RC4 key. Both are valid per ISO 32000-1, but the
+# "cryptography" backend pyHanko uses accepts only 40, 56, 64, 80, 128, 160, 192 and 256 bit
+# keys and raises on the rest. qpdf covers those lengths instead; do not add them here.
 
 
 def main():
@@ -86,13 +121,11 @@ def main():
         Returns an error string, or None when the file matches expectations.
         """
 
-        expected = EXPECTED_CRYPT_FILTER.get((algorithm.upper(), key_length))
+        expected = expected_encryption(algorithm.upper(), int(key_length))
         if expected is None:
-            return "no expected crypt filter recorded for {} {}".format(
+            return "{} {} is not a combination the standard security handler can express".format(
                 algorithm, key_length
             )
-
-        expected_method, expected_keylen = expected
 
         with open(destination, "rb") as handle:
             reader = PdfFileReader(handle, strict=False)
@@ -120,19 +153,24 @@ def main():
 
             # Streams and strings are checked separately: a writer can get the
             # /StmF and /StrF crypt filters out of step with each other.
-            if stream_filter.method != expected_method:
+            if stream_filter.method != expected.method:
                 return "stream crypt filter is {}, expected {}".format(
-                    stream_filter.method, expected_method
+                    stream_filter.method, expected.method
                 )
 
-            if string_filter.method != expected_method:
+            if string_filter.method != expected.method:
                 return "string crypt filter is {}, expected {}".format(
-                    string_filter.method, expected_method
+                    string_filter.method, expected.method
                 )
 
-            if handler.keylen != expected_keylen:
+            if handler.keylen != expected.key_length_bytes:
                 return "file encryption key is {} bytes, expected {}".format(
-                    handler.keylen, expected_keylen
+                    handler.keylen, expected.key_length_bytes
+                )
+
+            if handler.revision.value != expected.revision:
+                return "security handler revision is {}, expected {}".format(
+                    handler.revision.value, expected.revision
                 )
 
         return None

--- a/scripts/verify_encryption_interop_qpdf.py
+++ b/scripts/verify_encryption_interop_qpdf.py
@@ -37,20 +37,15 @@ OWNER_PASSWORD = "owner-secret"
 USER_PASSWORD = "user-secret"
 WRONG_PASSWORD = "definitely-not-the-password"
 
-# Encryption method name that "qpdf --show-encryption" must report for each
-# requested algorithm/key length combination. Compared case-insensitively.
-EXPECTED_ENCRYPTION_METHOD = {
-    ("RC4", "40"): "rc4",
-    ("RC4", "128"): "rc4",
-    ("AES", "128"): "aesv2",
-    ("AES", "256"): "aesv3",
+# Security handler revision and encryption method that "qpdf --show-encryption"
+# must report for each requested algorithm/key length combination. The method is
+# compared case-insensitively.
+EXPECTED_ENCRYPTION = {
+    ("RC4", "40"): (2, "rc4"),
+    ("RC4", "128"): (3, "rc4"),
+    ("AES", "128"): (4, "aesv2"),
+    ("AES", "256"): (6, "aesv3"),
 }
-
-# "stream encryption method: AESv2", "string encryption method: RC4", ...
-ENCRYPTION_METHOD_PATTERN = re.compile(
-    r"^\s*(stream|string|file) encryption method:\s*(\S+)\s*$",
-    re.IGNORECASE | re.MULTILINE,
-)
 
 
 def main():
@@ -90,11 +85,30 @@ def main():
         Returns an error string, or None when the file matches expectations.
         """
 
-        expected = EXPECTED_ENCRYPTION_METHOD.get((algorithm.upper(), key_length))
+        # "stream encryption method: AESv2", "string encryption method: RC4", ...
+        # qpdf only emits these lines when crypt filters are in play (/V 4 and
+        # above). For RC4 (/V 1 and /V 2) it prints none, and RC4 is implied by
+        # the revision.
+        method_pattern = re.compile(
+            r"^\s*(stream|string|file) encryption method:\s*(\S+)\s*$",
+            re.IGNORECASE | re.MULTILINE,
+        )
+
+        revision_pattern = re.compile(r"^\s*R\s*=\s*(\d+)\s*$", re.MULTILINE)
+
+        # qpdf echoes the user password back when handed the owner password.
+        # Keep it out of the CI log even though these are throwaway credentials.
+        user_password_pattern = re.compile(
+            r"^(\s*User password\s*=\s*).*$", re.IGNORECASE | re.MULTILINE
+        )
+
+        expected = EXPECTED_ENCRYPTION.get((algorithm.upper(), key_length))
         if expected is None:
-            return "no expected encryption method recorded for {} {}".format(
+            return "no expected encryption recorded for {} {}".format(
                 algorithm, key_length
             )
+
+        expected_revision, expected_method = expected
 
         show = subprocess.run(
             ["qpdf", "--show-encryption", "--password=" + OWNER_PASSWORD, destination],
@@ -103,38 +117,55 @@ def main():
             universal_newlines=True,
         )
 
-        output = show.stdout or ""
+        output = user_password_pattern.sub(r"\1<redacted>", show.stdout or "")
         if show.returncode != 0:
             return "qpdf --show-encryption exited with {}:\n{}".format(
                 show.returncode, output
             )
 
-        methods = {
-            scope.lower(): method for scope, method in
-            ENCRYPTION_METHOD_PATTERN.findall(output)
-        }
+        revision_match = revision_pattern.search(output)
 
         # Fail loudly rather than silently passing if qpdf ever changes how it
-        # words this output -- a missing match must never read as success.
-        if not methods:
+        # words this output -- an unparseable report must never read as success.
+        if revision_match is None:
             return (
-                "could not find any 'encryption method' line in qpdf output; "
-                "the output format may have changed:\n{}".format(output)
+                "could not find the 'R = ' line in qpdf output; the output "
+                "format may have changed:\n{}".format(output)
             )
 
-        for scope in ("stream", "string"):
-            actual = methods.get(scope)
-            if actual is None:
-                return "qpdf did not report a {} encryption method:\n{}".format(
-                    scope, output
-                )
+        revision = int(revision_match.group(1))
 
-            if actual.lower() != expected:
-                return "{} encryption method is {}, expected {}".format(
-                    scope, actual, expected
-                )
+        methods = {
+            scope.lower(): method.lower() for scope, method in
+            method_pattern.findall(output)
+        }
 
-        print("qpdf: encryption methods {}".format(methods))
+        # Absent method lines mean /V 1 or /V 2, which can only ever be RC4. An
+        # AES expectation therefore fails here exactly as it should.
+        stream_method = methods.get("stream", "rc4")
+        string_method = methods.get("string", "rc4")
+
+        print("qpdf: R={} stream={} string={}".format(
+            revision, stream_method, string_method
+        ))
+
+        if revision != expected_revision:
+            return "security handler revision is {}, expected {}".format(
+                revision, expected_revision
+            )
+
+        # Streams and strings are checked separately: a writer can get the /StmF
+        # and /StrF crypt filters out of step with each other.
+        if stream_method != expected_method:
+            return "stream encryption method is {}, expected {}".format(
+                stream_method, expected_method
+            )
+
+        if string_method != expected_method:
+            return "string encryption method is {}, expected {}".format(
+                string_method, expected_method
+            )
+
         return None
 
     algorithm_error = verify_algorithm()

--- a/scripts/verify_encryption_interop_qpdf.py
+++ b/scripts/verify_encryption_interop_qpdf.py
@@ -3,18 +3,22 @@
 
 Encrypts a PDF with the vanillapdf command-line tool using the requested
 algorithm and key length, then verifies that an independent implementation
-(qpdf) can decrypt it with the user and owner passwords and rejects a wrong
-password.
+(qpdf) reports the algorithm we actually asked for, can decrypt it with the user
+and owner passwords, and rejects a wrong password.
 
 This guards against key-derivation bugs that a self round-trip cannot catch: a
 scheme that is wrong but internally consistent decrypts fine against itself
 while being rejected by every third-party reader. It applies to every standard
 security handler:
 
-    RC4  40  -> V=1/V=2, R=2/R=3
-    RC4 128  -> V=2,     R=3
-    AES 128  -> V=4,     R=4  (AESV2)
-    AES 256  -> V=5,     R=6  (AESV3, ISO 32000-2 Algorithm 2.B)
+    RC4  40  -> V=1/V=2, R=2/R=3         (qpdf reports RC4)
+    RC4 128  -> V=2,     R=3             (qpdf reports RC4)
+    AES 128  -> V=4,     R=4             (qpdf reports AESv2)
+    AES 256  -> V=5,     R=6             (qpdf reports AESv3, ISO 32000-2 Algorithm 2.B)
+
+The algorithm check is deliberately independent of decryption. Requesting AES
+and receiving RC4 still decrypts and still round-trips against ourselves -- the
+reported encryption method is the only thing that reveals it.
 
 Usage:
     verify_encryption_interop_qpdf.py <tools_exe> <source_pdf> <output_dir> \
@@ -25,12 +29,28 @@ Usage:
 """
 
 import os
+import re
 import subprocess
 import sys
 
 OWNER_PASSWORD = "owner-secret"
 USER_PASSWORD = "user-secret"
 WRONG_PASSWORD = "definitely-not-the-password"
+
+# Encryption method name that "qpdf --show-encryption" must report for each
+# requested algorithm/key length combination. Compared case-insensitively.
+EXPECTED_ENCRYPTION_METHOD = {
+    ("RC4", "40"): "rc4",
+    ("RC4", "128"): "rc4",
+    ("AES", "128"): "aesv2",
+    ("AES", "256"): "aesv3",
+}
+
+# "stream encryption method: AESv2", "string encryption method: RC4", ...
+ENCRYPTION_METHOD_PATTERN = re.compile(
+    r"^\s*(stream|string|file) encryption method:\s*(\S+)\s*$",
+    re.IGNORECASE | re.MULTILINE,
+)
 
 
 def main():
@@ -63,6 +83,67 @@ def main():
         return 1
 
     decrypted = os.path.join(output_dir, "qpdf_" + os.path.basename(destination))
+
+    def verify_algorithm():
+        """Check that qpdf reports the algorithm we requested.
+
+        Returns an error string, or None when the file matches expectations.
+        """
+
+        expected = EXPECTED_ENCRYPTION_METHOD.get((algorithm.upper(), key_length))
+        if expected is None:
+            return "no expected encryption method recorded for {} {}".format(
+                algorithm, key_length
+            )
+
+        show = subprocess.run(
+            ["qpdf", "--show-encryption", "--password=" + OWNER_PASSWORD, destination],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            universal_newlines=True,
+        )
+
+        output = show.stdout or ""
+        if show.returncode != 0:
+            return "qpdf --show-encryption exited with {}:\n{}".format(
+                show.returncode, output
+            )
+
+        methods = {
+            scope.lower(): method for scope, method in
+            ENCRYPTION_METHOD_PATTERN.findall(output)
+        }
+
+        # Fail loudly rather than silently passing if qpdf ever changes how it
+        # words this output -- a missing match must never read as success.
+        if not methods:
+            return (
+                "could not find any 'encryption method' line in qpdf output; "
+                "the output format may have changed:\n{}".format(output)
+            )
+
+        for scope in ("stream", "string"):
+            actual = methods.get(scope)
+            if actual is None:
+                return "qpdf did not report a {} encryption method:\n{}".format(
+                    scope, output
+                )
+
+            if actual.lower() != expected:
+                return "{} encryption method is {}, expected {}".format(
+                    scope, actual, expected
+                )
+
+        print("qpdf: encryption methods {}".format(methods))
+        return None
+
+    algorithm_error = verify_algorithm()
+    if algorithm_error is not None:
+        print("FAILED: requested {} {} but {}".format(
+            algorithm, key_length, algorithm_error
+        ))
+        return 1
+    print("qpdf: algorithm matches the requested {} {}".format(algorithm, key_length))
 
     def qpdf_decrypt(password):
         # qpdf exits 0 on success, non-zero on error (e.g. wrong password).

--- a/scripts/verify_encryption_interop_qpdf.py
+++ b/scripts/verify_encryption_interop_qpdf.py
@@ -28,6 +28,7 @@ Usage:
     key_length  : 40 | 128 | 256
 """
 
+import collections
 import os
 import re
 import subprocess
@@ -37,15 +38,36 @@ OWNER_PASSWORD = "owner-secret"
 USER_PASSWORD = "user-secret"
 WRONG_PASSWORD = "definitely-not-the-password"
 
-# Security handler revision and encryption method that "qpdf --show-encryption"
-# must report for each requested algorithm/key length combination. The method is
-# compared case-insensitively.
-EXPECTED_ENCRYPTION = {
-    ("RC4", "40"): (2, "rc4"),
-    ("RC4", "128"): (3, "rc4"),
-    ("AES", "128"): (4, "aesv2"),
-    ("AES", "256"): (6, "aesv3"),
-}
+ExpectedEncryption = collections.namedtuple("ExpectedEncryption", "method revision")
+
+
+def expected_encryption(algorithm, key_length):
+    """What "qpdf --show-encryption" must report for a requested algorithm and key length.
+
+    Mirrors the selection in EncryptionUtils::CreateEncryptionDictionary rather than
+    enumerating key lengths, so every valid RC4 length is covered. The method is compared
+    case-insensitively.
+
+    Returns None for combinations the standard security handler cannot express.
+    """
+
+    if algorithm == "AES":
+        if key_length == 128:
+            return ExpectedEncryption(method="aesv2", revision=4)
+
+        if key_length == 256:
+            return ExpectedEncryption(method="aesv3", revision=6)
+
+        return None
+
+    if algorithm == "RC4":
+        if 40 <= key_length <= 128 and key_length % 8 == 0:
+            # Revision 2 only carries 40-bit keys; anything longer moves to revision 3.
+            return ExpectedEncryption(method="rc4", revision=(2 if key_length == 40 else 3))
+
+        return None
+
+    return None
 
 
 def main():
@@ -102,13 +124,11 @@ def main():
             r"^(\s*User password\s*=\s*).*$", re.IGNORECASE | re.MULTILINE
         )
 
-        expected = EXPECTED_ENCRYPTION.get((algorithm.upper(), key_length))
+        expected = expected_encryption(algorithm.upper(), int(key_length))
         if expected is None:
-            return "no expected encryption recorded for {} {}".format(
+            return "{} {} is not a combination the standard security handler can express".format(
                 algorithm, key_length
             )
-
-        expected_revision, expected_method = expected
 
         show = subprocess.run(
             ["qpdf", "--show-encryption", "--password=" + OWNER_PASSWORD, destination],
@@ -149,21 +169,21 @@ def main():
             revision, stream_method, string_method
         ))
 
-        if revision != expected_revision:
+        if revision != expected.revision:
             return "security handler revision is {}, expected {}".format(
-                revision, expected_revision
+                revision, expected.revision
             )
 
         # Streams and strings are checked separately: a writer can get the /StmF
         # and /StrF crypt filters out of step with each other.
-        if stream_method != expected_method:
+        if stream_method != expected.method:
             return "stream encryption method is {}, expected {}".format(
-                stream_method, expected_method
+                stream_method, expected.method
             )
 
-        if string_method != expected_method:
+        if string_method != expected.method:
             return "string encryption method is {}, expected {}".format(
-                string_method, expected_method
+                string_method, expected.method
             )
 
         return None

--- a/src/vanillapdf.unittest/document_test.cpp
+++ b/src/vanillapdf.unittest/document_test.cpp
@@ -102,6 +102,52 @@ void EncryptDocument(
     ASSERT_EQ(File_SetEncryptionPassword(destination_load_file, user_password.data()), VANILLAPDF_ERROR_SUCCESS);
 }
 
+void EncryptDocumentExpectingError(
+    std::string owner_password,
+    std::string user_password,
+    EncryptionAlgorithmType encryption_algorithm,
+    integer_type encryption_key_length,
+    UserAccessPermissionFlags user_permissions,
+    error_type expected_encryption_result) {
+
+    HandleGuard<FileHandle, File_Release> memory_file;
+    HandleGuard<DocumentHandle, Document_Release> memory_document;
+    HandleGuard<InputOutputStreamHandle, InputOutputStream_Release> io_stream;
+    HandleGuard<DocumentEncryptionSettingsHandle, DocumentEncryptionSettings_Release> encryption_settings;
+
+    ASSERT_EQ(InputOutputStream_CreateFromMemory(io_stream.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_NE(io_stream.get(), nullptr);
+
+    ASSERT_EQ(File_CreateStream(io_stream, "temp", memory_file.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_NE(memory_file.get(), nullptr);
+
+    ASSERT_EQ(Document_CreateFile(memory_file, memory_document.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_NE(memory_document.get(), nullptr);
+
+    ASSERT_EQ(DocumentEncryptionSettings_Create(encryption_settings.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_NE(encryption_settings.get(), nullptr);
+
+    ASSERT_EQ(DocumentEncryptionSettings_SetAlgorithm(encryption_settings, encryption_algorithm), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(DocumentEncryptionSettings_SetKeyLength(encryption_settings, encryption_key_length), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(DocumentEncryptionSettings_SetUserAccessPermissions(encryption_settings, user_permissions), VANILLAPDF_ERROR_SUCCESS);
+
+    HandleGuard<BufferHandle, Buffer_Release> owner_password_buffer;
+    HandleGuard<BufferHandle, Buffer_Release> user_password_buffer;
+
+    ASSERT_EQ(Buffer_CreateFromData(owner_password.data(), owner_password.length(), owner_password_buffer.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Buffer_CreateFromData(user_password.data(), user_password.length(), user_password_buffer.out()), VANILLAPDF_ERROR_SUCCESS);
+
+    ASSERT_NE(owner_password_buffer.get(), nullptr);
+    ASSERT_NE(user_password_buffer.get(), nullptr);
+
+    ASSERT_EQ(DocumentEncryptionSettings_SetOwnerPassword(encryption_settings, owner_password_buffer), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(DocumentEncryptionSettings_SetUserPassword(encryption_settings, user_password_buffer), VANILLAPDF_ERROR_SUCCESS);
+
+    // The requested configuration cannot be expressed by the standard security handler.
+    // Encryption must be refused rather than silently substituting another algorithm.
+    ASSERT_EQ(Document_AddEncryption(memory_document, encryption_settings), expected_encryption_result);
+}
+
 TEST(Document, Encrypt_RC4_40) {
     EncryptDocument("owner", "user", EncryptionAlgorithmType_RC4, 40, UserAccessPermissionFlag_None);
 }
@@ -110,16 +156,29 @@ TEST(Document, Encrypt_RC4_128) {
     EncryptDocument("owner", "user", EncryptionAlgorithmType_RC4, 128, UserAccessPermissionFlag_None);
 }
 
-TEST(Document, Encrypt_AES_40) {
-    EncryptDocument("owner", "user", EncryptionAlgorithmType_AES, 40, UserAccessPermissionFlag_None);
-}
-
 TEST(Document, Encrypt_AES_128) {
     EncryptDocument("owner", "user", EncryptionAlgorithmType_AES, 128, UserAccessPermissionFlag_None);
 }
 
 TEST(Document, Encrypt_AES_256) {
     EncryptDocument("owner", "user", EncryptionAlgorithmType_AES, 256, UserAccessPermissionFlag_None);
+}
+
+// PDF defines exactly two AES crypt filter methods: AESV2 (128-bit) and AESV3 (256-bit).
+// There is no crypt filter for any other key size, so these combinations are rejected
+// instead of being silently downgraded to RC4.
+TEST(Document, Encrypt_AES_40_Rejected) {
+    EncryptDocumentExpectingError("owner", "user", EncryptionAlgorithmType_AES, 40, UserAccessPermissionFlag_None, VANILLAPDF_ERROR_PARAMETER_VALUE);
+}
+
+TEST(Document, Encrypt_AES_192_Rejected) {
+    EncryptDocumentExpectingError("owner", "user", EncryptionAlgorithmType_AES, 192, UserAccessPermissionFlag_None, VANILLAPDF_ERROR_PARAMETER_VALUE);
+}
+
+// RC4 keys range from 40 to 128 bits. /V 2 cannot express a longer key, and the
+// resulting document would be rejected by conformant readers.
+TEST(Document, Encrypt_RC4_256_Rejected) {
+    EncryptDocumentExpectingError("owner", "user", EncryptionAlgorithmType_RC4, 256, UserAccessPermissionFlag_None, VANILLAPDF_ERROR_PARAMETER_VALUE);
 }
 
 // Parameterized test for AES encryption roundtrip with various string sizes.

--- a/src/vanillapdf/semantics/objects/document.cpp
+++ b/src/vanillapdf/semantics/objects/document.cpp
@@ -872,120 +872,16 @@ void Document::AddEncryption(DocumentEncryptionSettingsPtr settings) {
         LOG_ERROR_AND_THROW(CryptoErrorException, "Could not encrypt document with empty document ID");
     }
 
-    auto key_length = settings->GetKeyLength();
-
     auto permissions_flags = settings->GetUserPermissions();
     auto permission_value = DocumentEncryptionSettings::GetPermissionInteger(permissions_flags);
 
-    // AES-256 uses a completely different key derivation scheme (V=5, R=6)
-    if (key_length == 256 && settings->GetEncryptionAlgorithm() == syntax::EncryptionAlgorithm::AES) {
-
-        auto r6_data = EncryptionUtils::GenerateEncryptionDataR6(
-            settings->GetUserPassword(),
-            settings->GetOwnerPassword(),
-            permission_value);
-
-        // Create encryption dictionary for V=5, R=6
-        DictionaryObjectPtr encryption_dictionary;
-
-        // Table 20 - Entries common to all encryption dictionaries
-        encryption_dictionary->Insert(constant::Name::Filter, NameObject::CreateFromDecoded("Standard"));
-        encryption_dictionary->Insert(constant::Name::V, make_deferred<IntegerObject>(5));
-        encryption_dictionary->Insert(constant::Name::Length, make_deferred<IntegerObject>(256));
-
-        // Table 21 - Standard security handler entries for R=6
-        encryption_dictionary->Insert(constant::Name::R, make_deferred<IntegerObject>(6));
-        encryption_dictionary->Insert(constant::Name::O, HexadecimalStringObject::CreateFromDecoded(r6_data.o_value));
-        encryption_dictionary->Insert(constant::Name::U, HexadecimalStringObject::CreateFromDecoded(r6_data.u_value));
-        encryption_dictionary->Insert(constant::Name::OE, HexadecimalStringObject::CreateFromDecoded(r6_data.oe_value));
-        encryption_dictionary->Insert(constant::Name::UE, HexadecimalStringObject::CreateFromDecoded(r6_data.ue_value));
-        encryption_dictionary->Insert(constant::Name::P, make_deferred<IntegerObject>(permission_value));
-        encryption_dictionary->Insert(constant::Name::Perms, HexadecimalStringObject::CreateFromDecoded(r6_data.perms_value));
-        encryption_dictionary->Insert(constant::Name::EncryptMetadata, make_deferred<BooleanObject>(true));
-
-        // Build CryptFilter dictionary: /CF << /StdCF << /CFM /AESV3 /AuthEvent /DocOpen /Length 32 >> >>
-        DictionaryObjectPtr std_cf_dict;
-        std_cf_dict->Insert(constant::Name::CFM, make_deferred<NameObject>(constant::Name::AESV3));
-        std_cf_dict->Insert(constant::Name::AuthEvent, make_deferred<NameObject>(constant::Name::DocOpen));
-        std_cf_dict->Insert(constant::Name::Length, make_deferred<IntegerObject>(32));
-
-        DictionaryObjectPtr cf_dict;
-        cf_dict->Insert(constant::Name::StdCF, std_cf_dict);
-
-        encryption_dictionary->Insert(constant::Name::CF, cf_dict);
-        encryption_dictionary->Insert(constant::Name::StmF, make_deferred<NameObject>(constant::Name::StdCF));
-        encryption_dictionary->Insert(constant::Name::StrF, make_deferred<NameObject>(constant::Name::StdCF));
-
-        encryption_dictionary->SetEncryptionExempted();
-
-        auto encryption_entry = m_holder->AllocateNewEntry();
-        encryption_entry->SetReference(encryption_dictionary);
-        encryption_entry->SetFile(m_holder);
-        encryption_entry->SetInitialized();
-
-        auto encryption_dictionary_reference = make_deferred<syntax::IndirectReferenceObject>(encryption_dictionary);
-        trailer_dictionary->Insert(constant::Name::Encrypt, encryption_dictionary_reference);
-
-        m_holder->SetEncryptionDictionary(encryption_dictionary);
-
-        bool password_set = m_holder->SetEncryptionPassword(settings->GetUserPassword());
-        if (!password_set) {
-            throw CryptoErrorException("Could not verify the encryption password");
-        }
-
-        return;
-    }
-
-    // (PDF 1.4) "Algorithm 1: Encryption of data using the RC4 or AES algorithms"in 7.6.2,
-    // "General Encryption Algorithm," but permitting encryption key lengths greater than 40 bits.
-    int32_t algorithm_version = 1;
-
-    // if the document is encrypted with a V value of 2 or 3,
-    // or has any "Security handlers of revision 3 or greater" access permissions set to 0
-    int32_t security_revision = 2;
-
-    // There is some bug preventing to use security handler revision 2 with keys longer than 40.
-    // I have tried multiple tweaks, however either Acrobat or Foxit are not able to open such file.
-    // Since we have a solution, that works with both, let's not spend more time on this.
-    if (key_length > 40) {
-        algorithm_version = 2;
-        security_revision = 3;
-    }
-
-    // Calculate the encryption entries
-    auto owner_key_buffer = EncryptionUtils::GenerateOwnerEncryptionKey(
+    auto encryption_dictionary = EncryptionUtils::CreateEncryptionDictionary(
         document_id_buffer,
+        settings->GetUserPassword(),
         settings->GetOwnerPassword(),
-        settings->GetUserPassword(),
         settings->GetEncryptionAlgorithm(),
-        key_length,
-        permission_value,
-        security_revision);
-
-    auto user_key_buffer = EncryptionUtils::GenerateUserEncryptionKey(
-        document_id_buffer,
-        settings->GetUserPassword(),
-        owner_key_buffer,
-        settings->GetEncryptionAlgorithm(),
-        key_length,
-        permission_value,
-        security_revision);
-
-    // Create new encryption dictionary
-    DictionaryObjectPtr encryption_dictionary;
-
-    // Table 20 - Entries common to all encryption dictionaries
-    encryption_dictionary->Insert(constant::Name::Filter, NameObject::CreateFromDecoded("Standard"));
-    //encryption_dictionary->Insert(constant::Name::SubFilter, make_deferred<IntegerObject>(2));
-    encryption_dictionary->Insert(constant::Name::V, make_deferred<IntegerObject>(algorithm_version));
-    encryption_dictionary->Insert(constant::Name::Length, make_deferred<IntegerObject>(key_length));
-
-    // Table 21 - Additional encryption dictionary entries for the standard security handler
-    encryption_dictionary->Insert(constant::Name::R, make_deferred<IntegerObject>(security_revision));
-    encryption_dictionary->Insert(constant::Name::O, HexadecimalStringObject::CreateFromDecoded(owner_key_buffer));
-    encryption_dictionary->Insert(constant::Name::U, HexadecimalStringObject::CreateFromDecoded(user_key_buffer));
-    encryption_dictionary->Insert(constant::Name::P, make_deferred<IntegerObject>(permission_value));
-    //encryption_dictionary->Insert(constant::Name::EncryptMetadata, make_deferred<IntegerObject>(2));
+        settings->GetKeyLength(),
+        permission_value);
 
     // Mark this entry as encryption exempted
     encryption_dictionary->SetEncryptionExempted();

--- a/src/vanillapdf/syntax/utils/encryption.cpp
+++ b/src/vanillapdf/syntax/utils/encryption.cpp
@@ -827,6 +827,162 @@ BufferPtr EncryptionUtils::AESDecryptECB(const Buffer& key, const Buffer& data) 
 
 }
 
+// Reject algorithm and key length combinations the standard security handler cannot
+// express. Encrypting with an algorithm other than the one requested would misrepresent
+// the strength of the resulting document, so fail instead of silently substituting.
+static void ValidateEncryptionSettings(EncryptionAlgorithm algorithm, int32_t key_length) {
+    if (algorithm == EncryptionAlgorithm::AES) {
+        if (key_length != 128 && key_length != 256) {
+            LOG_ERROR_AND_THROW(InvalidParameterException,
+                "AES supports only 128-bit and 256-bit keys, got {}", key_length);
+        }
+    } else if (algorithm == EncryptionAlgorithm::RC4) {
+        if (key_length < 40 || key_length > 128 || (key_length % 8) != 0) {
+            LOG_ERROR_AND_THROW(InvalidParameterException,
+                "RC4 supports only 40 to 128 bit keys in 8-bit steps, got {}", key_length);
+        }
+    } else {
+        LOG_ERROR_AND_THROW(InvalidParameterException,
+            "Unsupported encryption algorithm: {}", static_cast<int32_t>(algorithm));
+    }
+}
+
+// Table 20 and 21 - the entries every standard security handler dictionary carries.
+static syntax::DictionaryObjectPtr CreateCommonEntries(
+    int32_t algorithm_version,
+    int32_t security_revision,
+    int32_t key_length,
+    int32_t permissions) {
+
+    syntax::DictionaryObjectPtr encryption_dictionary;
+
+    encryption_dictionary->Insert(constant::Name::Filter, NameObject::CreateFromDecoded("Standard"));
+    encryption_dictionary->Insert(constant::Name::V, make_deferred<IntegerObject>(algorithm_version));
+    encryption_dictionary->Insert(constant::Name::Length, make_deferred<IntegerObject>(key_length));
+    encryption_dictionary->Insert(constant::Name::R, make_deferred<IntegerObject>(security_revision));
+    encryption_dictionary->Insert(constant::Name::P, make_deferred<IntegerObject>(permissions));
+
+    return encryption_dictionary;
+}
+
+// Table 25 - Both AES variants are selected through a crypt filter:
+// /CF << /StdCF << /CFM /AESV2 or /AESV3 /AuthEvent /DocOpen /Length n >> >>
+// The /Length inside a crypt filter is in bytes, unlike the /Length above it, which is in bits.
+static void InsertCryptFilter(
+    syntax::DictionaryObjectPtr encryption_dictionary,
+    int32_t key_length) {
+
+    const auto& crypt_filter_method = (key_length == 256 ? constant::Name::AESV3 : constant::Name::AESV2);
+
+    DictionaryObjectPtr std_cf_dict;
+    std_cf_dict->Insert(constant::Name::CFM, make_deferred<NameObject>(crypt_filter_method));
+    std_cf_dict->Insert(constant::Name::AuthEvent, make_deferred<NameObject>(constant::Name::DocOpen));
+    std_cf_dict->Insert(constant::Name::Length, make_deferred<IntegerObject>(key_length / 8));
+
+    DictionaryObjectPtr cf_dict;
+    cf_dict->Insert(constant::Name::StdCF, std_cf_dict);
+
+    encryption_dictionary->Insert(constant::Name::CF, cf_dict);
+    encryption_dictionary->Insert(constant::Name::StmF, make_deferred<NameObject>(constant::Name::StdCF));
+    encryption_dictionary->Insert(constant::Name::StrF, make_deferred<NameObject>(constant::Name::StdCF));
+}
+
+// AES-256 (ISO 32000-2, /V 5 /R 6). Derives the password entries with SHA-256 (Algorithm 2.B)
+// and stores the file encryption key itself in /OE and /UE. The document ID is not involved.
+static syntax::DictionaryObjectPtr CreateRevision6Dictionary(
+    const Buffer& user_password,
+    const Buffer& owner_password,
+    int32_t permissions) {
+
+    auto encryption_dictionary = CreateCommonEntries(5, 6, 256, permissions);
+    auto r6_data = EncryptionUtils::GenerateEncryptionDataR6(user_password, owner_password, permissions);
+
+    encryption_dictionary->Insert(constant::Name::O, HexadecimalStringObject::CreateFromDecoded(r6_data.o_value));
+    encryption_dictionary->Insert(constant::Name::U, HexadecimalStringObject::CreateFromDecoded(r6_data.u_value));
+    encryption_dictionary->Insert(constant::Name::OE, HexadecimalStringObject::CreateFromDecoded(r6_data.oe_value));
+    encryption_dictionary->Insert(constant::Name::UE, HexadecimalStringObject::CreateFromDecoded(r6_data.ue_value));
+    encryption_dictionary->Insert(constant::Name::Perms, HexadecimalStringObject::CreateFromDecoded(r6_data.perms_value));
+    encryption_dictionary->Insert(constant::Name::EncryptMetadata, make_deferred<BooleanObject>(true));
+
+    InsertCryptFilter(encryption_dictionary, 256);
+
+    return encryption_dictionary;
+}
+
+// RC4 (any length) and AES-128, which derive the password entries with MD5 (Algorithm 2)
+// from the document ID.
+static syntax::DictionaryObjectPtr CreateLegacyDictionary(
+    const Buffer& document_id,
+    const Buffer& user_password,
+    const Buffer& owner_password,
+    EncryptionAlgorithm algorithm,
+    int32_t key_length,
+    int32_t permissions) {
+
+    int32_t algorithm_version = 0;
+    int32_t security_revision = 0;
+
+    if (algorithm == EncryptionAlgorithm::AES) {
+
+        // /V 1 and /V 2 always mean RC4 - there is no way to request AES within them. AES-128 is
+        // only expressible through a crypt filter (ISO 32000-1 7.6.5), which requires /V 4 and
+        // /R 4 with /CFM /AESV2. Key derivation is unchanged: /R 4 takes the "revision 3 or
+        // greater" path in Algorithm 2.
+        algorithm_version = 4;
+        security_revision = 4;
+    } else if (key_length > 40) {
+
+        // There is some bug preventing to use security handler revision 2 with keys longer than 40.
+        // I have tried multiple tweaks, however either Acrobat or Foxit are not able to open such file.
+        // Since we have a solution, that works with both, let's not spend more time on this.
+        algorithm_version = 2;
+        security_revision = 3;
+    } else {
+
+        // (PDF 1.4) "Algorithm 1: Encryption of data using the RC4 or AES algorithms"in 7.6.2,
+        // "General Encryption Algorithm," but permitting encryption key lengths greater than 40 bits.
+        algorithm_version = 1;
+        security_revision = 2;
+    }
+
+    auto encryption_dictionary = CreateCommonEntries(algorithm_version, security_revision, key_length, permissions);
+
+    auto owner_key_buffer = EncryptionUtils::GenerateOwnerEncryptionKey(
+        document_id, owner_password, user_password,
+        algorithm, key_length, permissions, security_revision);
+
+    auto user_key_buffer = EncryptionUtils::GenerateUserEncryptionKey(
+        document_id, user_password, owner_key_buffer,
+        algorithm, key_length, permissions, security_revision);
+
+    encryption_dictionary->Insert(constant::Name::O, HexadecimalStringObject::CreateFromDecoded(owner_key_buffer));
+    encryption_dictionary->Insert(constant::Name::U, HexadecimalStringObject::CreateFromDecoded(user_key_buffer));
+
+    if (algorithm == EncryptionAlgorithm::AES) {
+        InsertCryptFilter(encryption_dictionary, key_length);
+    }
+
+    return encryption_dictionary;
+}
+
+syntax::DictionaryObjectPtr EncryptionUtils::CreateEncryptionDictionary(
+    const Buffer& document_id,
+    const Buffer& user_password,
+    const Buffer& owner_password,
+    EncryptionAlgorithm algorithm,
+    int32_t key_length,
+    int32_t permissions) {
+
+    ValidateEncryptionSettings(algorithm, key_length);
+
+    // AES-256 is the only combination using the SHA-256 based key derivation of ISO 32000-2.
+    if (algorithm == EncryptionAlgorithm::AES && key_length == 256) {
+        return CreateRevision6Dictionary(user_password, owner_password, permissions);
+    }
+
+    return CreateLegacyDictionary(document_id, user_password, owner_password, algorithm, key_length, permissions);
+}
+
 BufferPtr EncryptionUtils::GenerateOwnerEncryptionKey(
     const Buffer& document_id,
     const Buffer& owner_password,

--- a/src/vanillapdf/syntax/utils/encryption.h
+++ b/src/vanillapdf/syntax/utils/encryption.h
@@ -55,6 +55,18 @@ public:
         EncryptionAlgorithm algorithm,
         IEncryptionKey& key);
 
+    // Builds a complete standard security handler dictionary for the requested algorithm and
+    // key length, deriving the /O, /U (and for revision 6 the /OE, /UE, /Perms) entries and
+    // declaring a crypt filter where the algorithm requires one. Throws InvalidParameterException
+    // for algorithm and key length combinations the standard security handler cannot express.
+    static syntax::DictionaryObjectPtr CreateEncryptionDictionary(
+        const Buffer& document_id,
+        const Buffer& user_password,
+        const Buffer& owner_password,
+        EncryptionAlgorithm algorithm,
+        int32_t key_length,
+        int32_t permissions);
+
     static BufferPtr GenerateOwnerEncryptionKey(
         const Buffer& document_id,
         const Buffer& owner_password,


### PR DESCRIPTION
Fixes #451.

## The bug

`Document::AddEncryption` derived `/V` purely from the key length, so requesting AES at 128 bits produced:

```
/Filter /Standard /V 2 /R 3 /Length 128
```

No `/CF`, no `/AESV2` — byte-identical to requesting RC4 at the same length. And it was not merely a mislabel: `File::EncryptStream` only consults the crypt filter when `/V` is 4 or 5 and otherwise falls back to a hardcoded `EncryptionAlgorithm::RC4`, so the payload really was RC4. `GetEncryptionAlgorithmType()` still read back `AES`, so callers had no way to notice.

AES was honoured at exactly one setting: 256-bit. `AESV2` appeared nowhere in the write path — only in the two read sites. The library could read AES-128 but had never been able to write it.

## Why the tests did not catch it

`Encrypt_AES_128` and the eight-case `AESEncryptionRoundtrip` suite both existed and both passed. They only assert round-trip: encrypt, save, reopen, decrypt, compare. Writer and reader were wrong in the same direction, so the file always agreed with itself, and RC4 round-trips perfectly.

The qpdf and pyHanko interop checks did not catch it either. They validated key derivation and password authentication — genuinely valuable — but had no notion of which algorithm was requested. `-ka AES -kl 128` went in and was never cross-checked against what came out.

## The fix

- AES-128 emits `/V 4 /R 4` with `/CF << /StdCF << /CFM /AESV2 /AuthEvent /DocOpen /Length 16 >> >>` plus `/StmF` and `/StrF`. Object key derivation already applied the AES salt, so only the writer was missing.
- Combinations the standard security handler cannot express are rejected with `InvalidParameterException` instead of silently substituting: AES outside 128/256 (PDF defines only `/AESV2` and `/AESV3`), and RC4 outside 40–128 bits (`/V 2` cannot carry a longer key, and the previous code would happily emit `/V 2 /R 3 /Length 256`).
- Both interop scripts now assert the algorithm, so this class of bug fails loudly from two independent implementations.

## Refactor

Dictionary construction moved out of `Document` and into `EncryptionUtils::CreateEncryptionDictionary`, which validates once and then dispatches:

```cpp
ValidateEncryptionSettings(algorithm, key_length);

if (algorithm == EncryptionAlgorithm::AES && key_length == 256) {
    return CreateRevision6Dictionary(user_password, owner_password, permissions);
}

return CreateLegacyDictionary(document_id, user_password, owner_password, algorithm, key_length, permissions);
```

AES-256 previously had its own early-return path that duplicated the crypt filter construction and the entire xref/trailer wiring tail. `Document::AddEncryption` now just fetches the document ID, calls the above, and wires the result in — 112 lines lighter.

## Verification

All four combinations verified against pyHanko (`reader.security_handler`), before and after:

| Requested | Before | After |
|---|---|---|
| RC4 40 | V=1 R=2 keylen=5 `/V2` | unchanged |
| RC4 128 | V=2 R=3 keylen=16 `/V2` | unchanged |
| **AES 128** | **V=2 R=3 keylen=16 `/V2`** | **V=4 R=4 keylen=16 `/AESV2`** |
| AES 256 | V=5 R=6 keylen=32 `/AESV3` | unchanged |

AES-256 producing identical output through the shared path is the main regression check, since the refactor put that code most at risk. 23 unit tests pass, including three new negative cases (`Encrypt_AES_40_Rejected`, `Encrypt_AES_192_Rejected`, `Encrypt_RC4_256_Rejected`) and the AES-128 round-trip cases, which now genuinely traverse the `/V 4` path with PKCS#7 padding.

## Notes for review

- **`Encrypt_AES_40` was removed** and replaced by `Encrypt_AES_40_Rejected`. AES has no 40-bit variant, so the old test asserted success on a configuration that cannot be represented.
- **Behaviour change:** callers passing AES with a key length other than 128 or 256 now get an error where they previously got a working (RC4) document. This is deliberate — they were not getting AES, and failing is better than continuing to misrepresent it.
- The docstrings in both interop scripts already claimed the `AES 128 -> V=4, R=4 (AESV2)` mapping. That claim is now enforced rather than aspirational.
- Two stale fixtures (`sample-encrypted-{rc4,aes}-128-rev3.pdf`) have a 16-byte `/U` and are rejected outright by pyHanko. That is a separate, already-fixed bug from January 2025 whose artifacts were committed pre-fix; they are untouched here but worth regenerating.

Targeting `main` for 2.4.0. This is long-standing rather than a regression — `AESV2` has never been written — so 2.3.0 shipping without it is no worse than 2.2.x.
