### PR TITLE
fix: Make downstream package automation update-only

### DIFF
--- a/.github/workflows/create-conan-pr.yml
+++ b/.github/workflows/create-conan-pr.yml
@@ -84,7 +84,9 @@ jobs:
           git checkout -b vanillapdf-${{ steps.version.outputs.version }} upstream/master
 
       - name: Require existing recipe (updates only)
-        if: ${{ steps.check_latest.outputs.is_latest == 'true' }}
+        # Real runs only: the guard exists to stop the automation from pushing a
+        # new recipe. A dry run never pushes, so it may proceed for inspection.
+        if: ${{ !inputs.dry_run && steps.check_latest.outputs.is_latest == 'true' }}
         run: |
           cd conan-center-index
           # This automation only bumps an already-registered recipe; first

--- a/.github/workflows/create-conan-pr.yml
+++ b/.github/workflows/create-conan-pr.yml
@@ -83,6 +83,18 @@ jobs:
           git fetch upstream
           git checkout -b vanillapdf-${{ steps.version.outputs.version }} upstream/master
 
+      - name: Require existing recipe (updates only)
+        if: ${{ steps.check_latest.outputs.is_latest == 'true' }}
+        run: |
+          cd conan-center-index
+          # This automation only bumps an already-registered recipe; first
+          # submissions to conan-io/conan-center-index are done manually.
+          if ! git cat-file -e upstream/master:recipes/vanillapdf/config.yml 2>/dev/null; then
+            echo "::error::vanillapdf is not yet in conan-io/conan-center-index. First submissions must be created manually; this automation only updates an existing recipe."
+            exit 1
+          fi
+          echo "Existing recipe found upstream - proceeding with update."
+
       - name: Calculate SHA256 for source archive
         if: ${{ steps.check_latest.outputs.is_latest == 'true' }}
         id: sha256
@@ -145,7 +157,7 @@ jobs:
         run: |
           cd conan-center-index
           git add recipes/vanillapdf/
-          git commit -m "Add vanillapdf/${{ steps.version.outputs.version }}"
+          git commit -m "vanillapdf: add version ${{ steps.version.outputs.version }}"
           git push origin vanillapdf-${{ steps.version.outputs.version }}
 
       - name: Generate PR info
@@ -184,7 +196,7 @@ jobs:
           VERSION="${{ inputs.tag }}"
           VERSION_NO_V="${VERSION#v}"
 
-          BODY="## New Recipe: vanillapdf/${VERSION_NO_V}
+          BODY="## Update: vanillapdf/${VERSION_NO_V}
 
           **Description:**
           Cross-platform toolkit for creating and modifying PDF documents.
@@ -206,7 +218,7 @@ jobs:
 
           gh pr create \
             --repo conan-io/conan-center-index \
-            --title "Add vanillapdf/${VERSION_NO_V}" \
+            --title "vanillapdf: add version ${VERSION_NO_V}" \
             --body "$BODY" \
             --base master \
             --head vanillapdf:${{ needs.prepare-conan-changes.outputs.branch-name }} \

--- a/.github/workflows/update-homebrew.yml
+++ b/.github/workflows/update-homebrew.yml
@@ -89,7 +89,9 @@ jobs:
           git checkout -b vanillapdf-${{ steps.version.outputs.version }} upstream/main
 
       - name: Require existing formula (updates only)
-        if: steps.check-latest.outputs.is_latest == 'true'
+        # Real runs only: the guard exists to stop the automation from pushing a
+        # new formula. A dry run never pushes, so it may proceed for inspection.
+        if: ${{ !inputs.dry_run && steps.check-latest.outputs.is_latest == 'true' }}
         run: |
           cd homebrew-core
           # This automation only bumps an already-published formula; first

--- a/.github/workflows/update-homebrew.yml
+++ b/.github/workflows/update-homebrew.yml
@@ -86,7 +86,7 @@ jobs:
           cd homebrew-core
           git remote add upstream https://github.com/Homebrew/homebrew-core.git
           git fetch upstream
