### PR TITLE
ci: Disable homebrew and conan submission until accepted upstream

### DIFF
--- a/.github/workflows/create-conan-pr.yml
+++ b/.github/workflows/create-conan-pr.yml
@@ -10,6 +10,10 @@ on:
         required: false
         type: boolean
         default: false
+      submit:
+        required: false
+        type: boolean
+        default: false
 
   workflow_dispatch:
     inputs:
@@ -22,6 +26,15 @@ on:
         required: false
         type: boolean
         default: true
+      # vanillapdf is not in conan-io/conan-center-index yet. Until that first
+      # submission is accepted, the recipe is only generated and inspected -
+      # nothing is pushed to the fork and no PR is opened. Flip the default to
+      # true once the recipe is live upstream.
+      submit:
+        description: "Submit to Conan Center - keep off until the recipe is accepted upstream"
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -84,9 +97,10 @@ jobs:
           git checkout -b vanillapdf-${{ steps.version.outputs.version }} upstream/master
 
       - name: Require existing recipe (updates only)
-        # Real runs only: the guard exists to stop the automation from pushing a
-        # new recipe. A dry run never pushes, so it may proceed for inspection.
-        if: ${{ !inputs.dry_run && steps.check_latest.outputs.is_latest == 'true' }}
+        # Submitting runs only: the guard exists to stop the automation from
+        # pushing a new recipe. Dry runs and non-submitting runs never push, so
+        # they may proceed for inspection.
+        if: ${{ inputs.submit && !inputs.dry_run && steps.check_latest.outputs.is_latest == 'true' }}
         run: |
           cd conan-center-index
           # This automation only bumps an already-registered recipe; first
@@ -122,11 +136,13 @@ jobs:
             --source-dir vanillapdf \
             --cci-dir conan-center-index
 
-      - name: Show prepared changes (dry run)
-        if: ${{ inputs.dry_run && steps.check_latest.outputs.is_latest == 'true' }}
+      - name: Show prepared changes
+        # Always shown: while submission is disabled this output is the entire
+        # point of the job, and it stays useful once submission is enabled.
+        if: ${{ steps.check_latest.outputs.is_latest == 'true' }}
         run: |
           cd conan-center-index
-          echo "=== Dry run mode - showing prepared changes ==="
+          echo "=== Prepared changes ==="
           echo ""
           echo "=== Recipe files ==="
           echo "--- config.yml ---"
@@ -143,11 +159,9 @@ jobs:
           echo ""
           echo "=== Git status ==="
           git status
-          echo ""
-          echo "=== Dry run complete - no changes committed ==="
 
       - name: Set authenticated origin for push
-        if: ${{ !inputs.dry_run && steps.check_latest.outputs.is_latest == 'true' }}
+        if: ${{ inputs.submit && !inputs.dry_run && steps.check_latest.outputs.is_latest == 'true' }}
         run: |
           cd conan-center-index
           git remote set-url origin "https://x-access-token:${BOT_TOKEN}@github.com/vanillapdf/conan-center-index.git"
@@ -155,7 +169,7 @@ jobs:
           BOT_TOKEN: ${{ secrets.BOT_TOKEN }}
 
       - name: Commit and push changes to fork
-        if: ${{ !inputs.dry_run && steps.check_latest.outputs.is_latest == 'true' }}
+        if: ${{ inputs.submit && !inputs.dry_run && steps.check_latest.outputs.is_latest == 'true' }}
         run: |
           cd conan-center-index
           git add recipes/vanillapdf/
@@ -163,7 +177,7 @@ jobs:
           git push origin vanillapdf-${{ steps.version.outputs.version }}
 
       - name: Generate PR info
-        if: ${{ steps.check_latest.outputs.is_latest == 'true' }}
+        if: ${{ inputs.submit && steps.check_latest.outputs.is_latest == 'true' }}
         id: pr-info
         run: |
           echo "pr-url=https://github.com/vanillapdf/conan-center-index/compare/master...vanillapdf-${{ steps.version.outputs.version }}" >> "$GITHUB_OUTPUT"
