### PR TITLE
feat: Expose document metadata setters in the C API

### DIFF
--- a/include/vanillapdf/semantics/c_document.h
+++ b/include/vanillapdf/semantics/c_document.h
@@ -92,14 +92,14 @@ extern "C"
     VANILLAPDF_API error_type CALLING_CONVENTION Document_GetDocumentInfo(DocumentHandle* handle, DocumentInfoHandle** result);
 
     /**
-    * \brief Get detailed document metadata, creating an empty
-    * document information dictionary when the document does not have any yet.
+    * \brief
+    * Attach a document information dictionary to the document.
     *
-    * Unlike \ref Document_GetDocumentInfo this function never reports
-    * \ref VANILLAPDF_ERROR_OBJECT_MISSING and is therefore the entry point
-    * for populating metadata through the \ref DocumentInfoHandle setters.
+    * The trailer stores an indirect reference, so the dictionary has to be
+    * registered within the document - use
+    * \ref DocumentInfo_CreateFromDocument to obtain one.
     */
-    VANILLAPDF_API error_type CALLING_CONVENTION Document_CreateDocumentInfo(DocumentHandle* handle, DocumentInfoHandle** result);
+    VANILLAPDF_API error_type CALLING_CONVENTION Document_SetDocumentInfo(DocumentHandle* handle, DocumentInfoHandle* value);
 
     /**
     * \brief Append another document's contents at the end of the file.

--- a/include/vanillapdf/semantics/c_document.h
+++ b/include/vanillapdf/semantics/c_document.h
@@ -92,6 +92,16 @@ extern "C"
     VANILLAPDF_API error_type CALLING_CONVENTION Document_GetDocumentInfo(DocumentHandle* handle, DocumentInfoHandle** result);
 
     /**
+    * \brief Get detailed document metadata, creating an empty
+    * document information dictionary when the document does not have any yet.
+    *
+    * Unlike \ref Document_GetDocumentInfo this function never reports
+    * \ref VANILLAPDF_ERROR_OBJECT_MISSING and is therefore the entry point
+    * for populating metadata through the \ref DocumentInfoHandle setters.
+    */
+    VANILLAPDF_API error_type CALLING_CONVENTION Document_CreateDocumentInfo(DocumentHandle* handle, DocumentInfoHandle** result);
+
+    /**
     * \brief Append another document's contents at the end of the file.
     *
     * This appends all \p source document's pages beyond \p handle document's pages.

--- a/include/vanillapdf/semantics/c_document_info.h
+++ b/include/vanillapdf/semantics/c_document_info.h
@@ -108,6 +108,55 @@ extern "C"
     VANILLAPDF_API error_type CALLING_CONVENTION DocumentInfo_GetTrapped(DocumentInfoHandle* handle, DocumentTrappedType* result);
 
     /**
+    * \brief Set the document's title.
+    */
+    VANILLAPDF_API error_type CALLING_CONVENTION DocumentInfo_SetTitle(DocumentInfoHandle* handle, StringObjectHandle* value);
+
+    /**
+    * \brief Set the name of the person who created the document.
+    */
+    VANILLAPDF_API error_type CALLING_CONVENTION DocumentInfo_SetAuthor(DocumentInfoHandle* handle, StringObjectHandle* value);
+
+    /**
+    * \brief Set the subject of the document.
+    */
+    VANILLAPDF_API error_type CALLING_CONVENTION DocumentInfo_SetSubject(DocumentInfoHandle* handle, StringObjectHandle* value);
+
+    /**
+    * \brief Set the keywords associated with the document.
+    */
+    VANILLAPDF_API error_type CALLING_CONVENTION DocumentInfo_SetKeywords(DocumentInfoHandle* handle, StringObjectHandle* value);
+
+    /**
+    * \brief
+    * Set the name of the conforming product that created the original
+    * document from which it was converted.
+    */
+    VANILLAPDF_API error_type CALLING_CONVENTION DocumentInfo_SetCreator(DocumentInfoHandle* handle, StringObjectHandle* value);
+
+    /**
+    * \brief
+    * Set the name of the conforming product that converted the original
+    * document to PDF.
+    */
+    VANILLAPDF_API error_type CALLING_CONVENTION DocumentInfo_SetProducer(DocumentInfoHandle* handle, StringObjectHandle* value);
+
+    /**
+    * \brief Set the date and time the document was created.
+    */
+    VANILLAPDF_API error_type CALLING_CONVENTION DocumentInfo_SetCreationDate(DocumentInfoHandle* handle, DateHandle* value);
+
+    /**
+    * \brief Set the date and time the document was most recently modified.
+    */
+    VANILLAPDF_API error_type CALLING_CONVENTION DocumentInfo_SetModificationDate(DocumentInfoHandle* handle, DateHandle* value);
+
+    /**
+    * \copydoc DocumentTrappedType
+    */
+    VANILLAPDF_API error_type CALLING_CONVENTION DocumentInfo_SetTrapped(DocumentInfoHandle* handle, DocumentTrappedType value);
+
+    /**
     * \brief Reinterpret current object as \ref IUnknownHandle
     */
     VANILLAPDF_API error_type CALLING_CONVENTION DocumentInfo_ToUnknown(DocumentInfoHandle* handle, IUnknownHandle** result);

--- a/include/vanillapdf/semantics/c_document_info.h
+++ b/include/vanillapdf/semantics/c_document_info.h
@@ -58,6 +58,17 @@ extern "C"
     */
 
     /**
+    * \brief
+    * Create an empty document information dictionary registered as an
+    * indirect object within the document.
+    *
+    * The dictionary does not take effect until it is attached with
+    * \ref Document_SetDocumentInfo. Creating and attaching are deliberately
+    * separate steps, so that reading a document never modifies it.
+    */
+    VANILLAPDF_API error_type CALLING_CONVENTION DocumentInfo_CreateFromDocument(DocumentHandle* handle, DocumentInfoHandle** result);
+
+    /**
     * \brief The document's title.
     */
     VANILLAPDF_API error_type CALLING_CONVENTION DocumentInfo_GetTitle(DocumentInfoHandle* handle, StringObjectHandle** result);