-          git checkout -b vanillapdf-${{ steps.version.outputs.version }} upstream/master
+          git checkout -b vanillapdf-${{ steps.version.outputs.version }} upstream/main
 
       - name: Calculate SHA256 for source archive
         if: steps.check-latest.outputs.is_latest == 'true'
@@ -123,8 +123,14 @@ jobs:
         if: steps.check-latest.outputs.is_latest == 'true'
         run: |
           cd homebrew-core
-          # Audit the formula for issues
-          brew audit --strict --online Formula/v/vanillapdf.rb || true
+          # First submissions must pass the stricter new-formula audit;
+          # subsequent version bumps use the standard audit. upstream is the
+          # real Homebrew/homebrew-core.
+          if git ls-tree upstream/main --name-only | grep -q "Formula/v/vanillapdf.rb"; then
+            brew audit --strict --online Formula/v/vanillapdf.rb || true
+          else
+            brew audit --new --strict --online Formula/v/vanillapdf.rb || true
+          fi
 
       - name: Show prepared changes (dry run)
         if: ${{ steps.check-latest.outputs.is_latest == 'true' && inputs.dry_run }}
@@ -161,7 +167,7 @@ jobs:
           git add Formula/v/vanillapdf.rb
 
           # Check if formula already exists in upstream (update vs new)
-          if git ls-tree upstream/master --name-only | grep -q "Formula/v/vanillapdf.rb"; then
+          if git ls-tree upstream/main --name-only | grep -q "Formula/v/vanillapdf.rb"; then
             git commit -m "vanillapdf ${VERSION}"
           else
             git commit -m "vanillapdf ${VERSION} (new formula)"
@@ -173,9 +179,9 @@ jobs:
         if: steps.check-latest.outputs.is_latest == 'true'
         id: pr-info
         run: |
-          echo "pr-url=https://github.com/vanillapdf/homebrew-core/compare/master...vanillapdf-${{ steps.version.outputs.version }}" >> "$GITHUB_OUTPUT"
+          echo "pr-url=https://github.com/vanillapdf/homebrew-core/compare/main...vanillapdf-${{ steps.version.outputs.version }}" >> "$GITHUB_OUTPUT"
           echo "Changes prepared and pushed to vanillapdf/homebrew-core"
-          echo "Review the changes at: https://github.com/vanillapdf/homebrew-core/compare/master...vanillapdf-${{ steps.version.outputs.version }}"
+          echo "Review the changes at: https://github.com/vanillapdf/homebrew-core/compare/main...vanillapdf-${{ steps.version.outputs.version }}"
 
   create-official-pr:
     name: Create PR to official Homebrew repo
@@ -206,8 +212,8 @@ jobs:
           VERSION_NO_V="${VERSION#v}"
 
           # Check if this is a new formula or update
-          git fetch upstream master
-          if git ls-tree upstream/master --name-only | grep -q "Formula/v/vanillapdf.rb"; then
+          git fetch upstream main
+          if git ls-tree upstream/main --name-only | grep -q "Formula/v/vanillapdf.rb"; then
             TITLE="vanillapdf ${VERSION_NO_V}"
             IS_NEW="false"
           else
@@ -246,7 +252,7 @@ jobs:
             --repo Homebrew/homebrew-core \
             --title "$TITLE" \
             --body "$BODY" \
-            --base master \
+            --base main \
             --head vanillapdf:${{ needs.prepare-homebrew-changes.outputs.branch-name }} \
             --draft
         env:

--- a/.github/workflows/update-homebrew.yml
+++ b/.github/workflows/update-homebrew.yml
@@ -88,6 +88,18 @@ jobs:
           git fetch upstream
           git checkout -b vanillapdf-${{ steps.version.outputs.version }} upstream/main
 
+      - name: Require existing formula (updates only)
+        if: steps.check-latest.outputs.is_latest == 'true'
+        run: |
+          cd homebrew-core
+          # This automation only bumps an already-published formula; first
+          # submissions to Homebrew/homebrew-core are done manually.
+          if ! git cat-file -e upstream/main:Formula/v/vanillapdf.rb 2>/dev/null; then
+            echo "::error::vanillapdf is not yet in Homebrew/homebrew-core. First submissions must be created manually; this automation only updates an existing formula."
+            exit 1
+          fi
+          echo "Existing formula found upstream - proceeding with update."
+
       - name: Calculate SHA256 for source archive
         if: steps.check-latest.outputs.is_latest == 'true'
         id: sha256