@@ -175,7 +189,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     needs: prepare-conan-changes
-    if: ${{ !inputs.dry_run && needs.prepare-conan-changes.outputs.is_latest == 'true' }}
+    if: ${{ inputs.submit && !inputs.dry_run && needs.prepare-conan-changes.outputs.is_latest == 'true' }}
     environment: production
     steps:
       - name: Setup Git & GitHub CLI

--- a/.github/workflows/update-homebrew.yml
+++ b/.github/workflows/update-homebrew.yml
@@ -10,6 +10,10 @@ on:
         required: false
         type: boolean
         default: false
+      submit:
+        required: false
+        type: boolean
+        default: false
 
   workflow_dispatch:
     inputs:
@@ -22,6 +26,15 @@ on:
         required: false
         type: boolean
         default: true
+      # vanillapdf is not in Homebrew/homebrew-core yet. Until that first
+      # submission is accepted, the formula is only generated and audited -
+      # nothing is pushed to the fork and no PR is opened. Flip the default to
+      # true once the formula is live upstream.
+      submit:
+        description: "Submit to homebrew-core - keep off until the formula is accepted upstream"
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -89,9 +102,10 @@ jobs:
           git checkout -b vanillapdf-${{ steps.version.outputs.version }} upstream/main
 
       - name: Require existing formula (updates only)
-        # Real runs only: the guard exists to stop the automation from pushing a
-        # new formula. A dry run never pushes, so it may proceed for inspection.
-        if: ${{ !inputs.dry_run && steps.check-latest.outputs.is_latest == 'true' }}
+        # Submitting runs only: the guard exists to stop the automation from
+        # pushing a new formula. Dry runs and non-submitting runs never push, so
+        # they may proceed for inspection.
+        if: ${{ inputs.submit && !inputs.dry_run && steps.check-latest.outputs.is_latest == 'true' }}
         run: |
           cd homebrew-core
           # This automation only bumps an already-published formula; first
@@ -137,16 +151,24 @@ jobs:
         if: steps.check-latest.outputs.is_latest == 'true'
         run: |
           cd homebrew-core
-          # Formula already exists upstream (enforced by the guard above), so
-          # this is always a version bump — use the standard audit. A failing
-          # audit fails the job rather than being swallowed.
-          brew audit --strict --online Formula/v/vanillapdf.rb
+          # While submission is disabled the formula is not upstream yet, so
+          # every run is a first submission and Homebrew audits those with
+          # --new-formula. Once submission is enabled the guard above has proven
+          # the formula exists, making it a version bump that takes the standard
+          # audit. A failing audit fails the job rather than being swallowed.
+          if [ "${{ inputs.submit }}" = "true" ]; then
+            brew audit --strict --online Formula/v/vanillapdf.rb
+          else
+            brew audit --strict --online --new-formula Formula/v/vanillapdf.rb
+          fi
 
-      - name: Show prepared changes (dry run)
-        if: ${{ steps.check-latest.outputs.is_latest == 'true' && inputs.dry_run }}
+      - name: Show prepared changes
+        # Always shown: while submission is disabled this output is the entire
+        # point of the job, and it stays useful once submission is enabled.
+        if: ${{ steps.check-latest.outputs.is_latest == 'true' }}
         run: |
           cd homebrew-core
-          echo "=== Dry run mode - showing prepared changes ==="
+          echo "=== Prepared changes ==="
           echo ""
           echo "=== Formula file ==="
           cat Formula/v/vanillapdf.rb
@@ -162,7 +184,7 @@ jobs:
           echo "=== Dry run complete - no changes committed ==="
 
       - name: Set authenticated origin for push
-        if: ${{ steps.check-latest.outputs.is_latest == 'true' && !inputs.dry_run }}
+        if: ${{ inputs.submit && steps.check-latest.outputs.is_latest == 'true' && !inputs.dry_run }}
         run: |
           cd homebrew-core
           git remote set-url origin "https://x-access-token:${BOT_TOKEN}@github.com/vanillapdf/homebrew-core.git"
