### PR TITLE
chore: Ban `|| true` error-swallowing and clean up backport.sh

### DIFF
--- a/.github/scripts/backport.sh
+++ b/.github/scripts/backport.sh
@@ -128,8 +128,11 @@ gh pr create --base $target --head $branch_name
 cleanup() {
     local branch_name="$1"
 
-    git checkout main 2>/dev/null || git checkout master 2>/dev/null || true
-    git branch -D "$branch_name" 2>/dev/null || true
+    # Return to the base branch and drop the temp branch. Both always exist here
+    # (main is the default branch; the temp branch was created in
+    # create_backport_branch), so a failure is a real error, not noise to hide.
+    git checkout main
+    git branch -D "$branch_name"
 }
 
 # Process a single backport target
@@ -163,8 +166,8 @@ process_target() {
             result=1
         fi
     else
-        # Cherry-pick failed
-        git cherry-pick --abort 2>/dev/null || true
+        # Cherry-pick failed with conflicts, so one is in progress — abort it.
+        git cherry-pick --abort
         echo "::error::Cherry-pick failed for $target (likely conflicts)"
         post_failure_comment "$target" "$branch_name"
         gh pr edit "$PR_NUMBER" --add-label "backport-failed $target"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,6 +94,26 @@ gh api repos/OWNER/REPO/git/tags/$(gh api repos/OWNER/REPO/git/refs/tags/TAG --j
 
 Always include the original tag name as a comment (`# v4.2.2`) so the pinned version remains human-readable.
 
+## CI Script Error Handling (CRITICAL)
+
+**Never append `|| true` to a command — anywhere.** It discards the exit code, so a real failure (a validation, build, test, or audit) turns into a silent green. This has shipped broken output before: `brew audit ... || true` let broken formulae through because the audit could never fail the job. The ban is unconditional, including "harmless" cleanup — there is always an explicit alternative below.
+
+```bash
+# BAD — a failing audit is swallowed, the job stays green
+brew audit --strict --online Formula/v/foo.rb || true
+
+# GOOD — a failing audit fails the job
+brew audit --strict --online Formula/v/foo.rb
+```
+
+First ask whether the command is *allowed* to fail at all. Usually it is not: if it should succeed in the surrounding context, call it plainly and let a genuine failure surface loudly — that is a signal, not noise. Defensively guarding a command that should always succeed just hides the bug you would want to see (e.g. `git cherry-pick --abort` right after a cherry-pick is known to have failed will succeed; a plain call is correct).
+
+When a command is genuinely *allowed* to fail, make that intent explicit — never implicit via `|| true`, and avoid fragile `set +e`/`set -e` toggling:
+- **Step-level (preferred in workflows):** set `continue-on-error: true` on the workflow step. The step's failure is recorded, not hidden.
+- **Restructure so it cannot fail:** guard on the precondition instead of tolerating the error — e.g. delete a branch only if it exists: `if git show-ref --quiet "refs/heads/$tmp"; then git branch -D "$tmp"; fi`.
+- **Non-trivial logic:** move it into a Python (or other dedicated) script that inspects exit codes explicitly and readably, rather than piling conditionals into inline bash.
+- **Probing a condition** (testing, not tolerating failure): branch on the exit code — `if ! git cat-file -e <rev>:<path> 2>/dev/null; then …`. Suppressing *stderr* with `2>/dev/null` is fine because the exit code is still inspected; only the exit code must never be thrown away.
+
 ## Automation Bot
 
 The repository uses `vanillapdf-bot` (info@vanillapdf.com) for automated operations:


### PR DESCRIPTION
## Summary

`|| true` discards a command's exit code, so a real failure — a validation, build, test, or audit — becomes a silent green. This already shipped broken output once: the Homebrew automation ran `brew audit ... || true`, so a failing audit could never fail the job. This PR bans the pattern repo-wide and removes the remaining occurrences.

The swallowed `brew audit` itself is fixed in the update-only automation PR (#464); this PR is the general policy plus the `backport.sh` cleanup.

## Changes

### Policy (`CLAUDE.md`)
New **CI Script Error Handling (CRITICAL)** section:
- Never append `|| true` to a command — anywhere, including "harmless" cleanup.
- First ask whether the command is allowed to fail at all. Usually not: call it plainly and let a genuine failure surface loudly.
- When failure is genuinely acceptable, be explicit — `continue-on-error:` on the step, a precondition guard, or a dedicated script — never `|| true` or fragile `set +e`/`set -e` toggling.
- Suppressing *stderr* (`2>/dev/null`) while still inspecting the exit code is fine; only the exit code must never be thrown away.

### Cleanup (`.github/scripts/backport.sh`)
Removes all three `|| true` occurrences:
- `cleanup()` — `git checkout main` and `git branch -D "$branch_name"` are now plain. Both refs always exist at that point (main is the default branch; the temp branch was created in `create_backport_branch`). The bogus `master` fallback is dropped — this repo's default is `main`.
- Post-conflict `git cherry-pick --abort` is now plain. That path is only reached when `create_backport_branch` returned non-zero, which happens solely because `git cherry-pick` failed — so a cherry-pick is always in progress and the abort will succeed.

Verified with `bash -n`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