@@ -123,14 +135,10 @@ jobs:
         if: steps.check-latest.outputs.is_latest == 'true'
         run: |
           cd homebrew-core
-          # First submissions must pass the stricter new-formula audit;
-          # subsequent version bumps use the standard audit. upstream is the
-          # real Homebrew/homebrew-core.
-          if git ls-tree upstream/main --name-only | grep -q "Formula/v/vanillapdf.rb"; then
-            brew audit --strict --online Formula/v/vanillapdf.rb || true
-          else
-            brew audit --new --strict --online Formula/v/vanillapdf.rb || true
-          fi
+          # Formula already exists upstream (enforced by the guard above), so
+          # this is always a version bump — use the standard audit. A failing
+          # audit fails the job rather than being swallowed.
+          brew audit --strict --online Formula/v/vanillapdf.rb
 
       - name: Show prepared changes (dry run)
         if: ${{ steps.check-latest.outputs.is_latest == 'true' && inputs.dry_run }}
@@ -165,14 +173,7 @@ jobs:
           cd homebrew-core
           VERSION="${{ steps.version.outputs.version }}"
           git add Formula/v/vanillapdf.rb
-
-          # Check if formula already exists in upstream (update vs new)
-          if git ls-tree upstream/main --name-only | grep -q "Formula/v/vanillapdf.rb"; then
-            git commit -m "vanillapdf ${VERSION}"
-          else
-            git commit -m "vanillapdf ${VERSION} (new formula)"
-          fi
-
+          git commit -m "vanillapdf ${VERSION}"
           git push origin vanillapdf-${{ steps.version.outputs.version }}
 
       - name: Generate PR info
@@ -211,26 +212,13 @@ jobs:
           VERSION="${{ inputs.tag }}"
           VERSION_NO_V="${VERSION#v}"
 
-          # Check if this is a new formula or update
-          git fetch upstream main
-          if git ls-tree upstream/main --name-only | grep -q "Formula/v/vanillapdf.rb"; then
-            TITLE="vanillapdf ${VERSION_NO_V}"
-            IS_NEW="false"
-          else
-            TITLE="vanillapdf ${VERSION_NO_V} (new formula)"
-            IS_NEW="true"
-          fi
+          # This automation only updates an existing formula; first submissions
+          # are done manually.
+          TITLE="vanillapdf ${VERSION_NO_V}"
 
           BODY="## Description
 
-          "
-          if [ "$IS_NEW" = "true" ]; then
-            BODY="${BODY}Add vanillapdf formula - a cross-platform toolkit for creating and modifying PDF documents."
-          else
-            BODY="${BODY}Update vanillapdf to version ${VERSION_NO_V}."
-          fi
-
-          BODY="${BODY}
+          Update vanillapdf to version ${VERSION_NO_V}.
 
           - **Homepage**: https://vanillapdf.com
           - **Repository**: https://github.com/vanillapdf/vanillapdf

--- a/scripts/prepare_cci_recipe.py
+++ b/scripts/prepare_cci_recipe.py
@@ -14,6 +14,32 @@ import argparse
 import os
 import shutil
 
+import yaml
+
+
+def load_yaml(path):
+    """Load a YAML mapping from path.
+
+    A missing file is expected for a first-time submission and yields an empty
+    mapping. A file that is present but malformed (unparseable, or parsing to
+    something other than a mapping) is a hard error: silently returning {} would
+    drop every previously published version from the regenerated recipe.
+    """
+    if not os.path.exists(path):
+        return {}
+    with open(path) as f:
+        data = yaml.safe_load(f)
+    if data is None:
+        return {}
+    if not isinstance(data, dict):
+        raise ValueError(f"{path} did not parse to a YAML mapping")
+    return data
+
+
+def dump_yaml(path, data):
+    with open(path, "w") as f:
+        yaml.safe_dump(data, f, sort_keys=False, default_flow_style=False)
+
 
 def main():
     parser = argparse.ArgumentParser(description="Prepare CCI recipe files")
