### PR TITLE
fix: Pin vcpkg port usage file to CRLF line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -14,6 +14,11 @@
 *.sln text eol=crlf
 *.vcxproj text eol=crlf
 
+# The vcpkg port "usage" text is stored with CRLF in Microsoft's vcpkg registry.
+# Pin it to CRLF here so the release automation (create-vcpkg-pr.yml) checks it
+# out with matching line endings and stops churning them on every port update.
+ports/vanillapdf/usage text eol=crlf
+
 # Denote all files that are truly binary and should not be modified.
 *.pdf binary
 *.smproj binary


### PR DESCRIPTION
## Summary

Microsoft's vcpkg registry stores `ports/vanillapdf/usage` with **CRLF** line endings, but this repo stores it **LF-normalized**. The release automation (`create-vcpkg-pr.yml`) copies our checked-out overlay into the vcpkg fork with `cp -r vanillapdf/ports/vanillapdf/* vcpkg/ports/vanillapdf/`, and on the Linux runner that checkout is LF — so every port-update PR flips the file LF→CRLF as pure churn.

This surfaced in [microsoft/vcpkg#53043](https://github.com/microsoft/vcpkg/pull/53043) (the 2.3.0 port update), where `usage` showed a spurious line-ending-only diff that had to be reverted by hand.

## Change

Pin `ports/vanillapdf/usage` to `eol=crlf` in the root `.gitattributes`, mirroring the existing `*.sln` / `*.vcxproj` CRLF rules, so it checks out with CRLF on every platform (including CI). The copied bytes then match what vcpkg stores, and future port-update PRs no longer churn the file.

- No functional change; the stored blob stays LF-normalized (only checkout EOL is pinned).
- Rule placed at repo root rather than a port-local `.gitattributes` so it can never be accidentally copied into the vcpkg port by the `cp -r` step.

## Verification

```
$ git check-attr -a ports/vanillapdf/usage
ports/vanillapdf/usage: text: set
ports/vanillapdf/usage: eol: crlf
```
