### PR TITLE
fix: Encrypt array-filter streams instead of writing them in the clear (#460)

### DIFF
--- a/.github/workflows/encryption-interop-check.yml
+++ b/.github/workflows/encryption-interop-check.yml
@@ -134,8 +134,13 @@ jobs:
       - name: "[vanillapdf->qpdf] RC4-128 encryption interop"
         run: python3 scripts/verify_encryption_interop_qpdf.py install/bin/vanillapdf.tools test/pdftest2.pdf /tmp/interop RC4 128
 
-      - name: "[vanillapdf->qpdf] AES-128 encryption interop"
-        run: python3 scripts/verify_encryption_interop_qpdf.py install/bin/vanillapdf.tools test/pdftest2.pdf /tmp/interop AES 128
+      # AES runs against pdf20-utf8-test.pdf, which carries a stream with an array /Filter
+      # (e.g. an image's /Filter [/FlateDecode]). pdftest2.pdf has none, so it never reached
+      # the stream path where issue #460 lived: the body was written unencrypted while /Length
+      # recorded the encrypted size, which qpdf rejects on decrypt. This fixture also covers
+      # the plain algorithm/method check, so a separate pdftest2 AES case would be redundant.
+      - name: "[vanillapdf->qpdf] AES-128 encryption interop (array-filter stream)"
+        run: python3 scripts/verify_encryption_interop_qpdf.py install/bin/vanillapdf.tools test/pdf-association/pdf20examples/pdf20-utf8-test.pdf /tmp/interop AES 128
 
-      - name: "[vanillapdf->qpdf] AES-256 encryption interop"
-        run: python3 scripts/verify_encryption_interop_qpdf.py install/bin/vanillapdf.tools test/pdftest2.pdf /tmp/interop AES 256
+      - name: "[vanillapdf->qpdf] AES-256 encryption interop (array-filter stream)"
+        run: python3 scripts/verify_encryption_interop_qpdf.py install/bin/vanillapdf.tools test/pdf-association/pdf20examples/pdf20-utf8-test.pdf /tmp/interop AES 256

--- a/src/vanillapdf/syntax/files/file_writer.cpp
+++ b/src/vanillapdf/syntax/files/file_writer.cpp
@@ -686,21 +686,22 @@ void FileWriter::RecalculateStreamLength(StreamObjectPtr obj) {
     auto stream_data = obj->GetBodyEncoded();
     auto stream_header = obj->GetHeader();
 
-    // Remove only if the value is different
-    // There was a case that the length was indirect reference to another integer
-    // Two different streams were pointing to this integer and the final
-    // value was updated to a different stream
+    // Only touch /Length if it does not already match. A fresh direct integer also replaces
+    // any indirect /Length shared between streams.
+    bool length_matches = false;
     if (stream_header->Contains(constant::Name::Length)) {
         auto length_obj = stream_header->FindAs<IntegerObjectPtr>(constant::Name::Length);
-        if (length_obj->GetUnsignedIntegerValue() != stream_data->size()) {
-            bool removed = stream_header->Remove(constant::Name::Length);
-            assert(removed && "Could not remove stream length"); UNUSED(removed);
-        }
+        length_matches = (length_obj->GetUnsignedIntegerValue() == stream_data->size());
     }
 
-    if (!stream_header->Contains(constant::Name::Length)) {
+    if (!length_matches) {
+
+        // Stamp /Length without dirtying: it is derived from the bytes being written, so
+        // dirtying here would send the body-write pass down a different GetBodyEncoded()
+        // branch and the two would disagree on the size (issue #460).
+        // TODO(2.4.0): encode the body once and derive /Length from that buffer at write time.
         IntegerObjectPtr new_length = make_deferred<IntegerObject>(stream_data->size());
-        stream_header->Insert(constant::Name::Length, new_length);
+        stream_header->ReplaceSerializationEntry(constant::Name::Length, new_length);
     }
 }
 

--- a/src/vanillapdf/syntax/objects/dictionary_object.cpp
+++ b/src/vanillapdf/syntax/objects/dictionary_object.cpp
@@ -189,6 +189,21 @@ void DictionaryObject::Insert(const NameObject& name, ContainableObjectPtr value
 }
 
 void DictionaryObject::Insert(NameObjectPtr name, ContainableObjectPtr value, bool overwrite) {
+    InsertInternal(name, value, overwrite, true /* mark_dirty */);
+}
+
+void DictionaryObject::ReplaceSerializationEntry(const NameObject& name, ContainableObjectPtr value) {
+    NameObjectPtr temp = make_deferred<NameObject>(name);
+    ReplaceSerializationEntry(temp, value);
+}
+
+void DictionaryObject::ReplaceSerializationEntry(NameObjectPtr name, ContainableObjectPtr value) {
+    // Stamps a write-time derived entry (e.g. /Length) without dirtying the object - see the
+    // header declaration and issue #460.
+    InsertInternal(name, value, true /* overwrite */, false /* mark_dirty */);
+}
+
+void DictionaryObject::InsertInternal(NameObjectPtr name, ContainableObjectPtr value, bool overwrite, bool mark_dirty) {
 
     ACCESS_LOCK_GUARD(m_access_lock);
 
@@ -198,7 +213,10 @@ void DictionaryObject::Insert(NameObjectPtr name, ContainableObjectPtr value, bo
             throw DuplicateKeyException("The key " + name->ToString() + " was already present in the dictionary");
         }
 
-        spdlog::info("Overwriting dictionary entry for key: {}", name->ToString());
+        // Only a genuine, dirtying overwrite is worth flagging.
+        if (mark_dirty) {
+            spdlog::info("Overwriting dictionary entry for key: {}", name->ToString());
+        }
 
         // Preserve the state of the existing objects before removing them
         auto found_key = found->first;
@@ -216,7 +234,9 @@ void DictionaryObject::Insert(NameObjectPtr name, ContainableObjectPtr value, bo
     name->SetOwner(Object::GetWeakReference());
     value->SetOwner(Object::GetWeakReference());
 
-    IncrementVersion();
+    if (mark_dirty) {
+        IncrementVersion();
+    }
 }
 
 bool DictionaryObject::Contains(const NameObject& name) const {

--- a/src/vanillapdf/syntax/objects/dictionary_object.h
+++ b/src/vanillapdf/syntax/objects/dictionary_object.h
@@ -133,6 +133,12 @@ public:
     void Insert(NameObjectPtr name, ContainableObjectPtr value, bool overwrite = false);
     void Insert(const NameObject& name, ContainableObjectPtr value, bool overwrite = false);
 
+    // Replaces a write-time derived entry (e.g. /Length) WITHOUT marking the dictionary dirty;
+    // stamping such a value is not a logical mutation. TODO(2.4.0): drop this once the writer
+    // derives /Length from a single encode pass. See issue #460.
+    void ReplaceSerializationEntry(NameObjectPtr name, ContainableObjectPtr value);
+    void ReplaceSerializationEntry(const NameObject& name, ContainableObjectPtr value);
+
     bool Remove(const NameObjectPtr name);
     bool Remove(const NameObject& name);
 
@@ -144,6 +150,10 @@ public:
     virtual ~DictionaryObject();
 
 private:
+    // Shared implementation of Insert() and ReplaceSerializationEntry(). mark_dirty controls
+    // whether the change bumps the version (Insert: yes; serialization-derived stamp: no).
+    void InsertInternal(NameObjectPtr name, ContainableObjectPtr value, bool overwrite, bool mark_dirty);
+
     // Protects concurrent access to the dictionary
     std::unique_ptr<std::recursive_mutex> m_access_lock;
 };

--- a/src/vanillapdf/syntax/objects/stream_object.cpp
+++ b/src/vanillapdf/syntax/objects/stream_object.cpp
@@ -382,6 +382,10 @@ BufferPtr StreamObject::GetBodyEncoded() const {
         auto filters_size = filter_array->GetSize();
         for (decltype(filters_size) i = 0; i < filters_size; ++i) {
             auto current_filter = (*filter_array)[i];
+
+            // NOTE: array /Crypt is unsupported and inconsistent with the single-name branch -
+            // it ignores the named handler and then throws at GetFilterByName below. Left as-is;
+            // see https://github.com/vanillapdf/vanillapdf/issues/461.
             if (current_filter == constant::Name::Crypt) {
                 decoded_body = EncryptStream(decoded_body, GetRootObjectNumber(), GetRootGenerationNumber());
             }
@@ -406,7 +410,11 @@ BufferPtr StreamObject::GetBodyEncoded() const {
             decoded_body = filter->Encode(decoded_body, DictionaryObjectPtr(), m_attributes);
         }
 
-        return decoded_body;
+        // Encrypt the encoded result, like the single-name branch does. Without this, array-
+        // filter streams (e.g. /Filter [/FlateDecode] images) were written unencrypted while
+        // /Length recorded the encrypted size, corrupting the file (issue #460). Not reached
+        // for /Crypt arrays - those throw at GetFilterByName above (see #461).
+        return EncryptStream(decoded_body, GetRootObjectNumber(), GetRootGenerationNumber());
     }
 
     assert(is_filter_name ^ is_filter_array);


### PR DESCRIPTION
Fixes #460.

## The bug

Adding encryption to a document whose stream uses an **array `/Filter`** (e.g. `/Filter [/FlateDecode]`, the shape emitted for images) wrote the stream body **unencrypted** while stamping the *encrypted* size into `/Length`. The file was corrupt: on reopen a conformant reader fed the still-compressed bytes to AES and failed with `VANILLAPDF_ERROR_CRYPTO` (`EVP_DecryptFinal`). Any encrypted document containing an image was affected. It surfaced under AES-256 (CBC padding validation fails loudly); RC4 silently produced garbage.

The existing AES round-trip and interop suites stayed green because none of their fixtures contained an array-filter stream — writer and reader were wrong in the same direction.

## The fix

Two interacting defects, both required:

1. **`FileWriter::RecalculateStreamLength` dirtied a clean stream.** Stamping `/Length` (Remove+Insert) bumped the header version, so the body-write `GetBodyEncoded()` call took the dirty re-encode branch while the length had been computed on the clean fast path — the two disagreed on the byte count. A new **`DictionaryObject::ReplaceSerializationEntry`** stamps the derived `/Length` **without** marking the object dirty (`Insert` and it now share one private `InsertInternal`). `/Length` is derived from the bytes being written, so updating it is a serialization detail, not a logical mutation.

2. **The array-filter branch never encrypted.** `StreamObject::GetBodyEncoded`'s `is_filter_array` path returned the encoded body without applying stream-level encryption. It now mirrors the single-name branch.

The array `/Crypt` path is left unchanged — it is unsupported and throws at `GetFilterByName` — and tracked separately in #461. A `TODO(2.4.0)` marks the deeper structural rework (encode the body once and derive `/Length` from that exact buffer, making `/Length == bytes written` an invariant).

## Regression coverage

`pdftest2.pdf` has no array-filter streams, so the encryption interop check never reached this path. The qpdf AES-128/256 cases now run against `pdf20-utf8-test.pdf`, which carries a `/Filter [/FlateDecode]` stream, so qpdf validates stream decryption with an independent reader. RC4 stays on `pdftest2.pdf`; pyhanko unchanged.

## Verification

Proven with libqpdf 12.3.2 (the qpdf engine) and locally:

| | unfixed build | fixed build |
| --- | --- | --- |
| `pdf20-utf8-test.pdf` encrypted AES-256, read by qpdf | **rejected** (`PdfError`) | accepts, streams decode |
| `pdftest2.pdf` (no array filter) | accepts (misses the bug) | accepts |

- End-to-end CLI repro (`vanillapdf.tools encrypt` -> reopen) flips from `VANILLAPDF_ERROR_CRYPTO` (unfixed) to a clean full read (fixed).
- 28 existing encryption / dictionary / stream unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