@@ -46,18 +72,22 @@ def main():
     for entry in os.listdir(src_dir):
         shutil.copy2(os.path.join(src_dir, entry), test_pkg_dir)
 
-    # Generate conandata.yml
-    with open(os.path.join(recipe_dir, "conandata.yml"), "w") as f:
-        f.write(f'sources:\n')
-        f.write(f'  "{args.version}":\n')
-        f.write(f'    url: "https://github.com/vanillapdf/vanillapdf/archive/refs/tags/v{args.version}.tar.gz"\n')
-        f.write(f'    sha256: "{args.sha256}"\n')
+    # Generate conandata.yml. Merge into any existing file so older releases
+    # keep their source entries — CCI expects every published version to remain
+    # buildable, and cloning the fork off upstream/master carries the existing
+    # recipe once vanillapdf is registered.
+    conandata_path = os.path.join(recipe_dir, "conandata.yml")
+    conandata = load_yaml(conandata_path)
+    conandata.setdefault("sources", {})[args.version] = {
+        "url": f"https://github.com/vanillapdf/vanillapdf/archive/refs/tags/v{args.version}.tar.gz",
+        "sha256": args.sha256,
+    }
+    dump_yaml(conandata_path, conandata)
 
-    # Generate config.yml
-    with open(config_path, "w") as f:
-        f.write(f'versions:\n')
-        f.write(f'  "{args.version}":\n')
-        f.write(f'    folder: all\n')
+    # Generate config.yml. Merge so previously published versions are preserved.
+    config = load_yaml(config_path)
+    config.setdefault("versions", {})[args.version] = {"folder": "all"}
+    dump_yaml(config_path, config)
 
     print(f"CCI recipe prepared for vanillapdf/{args.version}")
     print(f"  Recipe dir: {recipe_dir}")


### PR DESCRIPTION
## Summary

Corrects the Homebrew and Conan Center downstream package-PR automation so it is strictly **update-only**. First submissions to `Homebrew/homebrew-core` and `conan-io/conan-center-index` are done manually; the automation only bumps an already-published formula/recipe. None of this affects the release itself — the GitHub/NuGet/deb/rpm/dmg artifacts publish independently.

## Changes

### Homebrew: `master` → `main` (`update-homebrew.yml`)
`Homebrew/homebrew-core` migrated its default branch to `main`, but the workflow still targeted `master` for the branch base, the upstream fetch, the PR base, and the review URLs — every Homebrew PR job failed at checkout of `upstream/master`. All references now point at `main`.

`create-conan-pr.yml` stays on `master` — `conan-io/conan-center-index` still uses it.

### Conan: merge instead of overwrite (`prepare_cci_recipe.py`)
`config.yml` and `conandata.yml` are merged into the existing files instead of being regenerated with only the current version, so previously published versions survive each subsequent release. A missing file is treated as empty (only reachable before the manual first submission); a present-but-malformed file fails loudly rather than silently wiping published versions.

### Update-only: no automated first submissions
Per maintainer decision, the automation must never create a brand-new formula/recipe.
- Each prepare job now **fails fast** with a "create the first submission manually" message when the formula/recipe does not yet exist upstream. The check uses `git cat-file -e`; the previous `git ls-tree ... | grep "Formula/v/vanillapdf.rb"` was non-recursive and never matched a nested path, so it always fell through to the new-formula branch.
- The now-unreachable new-formula paths are removed: the `brew audit --new` branch, the `(new formula)` commit message and PR title, and the Conan `New Recipe` framing.

### Stop swallowing the Homebrew audit
`brew audit --strict --online … || true` discarded the audit's exit code, so a failing audit could still ship a formula. The `|| true` is removed — a failing audit now fails the job. (A repo-wide ban on `|| true` and cleanup of the remaining occurrences is handled in a separate PR.)

## Sequencing note
Intended to merge **after** 2.3.0. The 2.3.0 auto-run of `homebrew-pr` still failed on the old `master` config; after this merges to `main`, re-run `update-homebrew.yml` via `workflow_dispatch` (`dry_run: false`, tag `v2.3.0`) — dispatched workflows execute the YAML from `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
