### PR TITLE
feat: Expose page contents and resource dictionary setters

### DIFF
--- a/include/vanillapdf/semantics/c_page_contents.h
+++ b/include/vanillapdf/semantics/c_page_contents.h
@@ -33,10 +33,24 @@ extern "C"
 
     /**
     * \brief
+    * Create empty page contents backed by a new, empty content stream
+    * registered as an indirect object within the document.
+    *
+    * This is the entry point for \ref PageObject_SetContents, which stores an
+    * indirect reference to the content stream - the stream therefore has to
+    * own a cross-reference entry. There is deliberately no parameterless
+    * create, as an unregistered stream would produce a dangling reference
+    * that only fails when the document is written.
+    */
+    VANILLAPDF_API error_type CALLING_CONVENTION PageContents_CreateFromDocument(DocumentHandle* handle, PageContentsHandle** result);
+
+    /**
+    * \brief
     * Create page contents from an existing low-level content stream object.
     *
-    * Required for \ref PageObject_SetContents, as the semantic layer
-    * does not offer any other way of obtaining new page contents.
+    * Use this overload when the content stream is already registered in the
+    * document, for example through \ref File_AllocateNewEntry. Prefer
+    * \ref PageContents_CreateFromDocument otherwise.
     */
     VANILLAPDF_API error_type CALLING_CONVENTION PageContents_CreateFromStream(StreamObjectHandle* handle, PageContentsHandle** result);
 

--- a/include/vanillapdf/semantics/c_page_contents.h
+++ b/include/vanillapdf/semantics/c_page_contents.h
@@ -32,6 +32,15 @@ extern "C"
     */
 
     /**
+    * \brief
+    * Create page contents from an existing low-level content stream object.
+    *
+    * Required for \ref PageObject_SetContents, as the semantic layer
+    * does not offer any other way of obtaining new page contents.
+    */
+    VANILLAPDF_API error_type CALLING_CONVENTION PageContents_CreateFromStream(StreamObjectHandle* handle, PageContentsHandle** result);
+
+    /**
     * \brief Return collection of the content stream instructions
     */
     VANILLAPDF_API error_type CALLING_CONVENTION PageContents_GetInstructionCollection(PageContentsHandle* handle, ContentInstructionCollectionHandle** result);

--- a/include/vanillapdf/semantics/c_page_object.h
+++ b/include/vanillapdf/semantics/c_page_object.h
@@ -55,6 +55,11 @@ extern "C"
     VANILLAPDF_API error_type CALLING_CONVENTION PageObject_GetContents(PageObjectHandle* handle, PageContentsHandle** result);
 
     /**
+    * \copydoc PageObject_GetContents
+    */
+    VANILLAPDF_API error_type CALLING_CONVENTION PageObject_SetContents(PageObjectHandle* handle, PageContentsHandle* value);
+
+    /**
     * \brief
     * The page tree node that is the immediate parent of this page object.
     */
@@ -71,6 +76,11 @@ extern "C"
     * shall be inherited from an ancestor node in the page tree.
     */
     VANILLAPDF_API error_type CALLING_CONVENTION PageObject_GetResources(PageObjectHandle* handle, ResourceDictionaryHandle** result);
+
+    /**
+    * \copydoc PageObject_GetResources
+    */
+    VANILLAPDF_API error_type CALLING_CONVENTION PageObject_SetResources(PageObjectHandle* handle, ResourceDictionaryHandle* value);
 
     /**
     * \brief

--- a/include/vanillapdf/semantics/c_resource_dictionary.h
+++ b/include/vanillapdf/semantics/c_resource_dictionary.h
@@ -36,6 +36,25 @@ extern "C"
     * \brief
     * A dictionary that maps resource names to font dictionaries.
     */