--- a/src/vanillapdf.unittest/CMakeLists.txt
+++ b/src/vanillapdf.unittest/CMakeLists.txt
@@ -30,6 +30,7 @@ set(VANILLAPDF_UNITTEST_SOURCES
     color_test.cpp
     date_test.cpp
     document_test.cpp
+    document_info_test.cpp
     destinations_test.cpp
     fields_test.cpp
     filter_test.cpp

--- a/src/vanillapdf.unittest/document_info_test.cpp
+++ b/src/vanillapdf.unittest/document_info_test.cpp
@@ -17,20 +17,19 @@ static void CreateMemoryDocument(
     ASSERT_EQ(Document_CreateFile(file, document.out()), VANILLAPDF_ERROR_SUCCESS);
 }
 
-// Reads the decoded contents of a string object into a std::string
-static std::string GetDecodedString(StringObjectHandle* handle) {
+// Reads the decoded contents of a string object into result.
+// Buffer data is a std::vector<char> and is not null terminated, so it is
+// copied into a std::string, whose c_str() is terminated and therefore safe
+// to compare with EXPECT_STREQ.
+static void GetDecodedString(StringObjectHandle* handle, std::string& result) {
     HandleGuard<BufferHandle, Buffer_Release> buffer;
-    if (StringObject_GetValue(handle, buffer.out()) != VANILLAPDF_ERROR_SUCCESS) {
-        return std::string();
-    }
+    ASSERT_EQ(StringObject_GetValue(handle, buffer.out()), VANILLAPDF_ERROR_SUCCESS);
 
     string_type data = nullptr;
     size_type size = 0;
-    if (Buffer_GetData(buffer, &data, &size) != VANILLAPDF_ERROR_SUCCESS) {
-        return std::string();
-    }
+    ASSERT_EQ(Buffer_GetData(buffer, &data, &size), VANILLAPDF_ERROR_SUCCESS);
 
-    return std::string(data, size);
+    result.assign(data, size);
 }
 
 static void SetAndExpectString(
@@ -46,7 +45,10 @@ static void SetAndExpectString(
 
     HandleGuard<StringObjectHandle, StringObject_Release> result;
     ASSERT_EQ(getter(info, result.out()), VANILLAPDF_ERROR_SUCCESS);
-    EXPECT_EQ(GetDecodedString(result), std::string(value));
+
+    std::string decoded;
+    GetDecodedString(result, decoded);
+    EXPECT_STREQ(decoded.c_str(), value);
 }
 
 TEST(DocumentInfo, SetAndGetStringEntries) {
@@ -167,7 +169,10 @@ TEST(DocumentInfo, CreateDocumentInfoIsIdempotent) {
 
     HandleGuard<StringObjectHandle, StringObject_Release> title;
     ASSERT_EQ(DocumentInfo_GetTitle(second, title.out()), VANILLAPDF_ERROR_SUCCESS);
-    EXPECT_EQ(GetDecodedString(title), std::string("Persisted title"));
+
+    std::string decoded_title;
+    GetDecodedString(title, decoded_title);
+    EXPECT_STREQ(decoded_title.c_str(), "Persisted title");
 }
 
 // Metadata set through the setters has to survive a save/reload cycle
@@ -202,8 +207,13 @@ TEST(DocumentInfo, SettersPersistAcrossSave) {
     ASSERT_EQ(DocumentInfo_GetTitle(reloaded_info, title.out()), VANILLAPDF_ERROR_SUCCESS);
     ASSERT_EQ(DocumentInfo_GetAuthor(reloaded_info, author.out()), VANILLAPDF_ERROR_SUCCESS);
 
-    EXPECT_EQ(GetDecodedString(title), std::string("Saved title"));
-    EXPECT_EQ(GetDecodedString(author), std::string("Saved author"));
+    std::string decoded_title;
+    std::string decoded_author;
+    GetDecodedString(title, decoded_title);
+    GetDecodedString(author, decoded_author);
+
+    EXPECT_STREQ(decoded_title.c_str(), "Saved title");
+    EXPECT_STREQ(decoded_author.c_str(), "Saved author");
 }
 
 TEST(DocumentInfo, SettersRejectNullParameters) {

--- a/src/vanillapdf.unittest/document_info_test.cpp
+++ b/src/vanillapdf.unittest/document_info_test.cpp
@@ -1,0 +1,225 @@
+#include "unittest.h"
+#include "handle_guard.h"
+
+#include <string>
+
+namespace document_info {
+
+// Creates an empty in-memory document, which Document_CreateFile
+// already populates with a document information dictionary
+static void CreateMemoryDocument(
+    HandleGuard<InputOutputStreamHandle, InputOutputStream_Release>& io_stream,
+    HandleGuard<FileHandle, File_Release>& file,
+    HandleGuard<DocumentHandle, Document_Release>& document
+) {
+    ASSERT_EQ(InputOutputStream_CreateFromMemory(io_stream.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(File_CreateStream(io_stream, "temp", file.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Document_CreateFile(file, document.out()), VANILLAPDF_ERROR_SUCCESS);
+}
+
+// Reads the decoded contents of a string object into a std::string
+static std::string GetDecodedString(StringObjectHandle* handle) {
+    HandleGuard<BufferHandle, Buffer_Release> buffer;
+    if (StringObject_GetValue(handle, buffer.out()) != VANILLAPDF_ERROR_SUCCESS) {
+        return std::string();
+    }
+
+    string_type data = nullptr;
+    size_type size = 0;
+    if (Buffer_GetData(buffer, &data, &size) != VANILLAPDF_ERROR_SUCCESS) {
+        return std::string();
+    }
+
+    return std::string(data, size);
+}
+
+static void SetAndExpectString(
+    DocumentInfoHandle* info,
+    error_type (CALLING_CONVENTION *setter)(DocumentInfoHandle*, StringObjectHandle*),
+    error_type (CALLING_CONVENTION *getter)(DocumentInfoHandle*, StringObjectHandle**),
+    const char* value
+) {
+    HandleGuard<LiteralStringObjectHandle, LiteralStringObject_Release> source;
+    ASSERT_EQ(LiteralStringObject_CreateFromDecodedString(value, source.out()), VANILLAPDF_ERROR_SUCCESS);
+
+    ASSERT_EQ(setter(info, reinterpret_cast<StringObjectHandle*>(source.get())), VANILLAPDF_ERROR_SUCCESS);
+
+    HandleGuard<StringObjectHandle, StringObject_Release> result;
+    ASSERT_EQ(getter(info, result.out()), VANILLAPDF_ERROR_SUCCESS);
+    EXPECT_EQ(GetDecodedString(result), std::string(value));
+}
+
+TEST(DocumentInfo, SetAndGetStringEntries) {
+    HandleGuard<InputOutputStreamHandle, InputOutputStream_Release> io_stream;
+    HandleGuard<FileHandle, File_Release> file;
+    HandleGuard<DocumentHandle, Document_Release> document;
+    CreateMemoryDocument(io_stream, file, document);
+
+    HandleGuard<DocumentInfoHandle, DocumentInfo_Release> info;
+    ASSERT_EQ(Document_CreateDocumentInfo(document, info.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_NE(info.get(), nullptr);
+
+    SetAndExpectString(info, DocumentInfo_SetTitle, DocumentInfo_GetTitle, "Quarterly Report");
+    SetAndExpectString(info, DocumentInfo_SetAuthor, DocumentInfo_GetAuthor, "Jane Doe");
+    SetAndExpectString(info, DocumentInfo_SetSubject, DocumentInfo_GetSubject, "Finance");
+    SetAndExpectString(info, DocumentInfo_SetKeywords, DocumentInfo_GetKeywords, "report,finance,2026");
+    SetAndExpectString(info, DocumentInfo_SetCreator, DocumentInfo_GetCreator, "Vanilla.PDF UI");
+    SetAndExpectString(info, DocumentInfo_SetProducer, DocumentInfo_GetProducer, "Vanilla.PDF");
+}
+
+TEST(DocumentInfo, SetStringEntryOverwrite) {
+    HandleGuard<InputOutputStreamHandle, InputOutputStream_Release> io_stream;
+    HandleGuard<FileHandle, File_Release> file;
+    HandleGuard<DocumentHandle, Document_Release> document;
+    CreateMemoryDocument(io_stream, file, document);
+
+    HandleGuard<DocumentInfoHandle, DocumentInfo_Release> info;
+    ASSERT_EQ(Document_CreateDocumentInfo(document, info.out()), VANILLAPDF_ERROR_SUCCESS);
+
+    SetAndExpectString(info, DocumentInfo_SetTitle, DocumentInfo_GetTitle, "First title");
+    SetAndExpectString(info, DocumentInfo_SetTitle, DocumentInfo_GetTitle, "Second title");
+}
+
+TEST(DocumentInfo, SetAndGetDateEntries) {
+    HandleGuard<InputOutputStreamHandle, InputOutputStream_Release> io_stream;
+    HandleGuard<FileHandle, File_Release> file;
+    HandleGuard<DocumentHandle, Document_Release> document;
+    CreateMemoryDocument(io_stream, file, document);
+
+    HandleGuard<DocumentInfoHandle, DocumentInfo_Release> info;
+    ASSERT_EQ(Document_CreateDocumentInfo(document, info.out()), VANILLAPDF_ERROR_SUCCESS);
+
+    HandleGuard<DateHandle, Date_Release> source_date;
+    ASSERT_EQ(Date_CreateEmpty(source_date.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Date_SetYear(source_date, 2026), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Date_SetMonth(source_date, 7), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Date_SetDay(source_date, 25), VANILLAPDF_ERROR_SUCCESS);
+
+    ASSERT_EQ(DocumentInfo_SetModificationDate(info, source_date), VANILLAPDF_ERROR_SUCCESS);
+
+    HandleGuard<DateHandle, Date_Release> result_date;
+    ASSERT_EQ(DocumentInfo_GetModificationDate(info, result_date.out()), VANILLAPDF_ERROR_SUCCESS);
+
+    integer_type year = 0;
+    integer_type month = 0;
+    integer_type day = 0;
+    ASSERT_EQ(Date_GetYear(result_date, &year), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Date_GetMonth(result_date, &month), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Date_GetDay(result_date, &day), VANILLAPDF_ERROR_SUCCESS);
+
+    EXPECT_EQ(year, 2026);
+    EXPECT_EQ(month, 7);
+    EXPECT_EQ(day, 25);
+}
+
+TEST(DocumentInfo, SetAndGetTrapped) {
+    HandleGuard<InputOutputStreamHandle, InputOutputStream_Release> io_stream;
+    HandleGuard<FileHandle, File_Release> file;
+    HandleGuard<DocumentHandle, Document_Release> document;
+    CreateMemoryDocument(io_stream, file, document);
+
+    HandleGuard<DocumentInfoHandle, DocumentInfo_Release> info;
+    ASSERT_EQ(Document_CreateDocumentInfo(document, info.out()), VANILLAPDF_ERROR_SUCCESS);
+
+    DocumentTrappedType trapped = DocumentTrappedType_Undefined;
+
+    ASSERT_EQ(DocumentInfo_SetTrapped(info, DocumentTrappedType_True), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(DocumentInfo_GetTrapped(info, &trapped), VANILLAPDF_ERROR_SUCCESS);
+    EXPECT_EQ(trapped, DocumentTrappedType_True);
+
+    ASSERT_EQ(DocumentInfo_SetTrapped(info, DocumentTrappedType_False), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(DocumentInfo_GetTrapped(info, &trapped), VANILLAPDF_ERROR_SUCCESS);
+    EXPECT_EQ(trapped, DocumentTrappedType_False);
+
+    ASSERT_EQ(DocumentInfo_SetTrapped(info, DocumentTrappedType_Unknown), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(DocumentInfo_GetTrapped(info, &trapped), VANILLAPDF_ERROR_SUCCESS);
+    EXPECT_EQ(trapped, DocumentTrappedType_Unknown);
+}
+
+// DocumentTrappedType_Undefined has no /Trapped representation and is rejected
+// instead of being written out as a bogus name
+TEST(DocumentInfo, SetTrappedUndefinedRejected) {
+    HandleGuard<InputOutputStreamHandle, InputOutputStream_Release> io_stream;
+    HandleGuard<FileHandle, File_Release> file;
+    HandleGuard<DocumentHandle, Document_Release> document;
+    CreateMemoryDocument(io_stream, file, document);
+
+    HandleGuard<DocumentInfoHandle, DocumentInfo_Release> info;
+    ASSERT_EQ(Document_CreateDocumentInfo(document, info.out()), VANILLAPDF_ERROR_SUCCESS);
+
+    EXPECT_EQ(DocumentInfo_SetTrapped(info, DocumentTrappedType_Undefined), VANILLAPDF_ERROR_PARAMETER_VALUE);
+}
+
+// Repeated calls must return the same document information dictionary
+// rather than allocating a second one and orphaning the original
+TEST(DocumentInfo, CreateDocumentInfoIsIdempotent) {
+    HandleGuard<InputOutputStreamHandle, InputOutputStream_Release> io_stream;
+    HandleGuard<FileHandle, File_Release> file;
+    HandleGuard<DocumentHandle, Document_Release> document;
+    CreateMemoryDocument(io_stream, file, document);
+
+    HandleGuard<DocumentInfoHandle, DocumentInfo_Release> first;
+    ASSERT_EQ(Document_CreateDocumentInfo(document, first.out()), VANILLAPDF_ERROR_SUCCESS);
+    SetAndExpectString(first, DocumentInfo_SetTitle, DocumentInfo_GetTitle, "Persisted title");
+
+    HandleGuard<DocumentInfoHandle, DocumentInfo_Release> second;
+    ASSERT_EQ(Document_CreateDocumentInfo(document, second.out()), VANILLAPDF_ERROR_SUCCESS);
+
+    HandleGuard<StringObjectHandle, StringObject_Release> title;
+    ASSERT_EQ(DocumentInfo_GetTitle(second, title.out()), VANILLAPDF_ERROR_SUCCESS);
+    EXPECT_EQ(GetDecodedString(title), std::string("Persisted title"));
+}
+
+// Metadata set through the setters has to survive a save/reload cycle
+TEST(DocumentInfo, SettersPersistAcrossSave) {
+    HandleGuard<InputOutputStreamHandle, InputOutputStream_Release> io_stream;
+    HandleGuard<FileHandle, File_Release> file;
+    HandleGuard<DocumentHandle, Document_Release> document;
+    CreateMemoryDocument(io_stream, file, document);
+
+    HandleGuard<DocumentInfoHandle, DocumentInfo_Release> info;
+    ASSERT_EQ(Document_CreateDocumentInfo(document, info.out()), VANILLAPDF_ERROR_SUCCESS);
+    SetAndExpectString(info, DocumentInfo_SetTitle, DocumentInfo_GetTitle, "Saved title");
+    SetAndExpectString(info, DocumentInfo_SetAuthor, DocumentInfo_GetAuthor, "Saved author");
+
+    HandleGuard<InputOutputStreamHandle, InputOutputStream_Release> destination_stream;
+    HandleGuard<FileHandle, File_Release> destination_file;
+    ASSERT_EQ(InputOutputStream_CreateFromMemory(destination_stream.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(File_CreateStream(destination_stream, "temp_destination", destination_file.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Document_SaveFile(document, destination_file), VANILLAPDF_ERROR_SUCCESS);
+
+    HandleGuard<FileHandle, File_Release> reloaded_file;
+    HandleGuard<DocumentHandle, Document_Release> reloaded_document;
+    ASSERT_EQ(File_OpenStream(destination_stream, "temp_destination", reloaded_file.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(File_Initialize(reloaded_file), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Document_OpenFile(reloaded_file, reloaded_document.out()), VANILLAPDF_ERROR_SUCCESS);
+
+    HandleGuard<DocumentInfoHandle, DocumentInfo_Release> reloaded_info;
+    ASSERT_EQ(Document_GetDocumentInfo(reloaded_document, reloaded_info.out()), VANILLAPDF_ERROR_SUCCESS);
+
+    HandleGuard<StringObjectHandle, StringObject_Release> title;
+    HandleGuard<StringObjectHandle, StringObject_Release> author;
+    ASSERT_EQ(DocumentInfo_GetTitle(reloaded_info, title.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(DocumentInfo_GetAuthor(reloaded_info, author.out()), VANILLAPDF_ERROR_SUCCESS);
+
+    EXPECT_EQ(GetDecodedString(title), std::string("Saved title"));
+    EXPECT_EQ(GetDecodedString(author), std::string("Saved author"));
+}
+
+TEST(DocumentInfo, SettersRejectNullParameters) {
+    HandleGuard<InputOutputStreamHandle, InputOutputStream_Release> io_stream;
+    HandleGuard<FileHandle, File_Release> file;
+    HandleGuard<DocumentHandle, Document_Release> document;
+    CreateMemoryDocument(io_stream, file, document);
+
+    HandleGuard<DocumentInfoHandle, DocumentInfo_Release> info;
+    ASSERT_EQ(Document_CreateDocumentInfo(document, info.out()), VANILLAPDF_ERROR_SUCCESS);
+
+    EXPECT_EQ(DocumentInfo_SetTitle(nullptr, nullptr), VANILLAPDF_ERROR_PARAMETER_VALUE);
+    EXPECT_EQ(DocumentInfo_SetTitle(info, nullptr), VANILLAPDF_ERROR_PARAMETER_VALUE);
+    EXPECT_EQ(DocumentInfo_SetCreationDate(info, nullptr), VANILLAPDF_ERROR_PARAMETER_VALUE);
+    EXPECT_EQ(Document_CreateDocumentInfo(nullptr, info.out()), VANILLAPDF_ERROR_PARAMETER_VALUE);
+    EXPECT_EQ(Document_CreateDocumentInfo(document, nullptr), VANILLAPDF_ERROR_PARAMETER_VALUE);
+}
+
+} // namespace document_info

--- a/src/vanillapdf.unittest/document_info_test.cpp
+++ b/src/vanillapdf.unittest/document_info_test.cpp
@@ -58,7 +58,8 @@ TEST(DocumentInfo, SetAndGetStringEntries) {
     CreateMemoryDocument(io_stream, file, document);
 
     HandleGuard<DocumentInfoHandle, DocumentInfo_Release> info;
-    ASSERT_EQ(Document_CreateDocumentInfo(document, info.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(DocumentInfo_CreateFromDocument(document, info.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Document_SetDocumentInfo(document, info), VANILLAPDF_ERROR_SUCCESS);
     ASSERT_NE(info.get(), nullptr);
 
     SetAndExpectString(info, DocumentInfo_SetTitle, DocumentInfo_GetTitle, "Quarterly Report");
@@ -76,7 +77,8 @@ TEST(DocumentInfo, SetStringEntryOverwrite) {
     CreateMemoryDocument(io_stream, file, document);
 
     HandleGuard<DocumentInfoHandle, DocumentInfo_Release> info;
-    ASSERT_EQ(Document_CreateDocumentInfo(document, info.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(DocumentInfo_CreateFromDocument(document, info.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Document_SetDocumentInfo(document, info), VANILLAPDF_ERROR_SUCCESS);
 
     SetAndExpectString(info, DocumentInfo_SetTitle, DocumentInfo_GetTitle, "First title");
     SetAndExpectString(info, DocumentInfo_SetTitle, DocumentInfo_GetTitle, "Second title");
@@ -89,7 +91,8 @@ TEST(DocumentInfo, SetAndGetDateEntries) {
     CreateMemoryDocument(io_stream, file, document);
 
     HandleGuard<DocumentInfoHandle, DocumentInfo_Release> info;
-    ASSERT_EQ(Document_CreateDocumentInfo(document, info.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(DocumentInfo_CreateFromDocument(document, info.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Document_SetDocumentInfo(document, info), VANILLAPDF_ERROR_SUCCESS);
 
     HandleGuard<DateHandle, Date_Release> source_date;
     ASSERT_EQ(Date_CreateEmpty(source_date.out()), VANILLAPDF_ERROR_SUCCESS);
@@ -121,7 +124,8 @@ TEST(DocumentInfo, SetAndGetTrapped) {
     CreateMemoryDocument(io_stream, file, document);
 
     HandleGuard<DocumentInfoHandle, DocumentInfo_Release> info;
-    ASSERT_EQ(Document_CreateDocumentInfo(document, info.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(DocumentInfo_CreateFromDocument(document, info.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Document_SetDocumentInfo(document, info), VANILLAPDF_ERROR_SUCCESS);
 
     DocumentTrappedType trapped = DocumentTrappedType_Undefined;
 
@@ -147,32 +151,40 @@ TEST(DocumentInfo, SetTrappedUndefinedRejected) {
     CreateMemoryDocument(io_stream, file, document);
 
     HandleGuard<DocumentInfoHandle, DocumentInfo_Release> info;
-    ASSERT_EQ(Document_CreateDocumentInfo(document, info.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(DocumentInfo_CreateFromDocument(document, info.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Document_SetDocumentInfo(document, info), VANILLAPDF_ERROR_SUCCESS);
 
     EXPECT_EQ(DocumentInfo_SetTrapped(info, DocumentTrappedType_Undefined), VANILLAPDF_ERROR_PARAMETER_VALUE);
 }
 
-// Repeated calls must return the same document information dictionary
-// rather than allocating a second one and orphaning the original
-TEST(DocumentInfo, CreateDocumentInfoIsIdempotent) {
+// Attaching a second dictionary must replace the trailer entry rather than
+// throw on the duplicate /Info key
+TEST(DocumentInfo, SetDocumentInfoOverwrite) {
     HandleGuard<InputOutputStreamHandle, InputOutputStream_Release> io_stream;
     HandleGuard<FileHandle, File_Release> file;
     HandleGuard<DocumentHandle, Document_Release> document;
     CreateMemoryDocument(io_stream, file, document);
 
     HandleGuard<DocumentInfoHandle, DocumentInfo_Release> first;
-    ASSERT_EQ(Document_CreateDocumentInfo(document, first.out()), VANILLAPDF_ERROR_SUCCESS);
-    SetAndExpectString(first, DocumentInfo_SetTitle, DocumentInfo_GetTitle, "Persisted title");
+    ASSERT_EQ(DocumentInfo_CreateFromDocument(document, first.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Document_SetDocumentInfo(document, first), VANILLAPDF_ERROR_SUCCESS);
+    SetAndExpectString(first, DocumentInfo_SetTitle, DocumentInfo_GetTitle, "First title");
 
     HandleGuard<DocumentInfoHandle, DocumentInfo_Release> second;
-    ASSERT_EQ(Document_CreateDocumentInfo(document, second.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(DocumentInfo_CreateFromDocument(document, second.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Document_SetDocumentInfo(document, second), VANILLAPDF_ERROR_SUCCESS);
+    SetAndExpectString(second, DocumentInfo_SetTitle, DocumentInfo_GetTitle, "Second title");
+
+    // The document now reports the most recently attached dictionary
+    HandleGuard<DocumentInfoHandle, DocumentInfo_Release> found;
+    ASSERT_EQ(Document_GetDocumentInfo(document, found.out()), VANILLAPDF_ERROR_SUCCESS);
 
     HandleGuard<StringObjectHandle, StringObject_Release> title;
-    ASSERT_EQ(DocumentInfo_GetTitle(second, title.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(DocumentInfo_GetTitle(found, title.out()), VANILLAPDF_ERROR_SUCCESS);
 
     std::string decoded_title;
     GetDecodedString(title, decoded_title);
-    EXPECT_STREQ(decoded_title.c_str(), "Persisted title");
+    EXPECT_STREQ(decoded_title.c_str(), "Second title");
 }
 
 // Metadata set through the setters has to survive a save/reload cycle
@@ -183,7 +195,8 @@ TEST(DocumentInfo, SettersPersistAcrossSave) {
     CreateMemoryDocument(io_stream, file, document);
 
     HandleGuard<DocumentInfoHandle, DocumentInfo_Release> info;
-    ASSERT_EQ(Document_CreateDocumentInfo(document, info.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(DocumentInfo_CreateFromDocument(document, info.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Document_SetDocumentInfo(document, info), VANILLAPDF_ERROR_SUCCESS);
     SetAndExpectString(info, DocumentInfo_SetTitle, DocumentInfo_GetTitle, "Saved title");
     SetAndExpectString(info, DocumentInfo_SetAuthor, DocumentInfo_GetAuthor, "Saved author");
 
@@ -223,13 +236,15 @@ TEST(DocumentInfo, SettersRejectNullParameters) {
     CreateMemoryDocument(io_stream, file, document);
 
     HandleGuard<DocumentInfoHandle, DocumentInfo_Release> info;
-    ASSERT_EQ(Document_CreateDocumentInfo(document, info.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(DocumentInfo_CreateFromDocument(document, info.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Document_SetDocumentInfo(document, info), VANILLAPDF_ERROR_SUCCESS);
 
     EXPECT_EQ(DocumentInfo_SetTitle(nullptr, nullptr), VANILLAPDF_ERROR_PARAMETER_VALUE);
     EXPECT_EQ(DocumentInfo_SetTitle(info, nullptr), VANILLAPDF_ERROR_PARAMETER_VALUE);
     EXPECT_EQ(DocumentInfo_SetCreationDate(info, nullptr), VANILLAPDF_ERROR_PARAMETER_VALUE);
-    EXPECT_EQ(Document_CreateDocumentInfo(nullptr, info.out()), VANILLAPDF_ERROR_PARAMETER_VALUE);
-    EXPECT_EQ(Document_CreateDocumentInfo(document, nullptr), VANILLAPDF_ERROR_PARAMETER_VALUE);
+    EXPECT_EQ(DocumentInfo_CreateFromDocument(nullptr, info.out()), VANILLAPDF_ERROR_PARAMETER_VALUE);
+    EXPECT_EQ(DocumentInfo_CreateFromDocument(document, nullptr), VANILLAPDF_ERROR_PARAMETER_VALUE);
+    EXPECT_EQ(Document_SetDocumentInfo(document, nullptr), VANILLAPDF_ERROR_PARAMETER_VALUE);
 }
 
 } // namespace document_info

--- a/src/vanillapdf.unittest/document_info_test.cpp
+++ b/src/vanillapdf.unittest/document_info_test.cpp
@@ -17,11 +17,11 @@ static void CreateMemoryDocument(
     ASSERT_EQ(Document_CreateFile(file, document.out()), VANILLAPDF_ERROR_SUCCESS);
 }
 
-// Reads the decoded contents of a string object into result.
-// Buffer data is a std::vector<char> and is not null terminated, so it is
-// copied into a std::string, whose c_str() is terminated and therefore safe
-// to compare with EXPECT_STREQ.
-static void GetDecodedString(StringObjectHandle* handle, std::string& result) {
+// Verifies that a string object holds the expected decoded contents.
+// Buffer data is a std::vector<char> and carries no null terminator, so the
+// length is checked explicitly and the contents compared element wise rather
+// than handing the raw pointer to a string comparison.
+static void ExpectDecodedString(StringObjectHandle* handle, const std::string& expected) {
     HandleGuard<BufferHandle, Buffer_Release> buffer;
     ASSERT_EQ(StringObject_GetValue(handle, buffer.out()), VANILLAPDF_ERROR_SUCCESS);
 
@@ -29,7 +29,11 @@ static void GetDecodedString(StringObjectHandle* handle, std::string& result) {
     size_type size = 0;
     ASSERT_EQ(Buffer_GetData(buffer, &data, &size), VANILLAPDF_ERROR_SUCCESS);
 
-    result.assign(data, size);
+    ASSERT_EQ(size, expected.size());
+
+    for (size_type i = 0; i < size; ++i) {
+        EXPECT_EQ(data[i], expected[i]);
+    }
 }
 
 static void SetAndExpectString(
@@ -46,9 +50,7 @@ static void SetAndExpectString(
     HandleGuard<StringObjectHandle, StringObject_Release> result;
     ASSERT_EQ(getter(info, result.out()), VANILLAPDF_ERROR_SUCCESS);
 
-    std::string decoded;
-    GetDecodedString(result, decoded);
-    EXPECT_STREQ(decoded.c_str(), value);
+    ExpectDecodedString(result, value);
 }
 
 TEST(DocumentInfo, SetAndGetStringEntries) {
@@ -182,9 +184,7 @@ TEST(DocumentInfo, SetDocumentInfoOverwrite) {
     HandleGuard<StringObjectHandle, StringObject_Release> title;
     ASSERT_EQ(DocumentInfo_GetTitle(found, title.out()), VANILLAPDF_ERROR_SUCCESS);
 
-    std::string decoded_title;
-    GetDecodedString(title, decoded_title);
-    EXPECT_STREQ(decoded_title.c_str(), "Second title");
+    ExpectDecodedString(title, "Second title");
 }
 
 // Metadata set through the setters has to survive a save/reload cycle
@@ -220,13 +220,8 @@ TEST(DocumentInfo, SettersPersistAcrossSave) {
     ASSERT_EQ(DocumentInfo_GetTitle(reloaded_info, title.out()), VANILLAPDF_ERROR_SUCCESS);
     ASSERT_EQ(DocumentInfo_GetAuthor(reloaded_info, author.out()), VANILLAPDF_ERROR_SUCCESS);
 
-    std::string decoded_title;
-    std::string decoded_author;
-    GetDecodedString(title, decoded_title);
-    GetDecodedString(author, decoded_author);
-
-    EXPECT_STREQ(decoded_title.c_str(), "Saved title");
-    EXPECT_STREQ(decoded_author.c_str(), "Saved author");
+    ExpectDecodedString(title, "Saved title");
+    ExpectDecodedString(author, "Saved author");
 }
 
 TEST(DocumentInfo, SettersRejectNullParameters) {

--- a/src/vanillapdf/implementation/semantics/c_document.cpp
+++ b/src/vanillapdf/implementation/semantics/c_document.cpp
@@ -192,17 +192,16 @@ VANILLAPDF_API error_type CALLING_CONVENTION Document_GetDocumentInfo(DocumentHa
     } CATCH_VANILLAPDF_EXCEPTIONS
 }
 
-VANILLAPDF_API error_type CALLING_CONVENTION Document_CreateDocumentInfo(DocumentHandle* handle, DocumentInfoHandle** result)
+VANILLAPDF_API error_type CALLING_CONVENTION Document_SetDocumentInfo(DocumentHandle* handle, DocumentInfoHandle* value)
 {
     Document* document = reinterpret_cast<Document*>(handle);
+    DocumentInfo* info = reinterpret_cast<DocumentInfo*>(value);
     RETURN_ERROR_PARAM_VALUE_IF_NULL(document);
-    RETURN_ERROR_PARAM_VALUE_IF_NULL(result);
+    RETURN_ERROR_PARAM_VALUE_IF_NULL(info);
 
     try
     {
-        auto info = document->CreateDocumentInfo();
-        auto ptr = info.AddRefGet();
-        *result = reinterpret_cast<DocumentInfoHandle*>(ptr);
+        document->SetDocumentInfo(info);
         return VANILLAPDF_ERROR_SUCCESS;
     } CATCH_VANILLAPDF_EXCEPTIONS
 }

--- a/src/vanillapdf/implementation/semantics/c_document.cpp
+++ b/src/vanillapdf/implementation/semantics/c_document.cpp
@@ -192,6 +192,21 @@ VANILLAPDF_API error_type CALLING_CONVENTION Document_GetDocumentInfo(DocumentHa
     } CATCH_VANILLAPDF_EXCEPTIONS
 }
 
+VANILLAPDF_API error_type CALLING_CONVENTION Document_CreateDocumentInfo(DocumentHandle* handle, DocumentInfoHandle** result)
+{
+    Document* document = reinterpret_cast<Document*>(handle);
+    RETURN_ERROR_PARAM_VALUE_IF_NULL(document);
+    RETURN_ERROR_PARAM_VALUE_IF_NULL(result);
+
+    try
+    {
+        auto info = document->CreateDocumentInfo();
+        auto ptr = info.AddRefGet();
+        *result = reinterpret_cast<DocumentInfoHandle*>(ptr);
+        return VANILLAPDF_ERROR_SUCCESS;
+    } CATCH_VANILLAPDF_EXCEPTIONS
+}
+
 VANILLAPDF_API error_type CALLING_CONVENTION Document_AppendDocument(DocumentHandle* handle, DocumentHandle* source_handle)
 {
     Document* document = reinterpret_cast<Document*>(handle);

--- a/src/vanillapdf/implementation/semantics/c_document_info.cpp
+++ b/src/vanillapdf/implementation/semantics/c_document_info.cpp
@@ -1,5 +1,6 @@
 #include "precompiled.h"
 #include "semantics/objects/document_info.h"
+#include "semantics/objects/document.h"
 #include "semantics/objects/date.h"
 
 #include "vanillapdf/semantics/c_document_info.h"
@@ -8,6 +9,21 @@
 using namespace vanillapdf;
 using namespace vanillapdf::syntax;
 using namespace vanillapdf::semantics;
+
+VANILLAPDF_API error_type CALLING_CONVENTION DocumentInfo_CreateFromDocument(DocumentHandle* handle, DocumentInfoHandle** result)
+{
+    Document* document = reinterpret_cast<Document*>(handle);
+    RETURN_ERROR_PARAM_VALUE_IF_NULL(document);
+    RETURN_ERROR_PARAM_VALUE_IF_NULL(result);
+
+    try
+    {
+        auto info = DocumentInfo::Create(document);
+        auto ptr = info.AddRefGet();
+        *result = reinterpret_cast<DocumentInfoHandle*>(ptr);
+        return VANILLAPDF_ERROR_SUCCESS;
+    } CATCH_VANILLAPDF_EXCEPTIONS
+}
 
 VANILLAPDF_API error_type CALLING_CONVENTION DocumentInfo_GetTitle(DocumentInfoHandle* handle, StringObjectHandle** result)
 {

--- a/src/vanillapdf/implementation/semantics/c_document_info.cpp
+++ b/src/vanillapdf/implementation/semantics/c_document_info.cpp
@@ -173,6 +173,144 @@ VANILLAPDF_API error_type CALLING_CONVENTION DocumentInfo_GetTrapped(DocumentInf
     } CATCH_VANILLAPDF_EXCEPTIONS
 }
 
+VANILLAPDF_API error_type CALLING_CONVENTION DocumentInfo_SetTitle(DocumentInfoHandle* handle, StringObjectHandle* value)
+{
+    DocumentInfo* obj = reinterpret_cast<DocumentInfo*>(handle);
+    StringObjectBase* title = reinterpret_cast<StringObjectBase*>(value);
+    RETURN_ERROR_PARAM_VALUE_IF_NULL(obj);
+    RETURN_ERROR_PARAM_VALUE_IF_NULL(title);
+
+    try
+    {
+        obj->SetTitle(title);
+        return VANILLAPDF_ERROR_SUCCESS;
+    } CATCH_VANILLAPDF_EXCEPTIONS
+}
+
+VANILLAPDF_API error_type CALLING_CONVENTION DocumentInfo_SetAuthor(DocumentInfoHandle* handle, StringObjectHandle* value)
+{
+    DocumentInfo* obj = reinterpret_cast<DocumentInfo*>(handle);
+    StringObjectBase* author = reinterpret_cast<StringObjectBase*>(value);
+    RETURN_ERROR_PARAM_VALUE_IF_NULL(obj);
+    RETURN_ERROR_PARAM_VALUE_IF_NULL(author);
+
+    try
+    {
+        obj->SetAuthor(author);
+        return VANILLAPDF_ERROR_SUCCESS;
+    } CATCH_VANILLAPDF_EXCEPTIONS
+}
+
+VANILLAPDF_API error_type CALLING_CONVENTION DocumentInfo_SetSubject(DocumentInfoHandle* handle, StringObjectHandle* value)
+{
+    DocumentInfo* obj = reinterpret_cast<DocumentInfo*>(handle);
+    StringObjectBase* subject = reinterpret_cast<StringObjectBase*>(value);
+    RETURN_ERROR_PARAM_VALUE_IF_NULL(obj);
+    RETURN_ERROR_PARAM_VALUE_IF_NULL(subject);
+
+    try
+    {
+        obj->SetSubject(subject);
+        return VANILLAPDF_ERROR_SUCCESS;
+    } CATCH_VANILLAPDF_EXCEPTIONS
+}
+
+VANILLAPDF_API error_type CALLING_CONVENTION DocumentInfo_SetKeywords(DocumentInfoHandle* handle, StringObjectHandle* value)
+{
+    DocumentInfo* obj = reinterpret_cast<DocumentInfo*>(handle);
+    StringObjectBase* keywords = reinterpret_cast<StringObjectBase*>(value);
+    RETURN_ERROR_PARAM_VALUE_IF_NULL(obj);
+    RETURN_ERROR_PARAM_VALUE_IF_NULL(keywords);
+
+    try
+    {
+        obj->SetKeywords(keywords);
+        return VANILLAPDF_ERROR_SUCCESS;
+    } CATCH_VANILLAPDF_EXCEPTIONS
+}
+
+VANILLAPDF_API error_type CALLING_CONVENTION DocumentInfo_SetCreator(DocumentInfoHandle* handle, StringObjectHandle* value)
+{
+    DocumentInfo* obj = reinterpret_cast<DocumentInfo*>(handle);
+    StringObjectBase* creator = reinterpret_cast<StringObjectBase*>(value);
+    RETURN_ERROR_PARAM_VALUE_IF_NULL(obj);
+    RETURN_ERROR_PARAM_VALUE_IF_NULL(creator);
+
+    try
+    {
+        obj->SetCreator(creator);
+        return VANILLAPDF_ERROR_SUCCESS;
+    } CATCH_VANILLAPDF_EXCEPTIONS
+}
+
+VANILLAPDF_API error_type CALLING_CONVENTION DocumentInfo_SetProducer(DocumentInfoHandle* handle, StringObjectHandle* value)
+{
+    DocumentInfo* obj = reinterpret_cast<DocumentInfo*>(handle);
+    StringObjectBase* producer = reinterpret_cast<StringObjectBase*>(value);
+    RETURN_ERROR_PARAM_VALUE_IF_NULL(obj);
+    RETURN_ERROR_PARAM_VALUE_IF_NULL(producer);
+
+    try
+    {
+        obj->SetProducer(producer);
+        return VANILLAPDF_ERROR_SUCCESS;
+    } CATCH_VANILLAPDF_EXCEPTIONS
+}
+
+VANILLAPDF_API error_type CALLING_CONVENTION DocumentInfo_SetCreationDate(DocumentInfoHandle* handle, DateHandle* value)
+{
+    DocumentInfo* obj = reinterpret_cast<DocumentInfo*>(handle);
+    Date* creation_date = reinterpret_cast<Date*>(value);
+    RETURN_ERROR_PARAM_VALUE_IF_NULL(obj);
+    RETURN_ERROR_PARAM_VALUE_IF_NULL(creation_date);
+
+    try
+    {
+        obj->SetCreationDate(creation_date);
+        return VANILLAPDF_ERROR_SUCCESS;
+    } CATCH_VANILLAPDF_EXCEPTIONS
+}
+
+VANILLAPDF_API error_type CALLING_CONVENTION DocumentInfo_SetModificationDate(DocumentInfoHandle* handle, DateHandle* value)
+{
+    DocumentInfo* obj = reinterpret_cast<DocumentInfo*>(handle);
+    Date* modification_date = reinterpret_cast<Date*>(value);
+    RETURN_ERROR_PARAM_VALUE_IF_NULL(obj);
+    RETURN_ERROR_PARAM_VALUE_IF_NULL(modification_date);
+
+    try
+    {
+        obj->SetModificationDate(modification_date);
+        return VANILLAPDF_ERROR_SUCCESS;
+    } CATCH_VANILLAPDF_EXCEPTIONS
+}
+
+VANILLAPDF_API error_type CALLING_CONVENTION DocumentInfo_SetTrapped(DocumentInfoHandle* handle, DocumentTrappedType value)
+{
+    DocumentInfo* obj = reinterpret_cast<DocumentInfo*>(handle);
+    RETURN_ERROR_PARAM_VALUE_IF_NULL(obj);
+
+    try
+    {
+        vanillapdf::semantics::DocumentTrapped trapped = vanillapdf::semantics::DocumentTrapped::Undefined;
+
+        switch (value)
+        {
+        case DocumentTrappedType_Unknown:
+            trapped = vanillapdf::semantics::DocumentTrapped::Unknown; break;
+        case DocumentTrappedType_True:
+            trapped = vanillapdf::semantics::DocumentTrapped::True; break;
+        case DocumentTrappedType_False:
+            trapped = vanillapdf::semantics::DocumentTrapped::False; break;
+        default:
+            return VANILLAPDF_ERROR_PARAMETER_VALUE;
+        }
+
+        obj->SetTrapped(trapped);
+        return VANILLAPDF_ERROR_SUCCESS;
+    } CATCH_VANILLAPDF_EXCEPTIONS
+}
+
 VANILLAPDF_API error_type CALLING_CONVENTION DocumentInfo_ToUnknown(DocumentInfoHandle* handle, IUnknownHandle** result) {
     return SafeObjectConvert<DocumentInfo, IUnknown, DocumentInfoHandle, IUnknownHandle>(handle, result);
 }

--- a/src/vanillapdf/semantics/objects/document.cpp
+++ b/src/vanillapdf/semantics/objects/document.cpp
@@ -227,15 +227,20 @@ CatalogPtr Document::CreateCatalog() {
     return make_deferred<Catalog>(raw_dictionary);
 }
 
+void Document::SetDocumentInfo(DocumentInfoPtr value) {
+    auto chain = m_holder->GetXrefChain();
+    auto xref = chain->Begin()->Value();
+    auto trailer_dictionary = xref->GetTrailerDictionary();
+
+    // The information dictionary is an indirect object,
+    // so the trailer stores a reference to it
+    auto info_object = value->GetObject();
+    IndirectReferenceObjectPtr reference = make_deferred<IndirectReferenceObject>(info_object);
+
+    trailer_dictionary->Insert(constant::Name::Info, reference, true);
+}
+
 DocumentInfoPtr Document::CreateDocumentInfo() {
-
-    // Return the existing document information dictionary when there is one,
-    // inserting a second /Info entry would throw and orphan the original object
-    OutputDocumentInfoPtr existing_info;
-    if (GetDocumentInfo(existing_info)) {
-        return *existing_info;
-    }
-
     auto chain = m_holder->GetXrefChain();
     auto entry = m_holder->AllocateNewEntry();
 

--- a/src/vanillapdf/semantics/objects/document.cpp
+++ b/src/vanillapdf/semantics/objects/document.cpp
@@ -228,6 +228,14 @@ CatalogPtr Document::CreateCatalog() {
 }
 
 DocumentInfoPtr Document::CreateDocumentInfo() {
+
+    // Return the existing document information dictionary when there is one,
+    // inserting a second /Info entry would throw and orphan the original object
+    OutputDocumentInfoPtr existing_info;
+    if (GetDocumentInfo(existing_info)) {
+        return *existing_info;
+    }
+
     auto chain = m_holder->GetXrefChain();
     auto entry = m_holder->AllocateNewEntry();
 

--- a/src/vanillapdf/semantics/objects/document.h
+++ b/src/vanillapdf/semantics/objects/document.h
@@ -38,10 +38,7 @@ public:
 
     bool GetDocumentCatalog(OutputCatalogPtr& result) const;
     bool GetDocumentInfo(OutputDocumentInfoPtr& result) const;
-
-    // Returns the existing document information dictionary,
-    // creating an empty one when the document does not have any yet
-    DocumentInfoPtr CreateDocumentInfo();
+    void SetDocumentInfo(DocumentInfoPtr value);
 
 private:
     bool ResolveCatalog(OutputCatalogPtr& result) const;
@@ -67,6 +64,7 @@ private:
     syntax::FilePtr m_holder;
 
     CatalogPtr CreateCatalog();
+    DocumentInfoPtr CreateDocumentInfo();
     PageTreePtr CreatePageTree(CatalogPtr catalog);
     NamedDestinationsPtr CreateNameDestinations(CatalogPtr catalog);
     NameDictionaryPtr CreateNameDictionary(CatalogPtr catalog);

--- a/src/vanillapdf/semantics/objects/document.h
+++ b/src/vanillapdf/semantics/objects/document.h
@@ -39,6 +39,10 @@ public:
     bool GetDocumentCatalog(OutputCatalogPtr& result) const;
     bool GetDocumentInfo(OutputDocumentInfoPtr& result) const;
 
+    // Returns the existing document information dictionary,
+    // creating an empty one when the document does not have any yet
+    DocumentInfoPtr CreateDocumentInfo();
+
 private:
     bool ResolveCatalog(OutputCatalogPtr& result) const;
 
@@ -63,7 +67,6 @@ private:
     syntax::FilePtr m_holder;
 
     CatalogPtr CreateCatalog();
-    DocumentInfoPtr CreateDocumentInfo();
     PageTreePtr CreatePageTree(CatalogPtr catalog);
     NamedDestinationsPtr CreateNameDestinations(CatalogPtr catalog);
     NameDictionaryPtr CreateNameDictionary(CatalogPtr catalog);

--- a/src/vanillapdf/semantics/objects/document_info.cpp
+++ b/src/vanillapdf/semantics/objects/document_info.cpp
@@ -145,35 +145,35 @@ bool DocumentInfo::Trapped(DocumentTrapped& result) const {
 }
 
 void DocumentInfo::SetTitle(syntax::StringObjectPtr value) {
-    _obj->Insert(constant::Name::Title, value);
+    _obj->Insert(constant::Name::Title, value, true);
 }
 
 void DocumentInfo::SetAuthor(syntax::StringObjectPtr value) {
-    _obj->Insert(constant::Name::Author, value);
+    _obj->Insert(constant::Name::Author, value, true);
 }
 
 void DocumentInfo::SetSubject(syntax::StringObjectPtr value) {
-    _obj->Insert(constant::Name::Subject, value);
+    _obj->Insert(constant::Name::Subject, value, true);
 }
 
 void DocumentInfo::SetKeywords(syntax::StringObjectPtr value) {
-    _obj->Insert(constant::Name::Keywords, value);
+    _obj->Insert(constant::Name::Keywords, value, true);
 }
 
 void DocumentInfo::SetCreator(syntax::StringObjectPtr value) {
-    _obj->Insert(constant::Name::Creator, value);
+    _obj->Insert(constant::Name::Creator, value, true);
 }
 
 void DocumentInfo::SetProducer(syntax::StringObjectPtr value) {
-    _obj->Insert(constant::Name::Producer, value);
+    _obj->Insert(constant::Name::Producer, value, true);
 }
 
 void DocumentInfo::SetCreationDate(DatePtr value) {
-    _obj->Insert(constant::Name::CreationDate, value->GetObject());
+    _obj->Insert(constant::Name::CreationDate, value->GetObject(), true);
 }
 
 void DocumentInfo::SetModificationDate(DatePtr value) {
-    _obj->Insert(constant::Name::ModDate, value->GetObject());
+    _obj->Insert(constant::Name::ModDate, value->GetObject(), true);
 }
 
 void DocumentInfo::SetTrapped(DocumentTrapped value) {
@@ -194,7 +194,7 @@ void DocumentInfo::SetTrapped(DocumentTrapped value) {
             throw InvalidParameterException("Unknown trapped type");
     }
 
-    _obj->Insert(constant::Name::Trapped, name);
+    _obj->Insert(constant::Name::Trapped, name, true);
 }
 
 } // semantics

--- a/src/vanillapdf/semantics/objects/document_info.cpp
+++ b/src/vanillapdf/semantics/objects/document_info.cpp
@@ -4,6 +4,7 @@
 #include "syntax/files/file.h"
 
 #include "semantics/objects/document_info.h"
+#include "semantics/objects/document.h"
 #include "semantics/objects/date.h"
 
 #include "syntax/utils/name_constants.h"
@@ -142,6 +143,22 @@ bool DocumentInfo::Trapped(DocumentTrapped& result) const {
 
     assert(false && "Document trapped is neither of name or string");
     return false;
+}
+
+DocumentInfoPtr DocumentInfo::Create(DocumentPtr document) {
+    auto file = document->GetFile();
+
+    syntax::DictionaryObjectPtr raw_dictionary;
+
+    auto new_entry = file->AllocateNewEntry();
+    new_entry->SetReference(raw_dictionary);
+    new_entry->SetFile(file);
+    new_entry->SetInitialized();
+
+    raw_dictionary->SetFile(file);
+    raw_dictionary->SetInitialized();
+
+    return make_deferred<DocumentInfo>(raw_dictionary);
 }
 
 void DocumentInfo::SetTitle(syntax::StringObjectPtr value) {

--- a/src/vanillapdf/semantics/objects/document_info.h
+++ b/src/vanillapdf/semantics/objects/document_info.h
@@ -20,6 +20,10 @@ class DocumentInfo : public HighLevelObject<syntax::DictionaryObjectPtr> {
 public:
     explicit DocumentInfo(syntax::DictionaryObjectPtr root);
 
+    // Creates an empty information dictionary registered as an indirect object
+    // within the document. Attach it through Document::SetDocumentInfo.
+    static DocumentInfoPtr Create(DocumentPtr document);
+
     // optional
     bool Title(syntax::OutputStringObjectPtr& result) const;
     bool Author(syntax::OutputStringObjectPtr& result) const;


### PR DESCRIPTION
## Summary

First of three PRs exposing semantic API that already exists in C++ but was never reachable from C. This one covers document metadata, which downstream consumers could read but never write.

All nine `DocumentInfo` setters have been implemented on the C++ class since its introduction — they simply had no C declaration.

## Added

```c
DocumentInfo_SetTitle / _SetAuthor / _SetSubject / _SetKeywords / _SetCreator / _SetProducer
DocumentInfo_SetCreationDate / _SetModificationDate
DocumentInfo_SetTrapped
DocumentInfo_CreateFromDocument
Document_SetDocumentInfo
```

`DocumentInfo_SetTrapped` rejects `DocumentTrappedType_Undefined` with `VANILLAPDF_ERROR_PARAMETER_VALUE`, since it has no `/Trapped` representation.

## Create + Set

The setters are useless on a document with no `/Info` dictionary, and `Document_GetDocumentInfo` reports `VANILLAPDF_ERROR_OBJECT_MISSING` for those. Rather than a create-if-missing accessor, this follows the Create + Set pairing used across the API:

```c
DocumentInfo_CreateFromDocument(document, &info);   /* registers an indirect dictionary */
Document_SetDocumentInfo(document, info);           /* attaches it to the trailer */
```

Each verb means one thing — `Get` never modifies, `CreateFrom*` always makes a new object, `Set` attaches it. Keeping them separate also keeps reads side-effect free: a create-if-missing getter would let a caller dirty a document merely by asking for its metadata.

`Document::CreateDocumentInfo` stays private. It creates and attaches in one step, which suits `Document::CreateFile`, its only caller. `Document::SetDocumentInfo` inserts with overwrite, so attaching a second dictionary replaces the trailer entry rather than throwing on a duplicate `/Info` key.

## Library defect fixed

The setters inserted without overwrite, so any second call raised `VANILLAPDF_ERROR_DUPLICATE_KEY`. This was invisible while they were only ever called on a freshly created dictionary, but it made `DocumentInfo_SetProducer` fail on **every** document produced by `Document_CreateFile` — that path already populates `/Producer`. They now pass `overwrite = true`, matching how `PageObject::SetResources` and `InteractiveForm::SetNeedAppearances` already behave.

## Testing

Eight tests in `document_info_test.cpp`, all passing:

- round-trip for all six string entries, and for the date entries
- overwrite behaviour — the regression test for the defect above
- all three `Trapped` values plus `Undefined` rejection
- `SetDocumentInfoOverwrite` — attaching twice replaces the entry and the document reports the most recent dictionary
- persistence across a save and reopen, confirming the values reach the written file
- null parameter handling

String comparisons check the length explicitly and compare contents element wise, since `Buffer` data is a `std::vector<char>` with no null terminator — the convention already used in `main.cpp`, `document_test.cpp` and `objects_test.cpp`.

Verified on `windows-x64-msvc-18`. Merging all three PRs together builds clean and runs 436 unit tests with no failures.

## Context

Part of the API gap analysis for making the .NET UI application usable for annotation, bookmark, form filling and signing workflows. Companion PRs cover interactive forms / signature flags and page contents / resource dictionaries. The three are independent — the only shared file is the unit test `CMakeLists.txt`, which merges cleanly in any order.
