### PR TITLE
ci: make backport PR titles Conventional-Commits compliant

### DIFF
--- a/.github/scripts/backport.sh
+++ b/.github/scripts/backport.sh
@@ -66,10 +66,14 @@ ${PR_BODY:-No description provided.}"
 
     # Create the PR
     local pr_url
+    # Keep the original (Conventional-Commits-compliant) title and append the
+    # backport marker, so the title still passes the PR-title lint. The marker
+    # is for humans; the automation identifies backports by branch name and
+    # reads the target from the body (see backport.yml).
     pr_url=$(gh pr create \
         --base "$target" \
         --head "$branch_name" \
-        --title "[Backport $target] $PR_TITLE" \
+        --title "$PR_TITLE (backport #${PR_NUMBER} to $target)" \
         --body "$pr_body")
 
     echo "$pr_url"

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -16,7 +16,7 @@ jobs:
     timeout-minutes: 60
     if: |
       github.event.pull_request.merged == true &&
-      !startsWith(github.event.pull_request.title, '[Backport')
+      !startsWith(github.event.pull_request.head.ref, 'backport-')
     steps:
       - name: Get target branches from labels
         id: get-targets
@@ -69,31 +69,25 @@ jobs:
     timeout-minutes: 60
     if: |
       github.event.pull_request.merged == true &&
-      startsWith(github.event.pull_request.title, '[Backport')
+      startsWith(github.event.pull_request.head.ref, 'backport-')
     steps:
       - name: Extract original PR and target branch
         id: extract-info
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
         with:
           script: |
-            const title = context.payload.pull_request.title;
             const body = context.payload.pull_request.body || '';
 
-            // Extract target branch from title: "[Backport release/2.2] Original title"
-            const titleMatch = title.match(/^\[Backport ([^\]]+)\]/);
-            if (!titleMatch) {
-              console.log('Could not parse backport target from title');
+            // Both the original PR number and the target branch come from the
+            // canonical marker backport.sh writes at the top of the body:
+            // "Backport of #123 to `release/2.2`."
+            const match = body.match(/Backport of #(\d+) to `([^`]+)`/);
+            if (!match) {
+              console.log('Could not parse backport info (original PR / target) from body');
               return;
             }
-            const targetBranch = titleMatch[1];
-
-            // Extract original PR number from body: "Backport of #123 to ..."
-            const bodyMatch = body.match(/Backport of #(\d+)/);
-            if (!bodyMatch) {
-              console.log('Could not find original PR number in body');
-              return;
-            }
-            const originalPR = bodyMatch[1];
+            const originalPR = match[1];
+            const targetBranch = match[2];
 
             console.log(`Target branch: ${targetBranch}`);
             console.log(`Original PR: #${originalPR}`);


### PR DESCRIPTION
Companion to #471 for the `release/2.3` branch.

`pull_request_target` runs the backport workflow from the **base branch**, so when a backport PR merges into `release/2.3` the `backported release/2.3` labeling runs from *this* branch's `backport.yml`. It must therefore learn the new backport-detection scheme, otherwise retitling backport PRs to a Conventional-Commits-compliant subject (dropping the `[Backport …]` prefix) silently stops the labeling from firing.

Same change as #471:

- **`backport.sh`** titles backport PRs `<original title> (backport #N to release/X.Y)` — Conventional-Commits type stays at the front, so the Lint PR title check passes.
- **`backport.yml`** identifies a backport PR by branch name (`head.ref` starts with `backport-`) and reads the original PR number and target branch from the body marker `` Backport of #N to `release/X.Y`. `` instead of parsing the title.

This makes #469 (retitled to the new format) still trigger the `backported release/2.3` label on #467 when it merges.