+    /**
+    * \brief
+    * Create an empty resource dictionary.
+    *
+    * The resulting dictionary is a direct object and becomes part of the
+    * document once it is attached through \ref PageObject_SetResources.
+    */
+    VANILLAPDF_API error_type CALLING_CONVENTION ResourceDictionary_Create(ResourceDictionaryHandle** result);
+
+    /**
+    * \brief
+    * Create a resource dictionary from an existing low-level dictionary object.
+    *
+    * Use this overload to wrap a dictionary that is already registered
+    * in the document, for example an indirect object obtained
+    * through \ref File_AllocateNewEntry.
+    */
+    VANILLAPDF_API error_type CALLING_CONVENTION ResourceDictionary_CreateFromDictionary(DictionaryObjectHandle* handle, ResourceDictionaryHandle** result);
+
     VANILLAPDF_API error_type CALLING_CONVENTION ResourceDictionary_GetFontMap(ResourceDictionaryHandle* handle, FontMapHandle** result);
 
     /**

--- a/src/vanillapdf.unittest/CMakeLists.txt
+++ b/src/vanillapdf.unittest/CMakeLists.txt
@@ -38,6 +38,7 @@ set(VANILLAPDF_UNITTEST_SOURCES
     test_environment.cpp
     attributes_test.cpp
     objects_test.cpp
+    page_object_test.cpp
     page_tree_test.cpp
     utils_test.cpp
     digital_signature_test.cpp

--- a/src/vanillapdf.unittest/page_object_test.cpp
+++ b/src/vanillapdf.unittest/page_object_test.cpp
@@ -1,0 +1,194 @@
+#include "unittest.h"
+#include "handle_guard.h"
+
+#include <string>
+
+namespace page_object {
+
+// Creates an in-memory document together with its first page.
+// Document_CreateFile always produces a document with exactly one page.
+static void CreateMemoryDocumentWithPage(
+    HandleGuard<InputOutputStreamHandle, InputOutputStream_Release>& io_stream,
+    HandleGuard<FileHandle, File_Release>& file,
+    HandleGuard<DocumentHandle, Document_Release>& document,
+    HandleGuard<PageObjectHandle, PageObject_Release>& page
+) {
+    HandleGuard<CatalogHandle, Catalog_Release> catalog;
+    HandleGuard<PageTreeHandle, PageTree_Release> page_tree;
+
+    ASSERT_EQ(InputOutputStream_CreateFromMemory(io_stream.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(File_CreateStream(io_stream, "temp", file.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Document_CreateFile(file, document.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Document_GetCatalog(document, catalog.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Catalog_GetPages(catalog, page_tree.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(PageTree_GetPage(page_tree, 1, page.out()), VANILLAPDF_ERROR_SUCCESS);
+}
+
+// Registers an object as a new indirect object within the file,
+// which is a precondition for anything referenced by an indirect reference
+static void RegisterIndirectObject(FileHandle* file, ObjectHandle* object) {
+    HandleGuard<XrefUsedEntryHandle, XrefUsedEntry_Release> entry;
+    ASSERT_EQ(File_AllocateNewEntry(file, entry.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(XrefUsedEntry_SetReference(entry, object), VANILLAPDF_ERROR_SUCCESS);
+}
+
+TEST(ResourceDictionary, CreateBlank) {
+    HandleGuard<ResourceDictionaryHandle, ResourceDictionary_Release> resources;
+
+    ASSERT_EQ(ResourceDictionary_Create(resources.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_NE(resources.get(), nullptr);
+}
+
+TEST(ResourceDictionary, CreateFromDictionary) {
+    HandleGuard<DictionaryObjectHandle, DictionaryObject_Release> dictionary;
+    ASSERT_EQ(DictionaryObject_Create(dictionary.out()), VANILLAPDF_ERROR_SUCCESS);
+
+    HandleGuard<ResourceDictionaryHandle, ResourceDictionary_Release> resources;
+    ASSERT_EQ(ResourceDictionary_CreateFromDictionary(dictionary, resources.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_NE(resources.get(), nullptr);
+}
+
+TEST(ResourceDictionary, CreateRejectsNullParameters) {
+    EXPECT_EQ(ResourceDictionary_Create(nullptr), VANILLAPDF_ERROR_PARAMETER_VALUE);
+    EXPECT_EQ(ResourceDictionary_CreateFromDictionary(nullptr, nullptr), VANILLAPDF_ERROR_PARAMETER_VALUE);
+}
+
+// A blank resource dictionary has no /Font entry
+TEST(ResourceDictionary, GetFontMapMissing) {
+    HandleGuard<ResourceDictionaryHandle, ResourceDictionary_Release> resources;
+    ASSERT_EQ(ResourceDictionary_Create(resources.out()), VANILLAPDF_ERROR_SUCCESS);
+
+    FontMapHandle* font_map = nullptr;
+    EXPECT_EQ(ResourceDictionary_GetFontMap(resources, &font_map), VANILLAPDF_ERROR_OBJECT_MISSING);
+    EXPECT_EQ(font_map, nullptr);
+}
+
+// Document_CreateFile produces a page without a /Resources entry
+TEST(PageObject, GetResourcesMissing) {
+    HandleGuard<InputOutputStreamHandle, InputOutputStream_Release> io_stream;
+    HandleGuard<FileHandle, File_Release> file;
+    HandleGuard<DocumentHandle, Document_Release> document;
+    HandleGuard<PageObjectHandle, PageObject_Release> page;
+    CreateMemoryDocumentWithPage(io_stream, file, document, page);
+
+    ResourceDictionaryHandle* resources = nullptr;
+    EXPECT_EQ(PageObject_GetResources(page, &resources), VANILLAPDF_ERROR_OBJECT_MISSING);
+    EXPECT_EQ(resources, nullptr);
+}
+
+TEST(PageObject, SetAndGetResources) {
+    HandleGuard<InputOutputStreamHandle, InputOutputStream_Release> io_stream;
+    HandleGuard<FileHandle, File_Release> file;
+    HandleGuard<DocumentHandle, Document_Release> document;
+    HandleGuard<PageObjectHandle, PageObject_Release> page;
+    CreateMemoryDocumentWithPage(io_stream, file, document, page);
+
+    HandleGuard<ResourceDictionaryHandle, ResourceDictionary_Release> resources;
+    ASSERT_EQ(ResourceDictionary_Create(resources.out()), VANILLAPDF_ERROR_SUCCESS);
+
+    ASSERT_EQ(PageObject_SetResources(page, resources), VANILLAPDF_ERROR_SUCCESS);
+
+    HandleGuard<ResourceDictionaryHandle, ResourceDictionary_Release> found_resources;
+    ASSERT_EQ(PageObject_GetResources(page, found_resources.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_NE(found_resources.get(), nullptr);
+}
+
+// Setting resources twice must replace the previous entry rather than throw
+TEST(PageObject, SetResourcesOverwrite) {
+    HandleGuard<InputOutputStreamHandle, InputOutputStream_Release> io_stream;
+    HandleGuard<FileHandle, File_Release> file;
+    HandleGuard<DocumentHandle, Document_Release> document;
+    HandleGuard<PageObjectHandle, PageObject_Release> page;
+    CreateMemoryDocumentWithPage(io_stream, file, document, page);
+
+    HandleGuard<ResourceDictionaryHandle, ResourceDictionary_Release> first;
+    HandleGuard<ResourceDictionaryHandle, ResourceDictionary_Release> second;
+    ASSERT_EQ(ResourceDictionary_Create(first.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(ResourceDictionary_Create(second.out()), VANILLAPDF_ERROR_SUCCESS);
+
+    ASSERT_EQ(PageObject_SetResources(page, first), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(PageObject_SetResources(page, second), VANILLAPDF_ERROR_SUCCESS);
+
+    HandleGuard<ResourceDictionaryHandle, ResourceDictionary_Release> found;
+    ASSERT_EQ(PageObject_GetResources(page, found.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_NE(found.get(), nullptr);
+}
+
+TEST(PageObject, SetResourcesRejectsNullParameters) {
+    HandleGuard<InputOutputStreamHandle, InputOutputStream_Release> io_stream;
+    HandleGuard<FileHandle, File_Release> file;
+    HandleGuard<DocumentHandle, Document_Release> document;
+    HandleGuard<PageObjectHandle, PageObject_Release> page;
+    CreateMemoryDocumentWithPage(io_stream, file, document, page);
+
+    EXPECT_EQ(PageObject_SetResources(nullptr, nullptr), VANILLAPDF_ERROR_PARAMETER_VALUE);
+    EXPECT_EQ(PageObject_SetResources(page, nullptr), VANILLAPDF_ERROR_PARAMETER_VALUE);
+}
+
+TEST(PageContents, CreateFromStream) {
+    HandleGuard<StreamObjectHandle, StreamObject_Release> stream;
+    ASSERT_EQ(StreamObject_Create(stream.out()), VANILLAPDF_ERROR_SUCCESS);
+
+    HandleGuard<PageContentsHandle, PageContents_Release> contents;
+    ASSERT_EQ(PageContents_CreateFromStream(stream, contents.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_NE(contents.get(), nullptr);
+}
+
+TEST(PageContents, CreateFromStreamRejectsNullParameters) {
+    EXPECT_EQ(PageContents_CreateFromStream(nullptr, nullptr), VANILLAPDF_ERROR_PARAMETER_VALUE);
+
+    HandleGuard<StreamObjectHandle, StreamObject_Release> stream;
+    ASSERT_EQ(StreamObject_Create(stream.out()), VANILLAPDF_ERROR_SUCCESS);
+    EXPECT_EQ(PageContents_CreateFromStream(stream, nullptr), VANILLAPDF_ERROR_PARAMETER_VALUE);
+}
+
+// PageObject::SetContents stores an indirect reference to the content stream,
+// so the stream has to be registered as an indirect object first
+TEST(PageObject, SetAndGetContents) {
+    HandleGuard<InputOutputStreamHandle, InputOutputStream_Release> io_stream;
+    HandleGuard<FileHandle, File_Release> file;
+    HandleGuard<DocumentHandle, Document_Release> document;
+    HandleGuard<PageObjectHandle, PageObject_Release> page;
+    CreateMemoryDocumentWithPage(io_stream, file, document, page);
+
+    HandleGuard<StreamObjectHandle, StreamObject_Release> stream;
+    ASSERT_EQ(StreamObject_Create(stream.out()), VANILLAPDF_ERROR_SUCCESS);
+
+    HandleGuard<ObjectHandle, Object_Release> stream_object;
+    ASSERT_EQ(StreamObject_ToObject(stream, stream_object.out()), VANILLAPDF_ERROR_SUCCESS);
+    RegisterIndirectObject(file, stream_object);
+
+    const std::string body = "BT ET";
+    HandleGuard<BufferHandle, Buffer_Release> body_buffer;
+    ASSERT_EQ(Buffer_CreateFromData(body.data(), body.size(), body_buffer.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(StreamObject_SetBody(stream, body_buffer), VANILLAPDF_ERROR_SUCCESS);
+
+    HandleGuard<PageContentsHandle, PageContents_Release> contents;
+    ASSERT_EQ(PageContents_CreateFromStream(stream, contents.out()), VANILLAPDF_ERROR_SUCCESS);
+
+    ASSERT_EQ(PageObject_SetContents(page, contents), VANILLAPDF_ERROR_SUCCESS);
+
+    HandleGuard<PageContentsHandle, PageContents_Release> found_contents;
+    ASSERT_EQ(PageObject_GetContents(page, found_contents.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_NE(found_contents.get(), nullptr);
+
+    HandleGuard<ContentInstructionCollectionHandle, ContentInstructionCollection_Release> instructions;
+    ASSERT_EQ(PageContents_GetInstructionCollection(found_contents, instructions.out()), VANILLAPDF_ERROR_SUCCESS);
+
+    size_type instruction_count = 0;
+    ASSERT_EQ(ContentInstructionCollection_GetSize(instructions, &instruction_count), VANILLAPDF_ERROR_SUCCESS);
+    EXPECT_GT(instruction_count, 0u);
+}
+
+TEST(PageObject, SetContentsRejectsNullParameters) {
+    HandleGuard<InputOutputStreamHandle, InputOutputStream_Release> io_stream;
+    HandleGuard<FileHandle, File_Release> file;
+    HandleGuard<DocumentHandle, Document_Release> document;
+    HandleGuard<PageObjectHandle, PageObject_Release> page;
+    CreateMemoryDocumentWithPage(io_stream, file, document, page);
+
+    EXPECT_EQ(PageObject_SetContents(nullptr, nullptr), VANILLAPDF_ERROR_PARAMETER_VALUE);
+    EXPECT_EQ(PageObject_SetContents(page, nullptr), VANILLAPDF_ERROR_PARAMETER_VALUE);
+}
+
+} // namespace page_object

--- a/src/vanillapdf.unittest/page_object_test.cpp
+++ b/src/vanillapdf.unittest/page_object_test.cpp
@@ -134,6 +134,72 @@ TEST(PageContents, CreateFromStream) {
     ASSERT_NE(contents.get(), nullptr);
 }
 
+// The one call variant registers the content stream as an indirect object,
+// so the caller does not have to allocate the xref entry by hand
+TEST(PageContents, CreateFromDocument) {
+    HandleGuard<InputOutputStreamHandle, InputOutputStream_Release> io_stream;
+    HandleGuard<FileHandle, File_Release> file;
+    HandleGuard<DocumentHandle, Document_Release> document;
+    HandleGuard<PageObjectHandle, PageObject_Release> page;
+    CreateMemoryDocumentWithPage(io_stream, file, document, page);
+
+    HandleGuard<PageContentsHandle, PageContents_Release> contents;
+    ASSERT_EQ(PageContents_CreateFromDocument(document, contents.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_NE(contents.get(), nullptr);
+
+    ASSERT_EQ(PageObject_SetContents(page, contents), VANILLAPDF_ERROR_SUCCESS);
+
+    HandleGuard<PageContentsHandle, PageContents_Release> found_contents;
+    ASSERT_EQ(PageObject_GetContents(page, found_contents.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_NE(found_contents.get(), nullptr);
+}
+
+TEST(PageContents, CreateFromDocumentRejectsNullParameters) {
+    HandleGuard<InputOutputStreamHandle, InputOutputStream_Release> io_stream;
+    HandleGuard<FileHandle, File_Release> file;
+    HandleGuard<DocumentHandle, Document_Release> document;
+    HandleGuard<PageObjectHandle, PageObject_Release> page;
+    CreateMemoryDocumentWithPage(io_stream, file, document, page);
+
+    EXPECT_EQ(PageContents_CreateFromDocument(nullptr, nullptr), VANILLAPDF_ERROR_PARAMETER_VALUE);
+    EXPECT_EQ(PageContents_CreateFromDocument(document, nullptr), VANILLAPDF_ERROR_PARAMETER_VALUE);
+}
+
+// The indirect reference written by SetContents has to resolve after a save,
+// which is what an unregistered content stream would fail to do
+TEST(PageContents, CreateFromDocumentPersistsAcrossSave) {
+    HandleGuard<InputOutputStreamHandle, InputOutputStream_Release> io_stream;
+    HandleGuard<FileHandle, File_Release> file;
+    HandleGuard<DocumentHandle, Document_Release> document;
+    HandleGuard<PageObjectHandle, PageObject_Release> page;
+    CreateMemoryDocumentWithPage(io_stream, file, document, page);
+
+    HandleGuard<PageContentsHandle, PageContents_Release> contents;
+    ASSERT_EQ(PageContents_CreateFromDocument(document, contents.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(PageObject_SetContents(page, contents), VANILLAPDF_ERROR_SUCCESS);
+
+    HandleGuard<InputOutputStreamHandle, InputOutputStream_Release> destination_stream;
+    HandleGuard<FileHandle, File_Release> destination_file;
+    ASSERT_EQ(InputOutputStream_CreateFromMemory(destination_stream.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(File_CreateStream(destination_stream, "temp_destination", destination_file.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Document_SaveFile(document, destination_file), VANILLAPDF_ERROR_SUCCESS);
+
+    HandleGuard<FileHandle, File_Release> reloaded_file;
+    HandleGuard<DocumentHandle, Document_Release> reloaded_document;
+    HandleGuard<CatalogHandle, Catalog_Release> reloaded_catalog;
+    HandleGuard<PageTreeHandle, PageTree_Release> reloaded_page_tree;
+    HandleGuard<PageObjectHandle, PageObject_Release> reloaded_page;
+    ASSERT_EQ(File_OpenStream(destination_stream, "temp_destination", reloaded_file.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(File_Initialize(reloaded_file), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Document_OpenFile(reloaded_file, reloaded_document.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Document_GetCatalog(reloaded_document, reloaded_catalog.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Catalog_GetPages(reloaded_catalog, reloaded_page_tree.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(PageTree_GetPage(reloaded_page_tree, 1, reloaded_page.out()), VANILLAPDF_ERROR_SUCCESS);
+
+    HandleGuard<PageContentsHandle, PageContents_Release> reloaded_contents;
+    EXPECT_EQ(PageObject_GetContents(reloaded_page, reloaded_contents.out()), VANILLAPDF_ERROR_SUCCESS);
+}
+
 TEST(PageContents, CreateFromStreamRejectsNullParameters) {
     EXPECT_EQ(PageContents_CreateFromStream(nullptr, nullptr), VANILLAPDF_ERROR_PARAMETER_VALUE);
 
@@ -189,6 +255,41 @@ TEST(PageObject, SetContentsRejectsNullParameters) {
 
     EXPECT_EQ(PageObject_SetContents(nullptr, nullptr), VANILLAPDF_ERROR_PARAMETER_VALUE);
     EXPECT_EQ(PageObject_SetContents(page, nullptr), VANILLAPDF_ERROR_PARAMETER_VALUE);
+}
+
+// A blank resource dictionary is attached as a direct object, so it is
+// serialized inline with the page - confirm it reaches the written file
+TEST(PageObject, SetResourcesPersistAcrossSave) {
+    HandleGuard<InputOutputStreamHandle, InputOutputStream_Release> io_stream;
+    HandleGuard<FileHandle, File_Release> file;
+    HandleGuard<DocumentHandle, Document_Release> document;
+    HandleGuard<PageObjectHandle, PageObject_Release> page;
+    CreateMemoryDocumentWithPage(io_stream, file, document, page);
+
+    HandleGuard<ResourceDictionaryHandle, ResourceDictionary_Release> resources;
+    ASSERT_EQ(ResourceDictionary_Create(resources.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(PageObject_SetResources(page, resources), VANILLAPDF_ERROR_SUCCESS);
+
+    HandleGuard<InputOutputStreamHandle, InputOutputStream_Release> dest_stream;
+    HandleGuard<FileHandle, File_Release> dest_file;
+    ASSERT_EQ(InputOutputStream_CreateFromMemory(dest_stream.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(File_CreateStream(dest_stream, "temp_destination", dest_file.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Document_SaveFile(document, dest_file), VANILLAPDF_ERROR_SUCCESS);
+
+    HandleGuard<FileHandle, File_Release> reloaded_file;
+    HandleGuard<DocumentHandle, Document_Release> reloaded_doc;
+    HandleGuard<CatalogHandle, Catalog_Release> reloaded_catalog;
+    HandleGuard<PageTreeHandle, PageTree_Release> reloaded_tree;
+    HandleGuard<PageObjectHandle, PageObject_Release> reloaded_page;
+    ASSERT_EQ(File_OpenStream(dest_stream, "temp_destination", reloaded_file.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(File_Initialize(reloaded_file), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Document_OpenFile(reloaded_file, reloaded_doc.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Document_GetCatalog(reloaded_doc, reloaded_catalog.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Catalog_GetPages(reloaded_catalog, reloaded_tree.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(PageTree_GetPage(reloaded_tree, 1, reloaded_page.out()), VANILLAPDF_ERROR_SUCCESS);
+
+    HandleGuard<ResourceDictionaryHandle, ResourceDictionary_Release> reloaded_resources;
+    EXPECT_EQ(PageObject_GetResources(reloaded_page, reloaded_resources.out()), VANILLAPDF_ERROR_SUCCESS);
 }
 
 } // namespace page_object

--- a/src/vanillapdf/implementation/semantics/c_page_contents.cpp
+++ b/src/vanillapdf/implementation/semantics/c_page_contents.cpp
@@ -1,5 +1,6 @@
 #include "precompiled.h"
 #include "semantics/objects/page_contents.h"
+#include "semantics/objects/document.h"
 
 #include "contents/content_stream_instruction_base.h"
 
@@ -11,6 +12,21 @@
 using namespace vanillapdf;
 using namespace vanillapdf::syntax;
 using namespace vanillapdf::semantics;
+
+VANILLAPDF_API error_type CALLING_CONVENTION PageContents_CreateFromDocument(DocumentHandle* handle, PageContentsHandle** result)
+{
+    Document* document = reinterpret_cast<Document*>(handle);
+    RETURN_ERROR_PARAM_VALUE_IF_NULL(document);
+    RETURN_ERROR_PARAM_VALUE_IF_NULL(result);
+
+    try
+    {
+        auto contents = PageContents::Create(document);
+        auto ptr = contents.AddRefGet();
+        *result = reinterpret_cast<PageContentsHandle*>(ptr);
+        return VANILLAPDF_ERROR_SUCCESS;
+    } CATCH_VANILLAPDF_EXCEPTIONS
+}
 
 VANILLAPDF_API error_type CALLING_CONVENTION PageContents_CreateFromStream(StreamObjectHandle* handle, PageContentsHandle** result)
 {

--- a/src/vanillapdf/implementation/semantics/c_page_contents.cpp
+++ b/src/vanillapdf/implementation/semantics/c_page_contents.cpp
@@ -3,11 +3,29 @@
 
 #include "contents/content_stream_instruction_base.h"
 
+#include "syntax/objects/stream_object.h"
+
 #include "vanillapdf/semantics/c_page_contents.h"
 #include "implementation/c_helper.h"
 
 using namespace vanillapdf;
+using namespace vanillapdf::syntax;
 using namespace vanillapdf::semantics;
+
+VANILLAPDF_API error_type CALLING_CONVENTION PageContents_CreateFromStream(StreamObjectHandle* handle, PageContentsHandle** result)
+{
+    StreamObject* stream = reinterpret_cast<StreamObject*>(handle);
+    RETURN_ERROR_PARAM_VALUE_IF_NULL(stream);
+    RETURN_ERROR_PARAM_VALUE_IF_NULL(result);
+
+    try
+    {
+        auto contents = make_deferred<PageContents>(stream);
+        auto ptr = contents.AddRefGet();
+        *result = reinterpret_cast<PageContentsHandle*>(ptr);
+        return VANILLAPDF_ERROR_SUCCESS;
+    } CATCH_VANILLAPDF_EXCEPTIONS
+}
 
 VANILLAPDF_API error_type CALLING_CONVENTION PageContents_GetInstructionCollection(PageContentsHandle* handle, ContentInstructionCollectionHandle** result)
 {

--- a/src/vanillapdf/implementation/semantics/c_page_object.cpp
+++ b/src/vanillapdf/implementation/semantics/c_page_object.cpp
@@ -27,6 +27,20 @@ VANILLAPDF_API error_type CALLING_CONVENTION PageObject_GetContents(PageObjectHa
     } CATCH_VANILLAPDF_EXCEPTIONS
 }
 
+VANILLAPDF_API error_type CALLING_CONVENTION PageObject_SetContents(PageObjectHandle* handle, PageContentsHandle* value)
+{
+    PageObject* obj = reinterpret_cast<PageObject*>(handle);
+    PageContents* contents = reinterpret_cast<PageContents*>(value);
+    RETURN_ERROR_PARAM_VALUE_IF_NULL(obj);
+    RETURN_ERROR_PARAM_VALUE_IF_NULL(contents);
+
+    try
+    {
+        obj->SetContents(contents);
+        return VANILLAPDF_ERROR_SUCCESS;
+    } CATCH_VANILLAPDF_EXCEPTIONS
+}
+
 VANILLAPDF_API error_type CALLING_CONVENTION PageObject_CreateFromDocument(DocumentHandle* handle, PageObjectHandle** result)
 {
     Document* obj = reinterpret_cast<Document*>(handle);
@@ -88,6 +102,20 @@ VANILLAPDF_API error_type CALLING_CONVENTION PageObject_GetResources(PageObjectH
 
         auto ptr = resources.AddRefGet();
         *result = reinterpret_cast<ResourceDictionaryHandle*>(ptr);
+        return VANILLAPDF_ERROR_SUCCESS;
+    } CATCH_VANILLAPDF_EXCEPTIONS
+}
+
+VANILLAPDF_API error_type CALLING_CONVENTION PageObject_SetResources(PageObjectHandle* handle, ResourceDictionaryHandle* value)
+{
+    PageObject* obj = reinterpret_cast<PageObject*>(handle);
+    ResourceDictionary* resources = reinterpret_cast<ResourceDictionary*>(value);
+    RETURN_ERROR_PARAM_VALUE_IF_NULL(obj);
+    RETURN_ERROR_PARAM_VALUE_IF_NULL(resources);
+
+    try
+    {
+        obj->SetResources(resources);
         return VANILLAPDF_ERROR_SUCCESS;
     } CATCH_VANILLAPDF_EXCEPTIONS
 }

--- a/src/vanillapdf/implementation/semantics/c_resource_dictionary.cpp
+++ b/src/vanillapdf/implementation/semantics/c_resource_dictionary.cpp
@@ -1,11 +1,43 @@
 #include "precompiled.h"
 #include "semantics/objects/resource_dictionary.h"
 
+#include "syntax/objects/dictionary_object.h"
+
 #include "vanillapdf/semantics/c_resource_dictionary.h"
 #include "implementation/c_helper.h"
 
 using namespace vanillapdf;
+using namespace vanillapdf::syntax;
 using namespace vanillapdf::semantics;
+
+VANILLAPDF_API error_type CALLING_CONVENTION ResourceDictionary_Create(ResourceDictionaryHandle** result)
+{
+    RETURN_ERROR_PARAM_VALUE_IF_NULL(result);
+
+    try
+    {
+        DictionaryObjectPtr dictionary;
+        auto resources = make_deferred<ResourceDictionary>(dictionary);
+        auto ptr = resources.AddRefGet();
+        *result = reinterpret_cast<ResourceDictionaryHandle*>(ptr);
+        return VANILLAPDF_ERROR_SUCCESS;
+    } CATCH_VANILLAPDF_EXCEPTIONS
+}
+
+VANILLAPDF_API error_type CALLING_CONVENTION ResourceDictionary_CreateFromDictionary(DictionaryObjectHandle* handle, ResourceDictionaryHandle** result)
+{
+    DictionaryObject* dictionary = reinterpret_cast<DictionaryObject*>(handle);
+    RETURN_ERROR_PARAM_VALUE_IF_NULL(dictionary);
+    RETURN_ERROR_PARAM_VALUE_IF_NULL(result);
+
+    try
+    {
+        auto resources = make_deferred<ResourceDictionary>(dictionary);
+        auto ptr = resources.AddRefGet();
+        *result = reinterpret_cast<ResourceDictionaryHandle*>(ptr);
+        return VANILLAPDF_ERROR_SUCCESS;
+    } CATCH_VANILLAPDF_EXCEPTIONS
+}
 
 VANILLAPDF_API error_type CALLING_CONVENTION ResourceDictionary_GetFontMap(ResourceDictionaryHandle* handle, FontMapHandle** result)
 {

--- a/src/vanillapdf/semantics/objects/page_contents.cpp
+++ b/src/vanillapdf/semantics/objects/page_contents.cpp
@@ -3,7 +3,9 @@
 #include "syntax/files/file.h"
 
 #include "semantics/objects/page_contents.h"
+#include "semantics/objects/document.h"
 
+#include "syntax/objects/stream_object.h"
 #include "syntax/exceptions/syntax_exceptions.h"
 
 #include "contents/content_stream_parser.h"
@@ -26,6 +28,22 @@ PageContents::PageContents(StreamObjectPtr obj) : HighLevelObject(obj) {
 
 PageContents::PageContents(ArrayObjectPtr<IndirectReferenceObjectPtr> obj)
     : HighLevelObject(obj->Data()) {
+}
+
+PageContentsPtr PageContents::Create(DocumentPtr document) {
+    auto file = document->GetFile();
+
+    StreamObjectPtr content_stream;
+
+    XrefUsedEntryBasePtr new_entry = file->AllocateNewEntry();
+    new_entry->SetReference(content_stream);
+    new_entry->SetFile(file);
+    new_entry->SetInitialized();
+
+    content_stream->SetFile(file);
+    content_stream->SetInitialized();
+
+    return make_deferred<PageContents>(content_stream);
 }
 
 bool PageContents::IsDirty() const {

--- a/src/vanillapdf/semantics/objects/page_contents.h
+++ b/src/vanillapdf/semantics/objects/page_contents.h
@@ -14,6 +14,11 @@ public:
     explicit PageContents(syntax::ArrayObjectPtr<syntax::IndirectReferenceObjectPtr> obj);
     ~PageContents() = default;
 
+    // Creates empty page contents backed by a new indirect content stream.
+    // PageObject::SetContents stores an indirect reference, so the stream has
+    // to own an xref entry - this registers one within the document's file.
+    static PageContentsPtr Create(DocumentPtr document);
+
     contents::BaseInstructionCollectionPtr Instructions(void) const;
 
     bool IsDirty() const;


### PR DESCRIPTION
## Summary

Third of three PRs exposing semantic API that already exists in C++ but was never reachable from C. This one covers page contents and resource dictionaries.

`PageObject::SetContents` and `SetResources` have existed on the C++ class alongside the already exposed `SetMediaBox` and `SetAnnotations`, but had no C declaration. Exposing them alone would not have been enough — the semantic layer offered no way to obtain a `PageContents` or `ResourceDictionary` handle for a page that does not already have one, so both setters would have shipped uncallable. `Document_CreateFile` produces a page with neither `/Contents` nor `/Resources`, so this is the common case rather than an edge case.

## Added

```c
PageObject_SetContents
PageObject_SetResources
PageContents_CreateFromDocument      /* creates and registers a content stream */
PageContents_CreateFromStream        /* wraps a stream you registered yourself */
ResourceDictionary_Create
ResourceDictionary_CreateFromDictionary
```

## Create + Set

```c
PageContents_CreateFromDocument(document, &contents);
PageObject_SetContents(page, contents);

