### PR TITLE
ci: make backport PR titles Conventional-Commits compliant

### DIFF
--- a/.github/scripts/backport.sh
+++ b/.github/scripts/backport.sh
@@ -66,10 +66,14 @@ ${PR_BODY:-No description provided.}"
 
     # Create the PR
     local pr_url
+    # Keep the original (Conventional-Commits-compliant) title and append the
+    # backport marker, so the title still passes the PR-title lint. The marker
+    # is for humans; the automation identifies backports by branch name and
+    # reads the target from the body (see backport.yml).
     pr_url=$(gh pr create \
         --base "$target" \
         --head "$branch_name" \
-        --title "[Backport $target] $PR_TITLE" \
+        --title "$PR_TITLE (backport #${PR_NUMBER} to $target)" \
         --body "$pr_body")
 
     echo "$pr_url"

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -16,7 +16,7 @@ jobs:
     timeout-minutes: 60
     if: |
       github.event.pull_request.merged == true &&
-      !startsWith(github.event.pull_request.title, '[Backport')
+      !startsWith(github.event.pull_request.head.ref, 'backport-')
     steps:
       - name: Get target branches from labels
         id: get-targets
@@ -69,31 +69,25 @@ jobs:
     timeout-minutes: 60
     if: |
       github.event.pull_request.merged == true &&
-      startsWith(github.event.pull_request.title, '[Backport')
+      startsWith(github.event.pull_request.head.ref, 'backport-')
     steps:
       - name: Extract original PR and target branch
         id: extract-info
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
         with:
           script: |
-            const title = context.payload.pull_request.title;
             const body = context.payload.pull_request.body || '';
 
-            // Extract target branch from title: "[Backport release/2.2] Original title"
-            const titleMatch = title.match(/^\[Backport ([^\]]+)\]/);
-            if (!titleMatch) {
-              console.log('Could not parse backport target from title');
+            // Both the original PR number and the target branch come from the
+            // canonical marker backport.sh writes at the top of the body:
+            // "Backport of #123 to `release/2.2`."
+            const match = body.match(/Backport of #(\d+) to `([^`]+)`/);
+            if (!match) {
+              console.log('Could not parse backport info (original PR / target) from body');
               return;
             }
-            const targetBranch = titleMatch[1];
-
-            // Extract original PR number from body: "Backport of #123 to ..."
-            const bodyMatch = body.match(/Backport of #(\d+)/);
-            if (!bodyMatch) {
-              console.log('Could not find original PR number in body');
-              return;
-            }
-            const originalPR = bodyMatch[1];
+            const originalPR = match[1];
+            const targetBranch = match[2];
 
             console.log(`Target branch: ${targetBranch}`);
             console.log(`Original PR: #${originalPR}`);


### PR DESCRIPTION
## Problem

Auto-generated backport PR titles look like `[Backport release/2.3] fix: …`. That leading bracket means the title has no Conventional Commits type prefix, so the **Lint PR title** check (`amannn/action-semantic-pull-request`) fails on every backport PR targeting a branch that runs the linter (e.g. #469 → `release/2.3`).

The bracket prefix wasn't cosmetic — `backport.yml` parsed the target branch out of it. So the title format was load-bearing for the `backported release/X.Y` labeling automation, which is why it couldn't simply be changed to a conventional title without breaking labeling.

## Fix — conform, don't exempt

Decouple the automation from the title so the title is free to satisfy the linter:

- **`backport.sh`** now titles backport PRs `<original title> (backport #N to release/X.Y)`. The original Conventional Commits type stays at the front (passes the lint), and the marker still names the source PR and target for humans.
- **`backport.yml`** no longer reads the title. It identifies a backport PR by branch name (`head.ref` starts with `backport-`, which `backport.sh` always generates) and reads **both** the original PR number and the target branch from the canonical body marker `` Backport of #N to `release/X.Y`. `` that `backport.sh` already writes.

Validated the new body regex against the live bodies of #469 and #470 (both extract `#467` + the right target) and against #467 (original PR — correctly does not match, so the create-side gate won't false-trip).

## Rollout

`pull_request_target` runs the backport workflow from the **base branch**, so the `backported`-label update for a backport PR runs from the release branch it merges into. This same change therefore also needs to land on `release/2.3` (separate PR) so #469's merge still labels #467. `release/2.2` has no `backport.yml`, so nothing to change there. Existing open backport PRs #469/#470 will be retitled to the new format so they pass the lint now; the branch-name + body detection already matches them.