@@ -170,7 +192,7 @@ jobs:
           BOT_TOKEN: ${{ secrets.BOT_TOKEN }}
 
       - name: Commit and push changes to fork
-        if: ${{ steps.check-latest.outputs.is_latest == 'true' && !inputs.dry_run }}
+        if: ${{ inputs.submit && steps.check-latest.outputs.is_latest == 'true' && !inputs.dry_run }}
         run: |
           cd homebrew-core
           VERSION="${{ steps.version.outputs.version }}"
@@ -179,7 +201,7 @@ jobs:
           git push origin vanillapdf-${{ steps.version.outputs.version }}
 
       - name: Generate PR info
-        if: steps.check-latest.outputs.is_latest == 'true'
+        if: ${{ inputs.submit && steps.check-latest.outputs.is_latest == 'true' }}
         id: pr-info
         run: |
           echo "pr-url=https://github.com/vanillapdf/homebrew-core/compare/main...vanillapdf-${{ steps.version.outputs.version }}" >> "$GITHUB_OUTPUT"
@@ -191,7 +213,7 @@ jobs:
     runs-on: macos-26
     timeout-minutes: 60
     needs: prepare-homebrew-changes
-    if: ${{ !inputs.dry_run && needs.prepare-homebrew-changes.outputs.is-latest == 'true' }}
+    if: ${{ inputs.submit && !inputs.dry_run && needs.prepare-homebrew-changes.outputs.is-latest == 'true' }}
     environment: production
     steps:
       - name: Setup Git & GitHub CLI


### PR DESCRIPTION
## Summary

vanillapdf is in neither `Homebrew/homebrew-core` nor `conan-io/conan-center-index`, so the update-only guards added in #474 fail both jobs on every official release. A package that was never submitted does not make a release broken, and the red run hides real failures.

Both workflows gain a `submit` input defaulting to `false`. It gates the fork push, the PR info step, and the entire `create-official-pr` job. What remains is the useful half: the formula and the recipe are still generated, audited, and printed, so the release run stays green and the output stays reviewable.

The update-only guard is kept rather than deleted — it now runs only when submitting, where it still does its job of refusing to push a brand-new recipe or formula. Turning submission on after acceptance is a one-line default flip, not a code restore.

`dry_run` and `submit` are deliberately separate: `dry_run` means the tag does not exist yet (it selects the checkout ref for the release rehearsal), while `submit` means the ecosystem accepts us. Pushing requires both `submit && !dry_run`.

Also switches the formula audit to `--new-formula` while the formula is not upstream. Until the first submission lands, every run *is* a first submission, and that is the audit Homebrew applies to one — the previous standard audit was checking against the wrong bar.

## Follow-up, not in this PR

The two manual first submissions are what actually unblock this. Conan Center is the better first target: it has no notability requirement, whereas Homebrew declines new formulae below roughly 30 forks / 30 watchers / 75 stars and vanillapdf is at 13 stars / 1 fork / 1 watcher. An own tap is the realistic homebrew path.

The conan recipe itself is already well covered: `examples-integration.yml` runs `conan create conan/` on Linux, Windows and macOS across Debug and Release, then builds a downstream consumer from `examples/conan-integration` and runs its tests — and `prepare_cci_recipe.py` copies `conan/conanfile.py` verbatim, so the submitted recipe is the validated one. The only untested path is the download-based `source()` that Conan Center actually uses (`conandata.yml` url + sha256) rather than the local `export_sources()`; `scripts/update_conandata.py` exercises that locally.

## Test plan

- [x] Both workflows parse as valid YAML
- [x] Every push, PR-info and official-PR path is gated on `inputs.submit`
- [ ] Confirmed on the next release run that both jobs finish green without pushing

🤖 Generated with [Claude Code](https://claude.com/claude-code)