ResourceDictionary_Create(&resources);
PageObject_SetResources(page, resources);
```

`Get` never modifies, `Create*` always makes a new object, `Set` attaches it.

## Why the two types differ

`PageObject::SetContents` stores an **indirect reference** to the content stream, so the stream must already own a cross-reference entry. `PageContents_CreateFromDocument` allocates one, mirroring the existing `PageObject_CreateFromDocument`; `PageContents_CreateFromStream` remains for callers that register the stream themselves through `File_AllocateNewEntry`.

There is deliberately **no parameterless `PageContents_Create`**. It could only wrap an unregistered stream, and the resulting dangling reference would surface when the document is written rather than at the call site.

`ResourceDictionary` does get a parameterless `Create`, because `SetResources` attaches the dictionary as a **direct** object and `DictionaryObject::Insert` sets the owner on insertion, so no prior registration is needed. That difference is asserted rather than assumed — see below.

## Testing

16 unit tests in `page_object_test.cpp`, all passing:

- both `ResourceDictionary` construction paths, and `GetFontMap` reporting `OBJECT_MISSING` on a blank one
- `PageObject_GetResources` reporting `OBJECT_MISSING` on a freshly created page
- `SetResources` round-trip, plus overwrite — setting twice replaces rather than throws
- `PageContents_CreateFromDocument` and `_CreateFromStream`
- `SetContents` round-trip, reading the instructions back through `PageContents_GetInstructionCollection` to confirm the page really points at the new stream
- null parameter handling for every new entry point

Two of these save the document and reopen it, which is the step that would expose an object that never reached the file: `SetResourcesPersistAcrossSave` confirms the direct dictionary is serialized inline with the page, and `CreateFromDocumentPersistsAcrossSave` confirms the content stream's indirect reference still resolves.

Verified on `windows-x64-msvc-18`. Merging all three PRs together builds clean and runs 436 unit tests with no failures.

## Context

Part of the API gap analysis for making the .NET UI application usable for annotation, bookmark, form filling and signing workflows. Writable page contents plus a writable resource dictionary are prerequisites for content stream authoring and for appearance streams. The remaining pieces there are tracked separately — operation constructors for `OperationGeneric`, and `/XObject` and font entries in the resource dictionary.
