### PR TITLE
fix: Install PDB next to the DLL instead of a hardcoded debug/bin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,6 +76,13 @@ include(cmake/vcpkg_init.cmake)
 # Define main solution
 project(vanillapdf)
 
+# Standard installation directory layout (CMAKE_INSTALL_BINDIR, CMAKE_INSTALL_LIBDIR, ...)
+# Included here rather than in cmake/vanillapdf_install.cmake, because the install
+# rules in src/vanillapdf/CMakeLists.txt run before that file is included.
+# It must come after project(), which GNUInstallDirs relies on to detect the
+# platform specific library directory.
+include(GNUInstallDirs)
+
 # Prefer files in CMAKE_MODULE_PATH over shipped ones in module directory
 # In the future, they may possibly add conflicting search modules
 # so let's be cautious and prevent it!

--- a/src/vanillapdf/CMakeLists.txt
+++ b/src/vanillapdf/CMakeLists.txt
@@ -807,25 +807,27 @@ target_include_directories(vanillapdf PUBLIC
 # Project install targets
 install(TARGETS vanillapdf
     EXPORT vanillapdfTargets
-    RUNTIME DESTINATION bin COMPONENT Runtime
+    RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}" COMPONENT Runtime
     LIBRARY DESTINATION lib COMPONENT Runtime
     ARCHIVE DESTINATION lib COMPONENT Development
 )
 
 if (MSVC AND BUILD_SHARED_LIBS)
 
-    # Install PDBs in vcpkg-style folders
+    # The PDB belongs next to the DLL it describes. Package managers that keep
+    # debug and release side by side in a single tree (vcpkg, conan) produce that
+    # split by installing each configuration into its own prefix, so the
+    # destination must not encode it. Hardcoding "debug/bin" here made vcpkg
+    # place the debug PDB in "debug/debug/bin"
+    # See https://github.com/vanillapdf/vanillapdf/issues/484
+    #
+    # $<TARGET_PDB_FILE:...> resolves per configuration, so a single rule covers
+    # all of them, including custom ones. The rule is deliberately not OPTIONAL,
+    # a missing PDB means an incomplete package and has to fail the installation
+    # instead of shipping silently.
     install(FILES
         "$<TARGET_PDB_FILE:vanillapdf>"
-        DESTINATION debug/bin
-        CONFIGURATIONS Debug
-        COMPONENT Development
-    )
-
-    install(FILES
-        "$<TARGET_PDB_FILE:vanillapdf>"
-        DESTINATION bin
-        CONFIGURATIONS Release RelWithDebInfo MinSizeRel
+        DESTINATION "${CMAKE_INSTALL_BINDIR}"
         COMPONENT Development
     )
 


### PR DESCRIPTION
## Problem

`src/vanillapdf/CMakeLists.txt` hardcoded `DESTINATION debug/bin` for the Debug configuration. An install destination describes the layout of a single install tree relative to `CMAKE_INSTALL_PREFIX`, and must not encode a package manager's debug and release merge convention. vcpkg produces that split itself, by installing each configuration into its own prefix (`packages/<port>/` and `packages/<port>/debug/`), so our hardcoded path stacked with it and produced `debug/debug/bin/libvanillapdf.pdb`.

Reported by a vcpkg maintainer while reviewing the v2.3.0 port update, https://github.com/microsoft/vcpkg/pull/53043, where the port now carries a `file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/debug")` workaround. That workaround can be dropped once a release carrying this fix is ported.

This is not vcpkg specific. Under FetchContent or `add_subdirectory` there is no toolchain to detect at all, and the old rule dropped a stray `debug/` tree into the consumer's prefix. The fix deliberately avoids any package manager specific conditional, since we ship through vcpkg, Conan, Homebrew, NuGet and FetchContent.

## Changes

- The two configuration specific PDB rules collapse into one that installs next to the DLL. `$<TARGET_PDB_FILE:...>` resolves per configuration, so a single rule covers all of them, including custom configurations that the previous `CONFIGURATIONS Release RelWithDebInfo MinSizeRel` list silently skipped.
- The rule stays non-`OPTIONAL` on purpose. A missing PDB means an incomplete package and should fail the installation rather than ship silently.
- `GNUInstallDirs` is included from the top level `CMakeLists.txt`. It was previously included by `cmake/vanillapdf_install.cmake`, which `src/vanillapdf/CMakeLists.txt` pulls in *after* the install rules, leaving `CMAKE_INSTALL_BINDIR` empty at that point.
- `RUNTIME DESTINATION` uses `${CMAKE_INSTALL_BINDIR}` for consistency. This is a no-op on every platform, `BINDIR` is always `bin`.

## Not in this PR

`LIBRARY` and `ARCHIVE DESTINATION` still hardcode `lib`, while `cmake/vanillapdf_install.cmake` installs the CMake config package to `${CMAKE_INSTALL_LIBDIR}/cmake/vanillapdf`. That mismatch is real, but fixing it moves the library on Debian (`lib/x86_64-linux-gnu` with `prefix=/usr`) and on Fedora/Rocky (`lib64`), which affects the DEB and RPM packaging and needs a package build to validate. Tracked separately.

## Testing

Windows, `windows-x64-msvc-18`:

| Config | `cmake --install` | Layout |
|---|---|---|
| Debug | exit 0 | `bin/libvanillapdf.dll` + `bin/libvanillapdf.pdb`, no `debug/` directory |
| Release | exit 0 | `bin/libvanillapdf.dll` + `bin/libvanillapdf.pdb`, no `debug/` directory |

Verified in the generated `cmake_install.cmake` that all four configurations resolve to `${CMAKE_INSTALL_PREFIX}/bin`.

Linux, Ubuntu 24.04 container, system dependencies with `VANILLAPDF_INTERNAL_VCPKG=OFF`, full configure, build and install: `CMAKE_INSTALL_BINDIR=bin`, `LIBDIR=lib`, `INCLUDEDIR=include`, no PDB rule present in the generated install script (the block is MSVC gated), and no `debug/` directory in the install prefix.

Fixes #484
