### PR TITLE
fix: Trim the terminating null from the signer common name buffer

### DIFF
--- a/src/vanillapdf.unittest/signature_verifier_test.cpp
+++ b/src/vanillapdf.unittest/signature_verifier_test.cpp
@@ -3,6 +3,22 @@
 #include "test_certificates.h"
 #include "handle_guard.h"
 
+#include <cstring>
+
+// The common name buffer holds exactly the name, with no trailing null, so
+// the length is checked explicitly and the contents compared element wise.
+static void ExpectBufferContent(BufferHandle* handle, const char* expected) {
+    string_type data = nullptr;
+    size_type size = 0;
+    ASSERT_EQ(Buffer_GetData(handle, &data, &size), VANILLAPDF_ERROR_SUCCESS);
+
+    ASSERT_EQ(size, strlen(expected));
+
+    for (size_type i = 0; i < size; ++i) {
+        EXPECT_EQ(data[i], expected[i]);
+    }
+}
+
 #if defined(VANILLAPDF_HAVE_OPENSSL)
 #include <openssl/opensslv.h>
 #endif
@@ -1003,12 +1019,8 @@ TEST(SignatureVerifier, CreateAndVerifySignature) {
               VANILLAPDF_ERROR_SUCCESS);
     ASSERT_NE(common_name_buffer.get(), nullptr);
 
-    string_type cn_data = nullptr;
-    size_type cn_len = 0;
-    ASSERT_EQ(Buffer_GetData(common_name_buffer, &cn_data, &cn_len), VANILLAPDF_ERROR_SUCCESS);
-
     // Common name should be "Unit test signer" from SIGNING_CERTIFICATE
-    EXPECT_STREQ(cn_data, "Unit test signer");
+    ExpectBufferContent(common_name_buffer, "Unit test signer");
 
     // Validate certificate chain
     size_type chain_count = 0;
@@ -1214,10 +1226,7 @@ TEST(DigitalSignatureExtensions, SignAndVerifyDocument) {
               VANILLAPDF_ERROR_SUCCESS);
     ASSERT_NE(common_name_buffer.get(), nullptr);
 
-    string_type cn_data = nullptr;
-    size_type cn_len = 0;
-    ASSERT_EQ(Buffer_GetData(common_name_buffer, &cn_data, &cn_len), VANILLAPDF_ERROR_SUCCESS);
-    EXPECT_STREQ(cn_data, "Unit test signer");
+    ExpectBufferContent(common_name_buffer, "Unit test signer");
 
     // Validate results
     EXPECT_EQ(status, SignatureStatus_Valid);
@@ -1322,11 +1331,8 @@ TEST_P(CertificateTypeTest, SignAndVerify_Integration) {
               VANILLAPDF_ERROR_SUCCESS);
     ASSERT_NE(common_name_buffer.get(), nullptr);
 
-    string_type cn_data = nullptr;
-    size_type cn_len = 0;
-    ASSERT_EQ(Buffer_GetData(common_name_buffer, &cn_data, &cn_len), VANILLAPDF_ERROR_SUCCESS);
-
-    EXPECT_STREQ(cn_data, cert_info.expected_cn) << "Common name mismatch for " << cert_info.name;
+    SCOPED_TRACE(cert_info.name);
+    ExpectBufferContent(common_name_buffer, cert_info.expected_cn);
 }
 
 // Instantiate the parameterized test with different certificate types

--- a/src/vanillapdf/utils/signature_verifier.cpp
+++ b/src/vanillapdf/utils/signature_verifier.cpp
@@ -160,6 +160,12 @@ void SignatureVerifier::ExtractCertificateChain(CMS_ContentInfo* cms, SignatureV
             } else {
                 auto cn_buffer = make_deferred_container<Buffer>(cn_len + 1);
                 X509_NAME_get_text_by_NID(subject, NID_commonName, cn_buffer->data(), cn_len + 1);
+
+                // OpenSSL writes a terminating null, which is not part of the value.
+                // Trim it so the buffer size is the length of the common name, the
+                // same meaning it has for every other buffer the library hands out.
+                cn_buffer->resize(cn_len);
+
                 result->SetSignerCommonName(cn_buffer);
             }
         }


### PR DESCRIPTION
## Summary

`SignatureVerificationResult_GetSignerCommonName` returned a buffer one byte longer than the name it contained. `X509_NAME_get_text_by_NID` writes a null-terminated C string, and the entire `cn_len + 1` allocation was passed to the caller with the terminator counted as content — so a 16-character common name was reported with `size == 17`.

## Why it matters

Every other buffer the library hands out reports the length of the value itself. The two certificate buffers in the *same function* allocate exactly `der_len`, and `StringObject_GetValue` returns raw PDF string bytes with no terminator. This was the only place in the library where `Buffer` size meant something different — `grep` finds exactly one `+ 1` allocation.

The practical consequence is for any caller that builds a string by length, which is what a marshalling layer does:

```c
std::string common_name(cn_data, cn_len);   // "Unit test signer\0" - 17 chars, trailing NUL inside
```

A .NET consumer marshalling by length gets the same trailing null embedded in the string.

## Fix

Trim the buffer back to `cn_len` once OpenSSL has written into it:

```cpp
auto cn_buffer = make_deferred_container<Buffer>(cn_len + 1);
X509_NAME_get_text_by_NID(subject, NID_commonName, cn_buffer->data(), cn_len + 1);

// OpenSSL writes a terminating null, which is not part of the value.
cn_buffer->resize(cn_len);
```

## Tests

The three sites that check the common name used `EXPECT_STREQ(cn_data, ...)`, which only worked because the terminator happened to be inside the buffer. With the terminator gone that would read past the allocation, so they now check the length and compare contents element wise — the convention already used in `main.cpp:42`, `document_test.cpp:311` and `objects_test.cpp:32`:

```cpp
static void ExpectBufferContent(BufferHandle* handle, const char* expected) {
    string_type data = nullptr;
    size_type size = 0;
    ASSERT_EQ(Buffer_GetData(handle, &data, &size), VANILLAPDF_ERROR_SUCCESS);

    ASSERT_EQ(size, strlen(expected));

    for (size_type i = 0; i < size; ++i) {
        EXPECT_EQ(data[i], expected[i]);
    }
}
```

These now fail if the extra byte ever comes back — the length assertion is what caught the discrepancy in the first place. The parameterized case keeps its per-certificate context through `SCOPED_TRACE`.

Verified on `windows-x64-msvc-18`: 394 unit tests, 0 failures. The five signature and certificate tests that exercise this path pass with the trimmed buffer.

## Compatibility

Callers that relied on the trailing null — for example passing `cn_data` straight to `strcmp` or `printf("%s")` — will need to use the length instead. That reading was never guaranteed by the API, and it produced a value with a spurious null for anyone using the documented pointer-and-size contract.
