### PR TITLE
fix: PNG predictor ceil stride and fail-closed on malformed input (#443, #442)

### DIFF
--- a/scripts/png_predictor_vectors.py
+++ b/scripts/png_predictor_vectors.py
@@ -25,10 +25,10 @@ reproduce the exact arrays committed there, run
 ``scripts/regenerate_filter_test_vectors.py``, which pins the parameters they
 were generated with.
 
-Sub-byte pixel depths (``colors * bits`` not a multiple of 8) are rejected:
-the byte stride this tool mirrors from ``flate_decode_filter.cpp`` floors,
-while the PNG specification (and MuPDF) round up, so such vectors can never
-certify (see GitHub issue #443).
+Sub-byte pixel depths (``colors * bits`` not a multiple of 8) are supported:
+the byte stride mirrors ``flate_decode_filter.cpp`` and the PNG specification
+(and MuPDF), which round the pixel bit depth up to whole bytes
+(see https://github.com/vanillapdf/vanillapdf/issues/443).
 
 Requires PyMuPDF (``pip install pymupdf``).
 
@@ -108,8 +108,9 @@ class Geometry:
 
     @property
     def bytes_per_pixel(self) -> int:
-        # Matches flate_decode_filter.cpp: colors * bits / 8 (integer division).
-        return self.colors * self.bits_per_component // 8
+        # Matches flate_decode_filter.cpp and the PNG spec: ceil(colors * bits / 8),
+        # minimum 1. See https://github.com/vanillapdf/vanillapdf/issues/443
+        return (self.colors * self.bits_per_component + 7) // 8
 
     @property
     def bytes_per_row(self) -> int:
@@ -246,17 +247,16 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--bytes-per-line", type=positive_int, default=12,
                         dest="bytes_per_line",
                         help="bytes per line in the emitted C arrays (default 12)")
+    parser.add_argument("--name-prefix", type=str, default="", dest="name_prefix",
+                        help="prefix for the emitted C array names, e.g. SUBBYTE_ "
+                             "(default empty)")
 
-    args = parser.parse_args(argv)
-    if (args.colors * args.bits_per_component) % 8 != 0:
-        parser.error("colors * bits must be a multiple of 8 (whole-byte pixels); "
-                     "sub-byte pixel depths cannot certify against MuPDF "
-                     "(see GitHub issue #443)")
-    return args
+    return parser.parse_args(argv)
 
 
 def render_vectors(geometry: Geometry, raw_rows: Sequence[Sequence[int]],
-                   compression_level: int, bytes_per_line: int) -> str:
+                   compression_level: int, bytes_per_line: int,
+                   name_prefix: str = "") -> str:
     """Encode, certify and render one vector per PNG filter as a C source block."""
     expected = flatten_rows(raw_rows)
 
@@ -265,9 +265,9 @@ def render_vectors(geometry: Geometry, raw_rows: Sequence[Sequence[int]],
         filtered = encode_scanlines(geometry, raw_rows, filter_code)
         compressed = zlib.compress(filtered, compression_level)
         certify_vector(compressed, geometry, expected, name)
-        blocks.append(format_c_array("INPUT_" + name.upper(), compressed, bytes_per_line))
+        blocks.append(format_c_array(name_prefix + "INPUT_" + name.upper(), compressed, bytes_per_line))
 
-    blocks.append(format_c_array("EXPECTED_RAW", expected, bytes_per_line))
+    blocks.append(format_c_array(name_prefix + "EXPECTED_RAW", expected, bytes_per_line))
 
     geometry_comment = (
         f"// geometry: Colors={geometry.colors} "
@@ -283,7 +283,8 @@ def main(argv: Sequence[str] | None = None) -> None:
     args = parse_args(argv)
     geometry = Geometry(args.colors, args.bits_per_component, args.columns)
     raw_rows = build_raw_rows(geometry, args.rows, args.seed)
-    output = render_vectors(geometry, raw_rows, args.compression_level, args.bytes_per_line)
+    output = render_vectors(geometry, raw_rows, args.compression_level,
+                            args.bytes_per_line, args.name_prefix)
     print(output)
 
 

--- a/scripts/regenerate_filter_test_vectors.py
+++ b/scripts/regenerate_filter_test_vectors.py
@@ -16,7 +16,7 @@ from png_predictor_vectors import main
 
 # Exact parameters behind the committed vectors: a 4x3 RGB (8-bit) image with a
 # fixed random seed, zlib level 9, wrapped at 12 bytes per emitted C line.
-PINNED_ARGUMENTS = [
+RGB8_ARGUMENTS = [
     "--colors", "3",
     "--bits", "8",
     "--columns", "4",
@@ -26,6 +26,24 @@ PINNED_ARGUMENTS = [
     "--bytes-per-line", "12",
 ]
 
+# Sub-byte pixel depth: 3 colors x 4 bits = 12 pixel bits, so bytes-per-pixel is
+# ceil(12/8)=2 where the old floor gave 1 -- the divergence that silently
+# corrupted such streams (https://github.com/vanillapdf/vanillapdf/issues/443).
+# Emitted with a SUBBYTE_ name prefix so the arrays don't collide with the RGB8
+# set above.
+SUBBYTE_ARGUMENTS = [
+    "--colors", "3",
+    "--bits", "4",
+    "--columns", "4",
+    "--rows", "3",
+    "--seed", "0",
+    "--compression-level", "9",
+    "--bytes-per-line", "12",
+    "--name-prefix", "SUBBYTE_",
+]
+
 
 if __name__ == "__main__":
-    main(PINNED_ARGUMENTS)
+    main(RGB8_ARGUMENTS)
+    print()
+    main(SUBBYTE_ARGUMENTS)

--- a/src/vanillapdf.unittest/filter_test.cpp
+++ b/src/vanillapdf.unittest/filter_test.cpp
@@ -70,14 +70,20 @@ TEST(FlateDecodeFilter, InvalidDataDecodeError) {
 // --- PNG predictor reconstruction regression -----------------------------
 //
 // Regenerate with scripts/regenerate_filter_test_vectors.py, which pins the
-// parameters and prints these arrays. The underlying tool
+// parameters and prints both array sets below. The underlying tool
 // (scripts/png_predictor_vectors.py) certifies every vector against MuPDF
 // (PyMuPDF), an independent PDF engine, before emitting it. Each INPUT_* array
-// is a zlib-compressed, PNG-filtered RGB image (Colors=3, BitsPerComponent=8,
-// Columns=4, 3 rows); decoding it with the matching DecodeParms must yield
-// EXPECTED_RAW. Average and Paeth carry the historical bug (the reconstructed
-// byte was written to current[i] instead of current[bytes_per_pixel + i]);
-// None/Sub/Up are covered too so every filter branch is guarded.
+// is a zlib-compressed, PNG-filtered image; decoding it with the matching
+// DecodeParms must yield the corresponding EXPECTED_RAW.
+//
+// INPUT_*         : RGB image (Colors=3, BitsPerComponent=8, Columns=4, 3 rows).
+//                   Average and Paeth carry the historical reconstruction bug
+//                   (byte written to current[i] instead of
+//                   current[bytes_per_pixel + i]); None/Sub/Up guard the rest.
+// SUBBYTE_INPUT_* : sub-byte pixel depth (Colors=3, BitsPerComponent=4,
+//                   Columns=4, 3 rows) where bytes_per_pixel is ceil(12/8)=2 but
+//                   the old floor gave 1, silently corrupting the output.
+//                   https://github.com/vanillapdf/vanillapdf/issues/443
 
 static const unsigned char INPUT_NONE[] = {
     0x78, 0xDA, 0x01, 0x27, 0x00, 0xD8, 0xFF, 0x00, 0xC5, 0xD7, 0x14, 0x84,
@@ -124,6 +130,64 @@ static const unsigned char EXPECTED_RAW[] = {
     0xA1, 0x68, 0xF4, 0xE2, 0x85, 0x1F, 0x07, 0x2F, 0xCC, 0x00, 0xFC, 0xAA,
 };
 
+static const unsigned char SUBBYTE_INPUT_NONE[] = {
+    0x78, 0xDA, 0x63, 0x38, 0x7A, 0x5D, 0xA4, 0xE5, 0xC7, 0x79, 0x86, 0xD9,
+    0x5F, 0xB6, 0xE7, 0xBB, 0x4F, 0x60, 0x70, 0x37, 0x68, 0xF0, 0x9E, 0x67,
+    0x04, 0x00, 0x72, 0xA5, 0x09, 0x9A,
+};
+
+static const unsigned char SUBBYTE_INPUT_SUB[] = {
+    0x78, 0xDA, 0x63, 0x3C, 0x7A, 0xDD, 0x7F, 0xED, 0x13, 0x6F, 0xC6, 0xD9,
+    0x5F, 0x64, 0xAA, 0x27, 0x28, 0x32, 0xBA, 0x1B, 0x58, 0x4A, 0xCB, 0x3D,
+    0x07, 0x00, 0x67, 0xA3, 0x08, 0x72,
+};
+
+static const unsigned char SUBBYTE_INPUT_UP[] = {
+    0x78, 0xDA, 0x63, 0x3A, 0x7A, 0x5D, 0xA4, 0xE5, 0xC7, 0x79, 0xA6, 0x6B,
+    0xB2, 0x8B, 0x5F, 0xFB, 0x1F, 0x64, 0x5A, 0x63, 0x73, 0xF2, 0x4E, 0xF8,
+    0x22, 0x00, 0x77, 0x03, 0x0B, 0x19,
+};
+
+static const unsigned char SUBBYTE_INPUT_AVERAGE[] = {
+    0x78, 0xDA, 0x63, 0x3E, 0x7A, 0x7D, 0x93, 0xE4, 0xBB, 0x5E, 0x66, 0xCB,
+    0xCE, 0x84, 0xCD, 0x05, 0x1F, 0x99, 0x7F, 0x6D, 0x63, 0xFC, 0x63, 0x7D,
+    0x14, 0x00, 0x72, 0xC0, 0x0A, 0xCF,
+};
+
+static const unsigned char SUBBYTE_INPUT_PAETH[] = {
+    0x78, 0xDA, 0x63, 0x39, 0x7A, 0xDD, 0x7F, 0xED, 0x13, 0x6F, 0x96, 0x6B,
+    0xB2, 0x8B, 0x5F, 0xFB, 0x1F, 0x64, 0x59, 0x63, 0x63, 0x29, 0x1D, 0x7E,
+    0x18, 0x00, 0x70, 0xD8, 0x09, 0xBB,
+};
+
+static const unsigned char SUBBYTE_EXPECTED_RAW[] = {
+    0xC5, 0xD7, 0x14, 0x84, 0xF8, 0xCF, 0x9B, 0xF4, 0xB7, 0x6F, 0x47, 0x90,
+    0x47, 0x30, 0x80, 0x4B, 0x9E, 0x32,
+};
+
+// --- PNG predictor malformed / edge input (#442) -------------------------
+//
+// Hand-crafted, NOT from the vector generator (which only emits valid data).
+// All three decode with Colors=1, BitsPerComponent=8, Columns=3 (bytes_per_row
+// = 3). Reproduce with (zlib is stdlib, no MuPDF needed):
+//   zlib.compress(bytes([0x07, 0x10, 0x20, 0x30]), 9)              # unknown filter (0x07 > 4)
+//   zlib.compress(b"", 9)                                          # empty predicted stream
+//   zlib.compress(bytes([0x00,0x10,0x20,0x30, 0x00,0x40,0x50]), 9) # truncated final scanline
+// https://github.com/vanillapdf/vanillapdf/issues/442
+
+static const unsigned char INPUT_UNKNOWN_FILTER[] = {
+    0x78, 0xDA, 0x63, 0x17, 0x50, 0x30, 0x00, 0x00, 0x00, 0xC0, 0x00, 0x68,
+};
+
+static const unsigned char INPUT_EMPTY_PREDICTED[] = {
+    0x78, 0xDA, 0x03, 0x00, 0x00, 0x00, 0x00, 0x01,
+};
+
+static const unsigned char INPUT_TRUNCATED_SCANLINE[] = {
+    0x78, 0xDA, 0x63, 0x10, 0x50, 0x30, 0x60, 0x70, 0x08, 0x00, 0x00, 0x02,
+    0x97, 0x00, 0xF1,
+};
+
 static void InsertIntegerEntry(DictionaryObjectHandle* dict, string_type key, bigint_type value) {
     HandleGuard<NameObjectHandle, NameObject_Release> name;
     HandleGuard<IntegerObjectHandle, IntegerObject_Release> integer;
@@ -135,9 +199,32 @@ static void InsertIntegerEntry(DictionaryObjectHandle* dict, string_type key, bi
     ASSERT_EQ(DictionaryObject_Insert(dict, name, object, VANILLAPDF_RV_TRUE), VANILLAPDF_ERROR_SUCCESS);
 }
 
-static void DecodePngPredictorAndCompare(
-    const unsigned char* input, size_type input_len,
-    const unsigned char* expected, size_type expected_len) {
+struct PngPredictorCase {
+    std::string_view name;
+    const unsigned char* input;
+    size_type input_len;
+    const unsigned char* expected;
+    size_type expected_len;
+    bigint_type colors;
+    bigint_type bits_per_component;
+    bigint_type columns;
+
+    // Deduce the array lengths so call sites pass the vectors directly without
+    // repeating sizeof for each one.
+    template <size_t input_size, size_t expected_size>
+    PngPredictorCase(
+        std::string_view case_name,
+        const unsigned char (&input_bytes)[input_size],
+        const unsigned char (&expected_bytes)[expected_size],
+        bigint_type color_count, bigint_type bit_depth, bigint_type column_count)
+        : name(case_name),
+          input(input_bytes), input_len(input_size),
+          expected(expected_bytes), expected_len(expected_size),
+          colors(color_count), bits_per_component(bit_depth), columns(column_count) {
+    }
+};
+
+static void DecodePngPredictorAndCompare(const PngPredictorCase& param) {
 
     HandleGuard<FlateDecodeFilterHandle, FlateDecodeFilter_Release> filter;
     HandleGuard<BufferHandle, Buffer_Release> input_buffer;
@@ -145,14 +232,14 @@ static void DecodePngPredictorAndCompare(
     HandleGuard<BufferHandle, Buffer_Release> decoded_buffer;
 
     ASSERT_EQ(FlateDecodeFilter_Create(filter.out()), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Buffer_CreateFromData(reinterpret_cast<string_type>(input), input_len, input_buffer.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Buffer_CreateFromData(reinterpret_cast<string_type>(param.input), param.input_len, input_buffer.out()), VANILLAPDF_ERROR_SUCCESS);
     ASSERT_EQ(DictionaryObject_Create(params.out()), VANILLAPDF_ERROR_SUCCESS);
 
-    // DecodeParms for a PNG-predicted (Predictor >= 10) RGB image.
+    // DecodeParms for a PNG-predicted (Predictor >= 10) image.
     InsertIntegerEntry(params, "Predictor", 15);
-    InsertIntegerEntry(params, "Colors", 3);
-    InsertIntegerEntry(params, "BitsPerComponent", 8);
-    InsertIntegerEntry(params, "Columns", 4);
+    InsertIntegerEntry(params, "Colors", param.colors);
+    InsertIntegerEntry(params, "BitsPerComponent", param.bits_per_component);
+    InsertIntegerEntry(params, "Columns", param.columns);
 
     ASSERT_EQ(FlateDecodeFilter_DecodeParams(filter, input_buffer, params, decoded_buffer.out()), VANILLAPDF_ERROR_SUCCESS);
     ASSERT_NE(decoded_buffer.get(), nullptr);
@@ -162,39 +249,82 @@ static void DecodePngPredictorAndCompare(
     ASSERT_EQ(Buffer_GetData(decoded_buffer, &decoded_data, &decoded_len), VANILLAPDF_ERROR_SUCCESS);
     ASSERT_NE(decoded_data, nullptr);
 
-    ASSERT_EQ(decoded_len, expected_len);
-    for (size_type i = 0; i < expected_len; ++i) {
-        EXPECT_EQ(static_cast<unsigned char>(decoded_data[i]), expected[i]);
+    ASSERT_EQ(decoded_len, param.expected_len);
+    for (size_type i = 0; i < param.expected_len; ++i) {
+        EXPECT_EQ(static_cast<unsigned char>(decoded_data[i]), param.expected[i]);
     }
 }
-
-struct PngPredictorCase {
-    std::string_view name;
-    const unsigned char* input;
-    size_type input_len;
-};
 
 class PngPredictorReconstructionTest : public ::testing::TestWithParam<PngPredictorCase> {};
 
 TEST_P(PngPredictorReconstructionTest, ReconstructsExpectedImage) {
-    const auto& param = GetParam();
-    DecodePngPredictorAndCompare(param.input, param.input_len, EXPECTED_RAW, sizeof(EXPECTED_RAW));
+    DecodePngPredictorAndCompare(GetParam());
 }
 
 INSTANTIATE_TEST_SUITE_P(
     FlateDecodeFilter,
     PngPredictorReconstructionTest,
     ::testing::Values(
-        PngPredictorCase{ "None", INPUT_NONE, sizeof(INPUT_NONE) },
-        PngPredictorCase{ "Sub", INPUT_SUB, sizeof(INPUT_SUB) },
-        PngPredictorCase{ "Up", INPUT_UP, sizeof(INPUT_UP) },
-        PngPredictorCase{ "Average", INPUT_AVERAGE, sizeof(INPUT_AVERAGE) },
-        PngPredictorCase{ "Paeth", INPUT_PAETH, sizeof(INPUT_PAETH) }
+        PngPredictorCase{ "None",    INPUT_NONE,    EXPECTED_RAW, 3, 8, 4 },
+        PngPredictorCase{ "Sub",     INPUT_SUB,     EXPECTED_RAW, 3, 8, 4 },
+        PngPredictorCase{ "Up",      INPUT_UP,      EXPECTED_RAW, 3, 8, 4 },
+        PngPredictorCase{ "Average", INPUT_AVERAGE, EXPECTED_RAW, 3, 8, 4 },
+        PngPredictorCase{ "Paeth",   INPUT_PAETH,   EXPECTED_RAW, 3, 8, 4 },
+        PngPredictorCase{ "SubByte_None",    SUBBYTE_INPUT_NONE,    SUBBYTE_EXPECTED_RAW, 3, 4, 4 },
+        PngPredictorCase{ "SubByte_Sub",     SUBBYTE_INPUT_SUB,     SUBBYTE_EXPECTED_RAW, 3, 4, 4 },
+        PngPredictorCase{ "SubByte_Up",      SUBBYTE_INPUT_UP,      SUBBYTE_EXPECTED_RAW, 3, 4, 4 },
+        PngPredictorCase{ "SubByte_Average", SUBBYTE_INPUT_AVERAGE, SUBBYTE_EXPECTED_RAW, 3, 4, 4 },
+        PngPredictorCase{ "SubByte_Paeth",   SUBBYTE_INPUT_PAETH,   SUBBYTE_EXPECTED_RAW, 3, 4, 4 }
     ),
     [](const ::testing::TestParamInfo<PngPredictorCase>& info) {
         return std::string(info.param.name);
     }
 );
+
+// PNG predictor malformed / edge input (#442): decode with a fixed geometry
+// (Colors=1, BitsPerComponent=8, Columns=3) and return the raw C API result so
+// the caller can assert on success/failure.
+static error_type DecodePngPredictorRaw(
+    const unsigned char* input, size_type input_len, BufferHandle** decoded_out) {
+
+    HandleGuard<FlateDecodeFilterHandle, FlateDecodeFilter_Release> filter;
+    HandleGuard<BufferHandle, Buffer_Release> input_buffer;
+    HandleGuard<DictionaryObjectHandle, DictionaryObject_Release> params;
+
+    EXPECT_EQ(FlateDecodeFilter_Create(filter.out()), VANILLAPDF_ERROR_SUCCESS);
+    EXPECT_EQ(Buffer_CreateFromData(reinterpret_cast<string_type>(input), input_len, input_buffer.out()), VANILLAPDF_ERROR_SUCCESS);
+    EXPECT_EQ(DictionaryObject_Create(params.out()), VANILLAPDF_ERROR_SUCCESS);
+
+    InsertIntegerEntry(params, "Predictor", 15);
+    InsertIntegerEntry(params, "Colors", 1);
+    InsertIntegerEntry(params, "BitsPerComponent", 8);
+    InsertIntegerEntry(params, "Columns", 3);
+
+    return FlateDecodeFilter_DecodeParams(filter, input_buffer, params, decoded_out);
+}
+
+TEST(FlateDecodeFilter, RejectsUnknownPngFilterType) {
+    HandleGuard<BufferHandle, Buffer_Release> decoded;
+    EXPECT_NE(DecodePngPredictorRaw(INPUT_UNKNOWN_FILTER, sizeof(INPUT_UNKNOWN_FILTER), decoded.out()), VANILLAPDF_ERROR_SUCCESS);
+    EXPECT_EQ(decoded.get(), nullptr);
+}
+
+TEST(FlateDecodeFilter, RejectsTruncatedScanline) {
+    HandleGuard<BufferHandle, Buffer_Release> decoded;
+    EXPECT_NE(DecodePngPredictorRaw(INPUT_TRUNCATED_SCANLINE, sizeof(INPUT_TRUNCATED_SCANLINE), decoded.out()), VANILLAPDF_ERROR_SUCCESS);
+    EXPECT_EQ(decoded.get(), nullptr);
+}
+
+TEST(FlateDecodeFilter, DecodesEmptyPredictedStream) {
+    HandleGuard<BufferHandle, Buffer_Release> decoded;
+    ASSERT_EQ(DecodePngPredictorRaw(INPUT_EMPTY_PREDICTED, sizeof(INPUT_EMPTY_PREDICTED), decoded.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_NE(decoded.get(), nullptr);
+
+    string_type decoded_data = nullptr;
+    size_type decoded_len = 0;
+    ASSERT_EQ(Buffer_GetData(decoded, &decoded_data, &decoded_len), VANILLAPDF_ERROR_SUCCESS);
+    EXPECT_EQ(decoded_len, 0u);
+}
 
 TEST(DCTDecodeFilter, Decode) {
 

--- a/src/vanillapdf/syntax/filters/flate_decode_filter.cpp
+++ b/src/vanillapdf/syntax/filters/flate_decode_filter.cpp
@@ -91,8 +91,12 @@ BufferPtr FlateDecodeFilter::ApplyPredictor(IInputStreamPtr src, types::stream_s
     uint32_t columns_int = columns->SafeConvert<uint32_t>();
     uint32_t bits_int = bits->SafeConvert<uint32_t>();
 
-    // Division should be safe?
-    uint32_t bytes_per_pixel = SafeMultiply<uint32_t>(colors_int, bits_int) / 8;
+    // PNG bytes-per-pixel is the pixel bit depth rounded UP to whole bytes
+    // (min 1); flooring yields 0 for sub-byte depths and corrupts output.
+    // Division by 8 cannot overflow, as in bytes_per_row below.
+    // https://github.com/vanillapdf/vanillapdf/issues/443
+    uint32_t pixel_bits = SafeMultiply<uint32_t>(colors_int, bits_int);
+    uint32_t bytes_per_pixel = SafeAddition<uint32_t>(pixel_bits, 7) / 8;
 
     uint32_t colors_columns = SafeMultiply<uint32_t>(colors_int, columns_int);
     uint32_t colors_columns_bits = SafeMultiply<uint32_t>(colors_columns, bits_int);
@@ -109,9 +113,11 @@ BufferPtr FlateDecodeFilter::ApplyPredictor(IInputStreamPtr src, types::stream_s
         }
         auto read = src->Read(reinterpret_cast<char*>(current.data()), bytes_per_row);
 
-        assert(read == bytes_per_row);
+        // A short read means a truncated final scanline, which is reachable
+        // corrupt input (not a programming bug), so throw rather than assert.
+        // https://github.com/vanillapdf/vanillapdf/issues/442
         if (read != bytes_per_row) {
-            throw DataCorruptionException("Corrupted deflate compressed data");
+            LOG_ERROR_AND_THROW(DataCorruptionException, "Corrupted deflate compressed data: read {} of {} scanline bytes", read, bytes_per_row);
         }
 
         switch (filter) {
@@ -187,8 +193,10 @@ BufferPtr FlateDecodeFilter::ApplyPredictor(IInputStreamPtr src, types::stream_s
 
                 break;
             default:
-                spdlog::error("Unknown PNG filter type: {}", filter);
-                break;
+                // A valid PDF never carries a PNG filter type outside 0-4; fail
+                // closed instead of appending the raw row and returning corrupt data.
+                // https://github.com/vanillapdf/vanillapdf/issues/442
+                LOG_ERROR_AND_THROW(DataCorruptionException, "Unknown PNG predictor filter type: {}", filter);
         }
 
         result->insert(result.end(), current.begin(), current.end());


### PR DESCRIPTION
## Summary

Two related FlateDecode PNG-predictor fixes in `FlateDecodeFilter::ApplyPredictor`, plus the assert that got in the way of the second one.

### #443 — ceil the pixel stride

`bytes_per_pixel` was computed with floor division (`colors * bits / 8`). For sub-byte pixel depths (e.g. 1- or 4-bit grayscale, valid per PDF 32000-1 Table 8) this yields **0**, which degenerates the Sub/Average/Paeth "left neighbour" onto the byte itself and silently mis-reconstructs the image. Use ceil (`(colors * bits + 7) / 8`, minimum 1) to match the PNG spec and other engines (libpng, MuPDF). Whole-byte depths are unchanged (ceil == floor when `colors * bits` is a multiple of 8), so no correctly-authored document changes behavior.

### #442 — fail closed on malformed input

The decoder returned success with silently-corrupt data on reachable bad input:

- An **unknown PNG filter type** (byte outside 0-4) only logged and appended the raw, un-reconstructed row. It now throws `DataCorruptionException`.
- A **truncated final scanline** tripped a debug-only `assert(read == bytes_per_row)` (aborting in Debug) instead of the throw right below it. The stale assert encodes a false invariant — truncated input is reachable corrupt data, not a programming bug — so it is removed and the throw carries the offending value via `LOG_ERROR_AND_THROW`.

Both matter for corrupt/truncated streams, mismatched `DecodeParms`, wrong decryption keys, and fuzzed input.

## Tests

- 5 new sub-byte reconstruction vectors (Colors=3, BitsPerComponent=4, where `bytes_per_pixel` is ceil(12/8)=2 but the old floor gave 1), certified against MuPDF, alongside the existing RGB8 set. Confirmed they fail against the old floor code and pass with ceil.
- 3 hand-crafted malformed-input cases: unknown filter type, empty predicted stream (decodes to an empty buffer), truncated final scanline.
- The vector generator now emits ceil strides and supports `--name-prefix`, so the regenerate wrapper produces both geometries. The committed RGB8 vectors reproduce byte-for-byte.

All 26 filter unit tests pass; the read/validate integration suite passes.

Closes #443
Closes #442
