### PR TITLE
docs: Document EOL policy for backport labels

### DIFF
--- a/.claude/rules/ci-cd.md
+++ b/.claude/rules/ci-cd.md
@@ -62,6 +62,17 @@ Build and run the affected tests against the release branch before opening the P
 
 **When creating a new `release/X.Y` branch**, also create its three labels (`backport release/X.Y`, `backported release/X.Y`, `backport-failed release/X.Y`) — they are created manually, and `backport.sh` applies `backport-failed` with a bare `gh` call that assumes the label exists.
 
+**Retiring a release line (EOL):** when a `release/X.Y` line is no longer supported, prune only the *actionable* labels and keep the historical one.
+- **Delete** `backport release/X.Y` (a request trigger — no meaning once the line is dead) and `backport-failed release/X.Y` (an action-needed signal — moot for an EOL line).
+- **Keep `backported release/X.Y` forever** — it is the historical record of what shipped where.
+- **Leave the `release/X.Y` branch in place** — the `deletion` rule in the "Protect release branches" ruleset blocks removal anyway, and the branch is harmless history.
+
+The `backported release/X.Y` label is the fast filter, but it is not the system of record: every backport also lands as a PR titled `[Backport release/X.Y] …` (body `Backport of #<original>`) plus a commit on the release branch, so the full trail survives even a label deletion:
+```bash
+gh pr list --state all --search "[Backport release/2.1] in:title"   # reconstruct a line's history without the label
+```
+Note: **deleting a label erases it from every PR it was on, and recreating the label does not restore those associations** — so never delete `backported release/X.Y`.
+
 ## Homebrew
 
 Formula template in `homebrew/vanillapdf.rb.in` (the concrete `.rb` is generated at release time). Releases auto-PR to `Homebrew/homebrew-core` via `update-homebrew.yml`.


### PR DESCRIPTION
## Summary

Documents what happens to backport labels when a `release/X.Y` line reaches end-of-life, so the decision is not re-litigated each time a line is retired.

## Policy

When a release line is no longer supported:
- **Delete** `backport release/X.Y` (a request trigger — no meaning once the line is dead) and `backport-failed release/X.Y` (an action-needed signal — moot for an EOL line).
- **Keep `backported release/X.Y` forever** — it is the historical record of what shipped where.
- **Leave the `release/X.Y` branch in place** — the `deletion` rule in the "Protect release branches" ruleset blocks removal anyway, and the branch is harmless history.

The write-up also records two facts that motivated the policy: the backport PRs (`[Backport release/X.Y] …` + `Backport of #<original>`) plus the release-branch commits are the real system of record — the label is only a fast filter — and deleting a label erases it from every PR it was on, with recreation *not* restoring those associations.

## Context

Applied while retiring `release/2.1`: the two actionable 2.1 labels were deleted and `backported release/2.1` was kept (re-applied to #341, the one PR that carried it). This PR just captures the rule so future EOL cleanups are consistent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
