### PR TITLE
build: Split install components and consume them from Conan

### DIFF
--- a/cmake/packaging.cmake
+++ b/cmake/packaging.cmake
@@ -61,13 +61,20 @@ set(CPACK_PACKAGE_ICON					${CMAKE_CURRENT_SOURCE_DIR}/cmake/vanilla_logo.ico)
 set(CPACK_PACKAGE_CHECKSUM				SHA256)
 
 # Component-based packaging (used by DEB and RPM generators)
-set(CPACK_COMPONENTS_ALL Runtime Development)
+# Licenses and Documentation were part of Runtime; listed so the packages keep
+# the same contents. Symbols is omitted, it is MSVC-only.
+set(CPACK_COMPONENTS_ALL Runtime Development Licenses Documentation)
 set(CPACK_COMPONENT_RUNTIME_DISPLAY_NAME "Vanilla.PDF Runtime")
 set(CPACK_COMPONENT_RUNTIME_DESCRIPTION "Shared library")
 set(CPACK_COMPONENT_RUNTIME_REQUIRED ON)
 set(CPACK_COMPONENT_DEVELOPMENT_DISPLAY_NAME "Vanilla.PDF Development")
 set(CPACK_COMPONENT_DEVELOPMENT_DESCRIPTION "Headers, static libraries, and CMake config files")
 set(CPACK_COMPONENT_DEVELOPMENT_DEPENDS Runtime)
+set(CPACK_COMPONENT_LICENSES_DISPLAY_NAME "Vanilla.PDF Licenses")
+set(CPACK_COMPONENT_LICENSES_DESCRIPTION "License and notice texts required for redistribution")
+set(CPACK_COMPONENT_LICENSES_REQUIRED ON)
+set(CPACK_COMPONENT_DOCUMENTATION_DISPLAY_NAME "Vanilla.PDF Documentation")
+set(CPACK_COMPONENT_DOCUMENTATION_DESCRIPTION "Readme bundled with the installation")
 
 # DEB and RPM use '~' for pre-release (sorts before release version)
 set(PACKAGE_VERSION_NAME_DEB_RPM "${CPACK_PACKAGE_VERSION_MAJOR}.${CPACK_PACKAGE_VERSION_MINOR}.${CPACK_PACKAGE_VERSION_PATCH}")

--- a/conan/conanfile.py
+++ b/conan/conanfile.py
@@ -1,8 +1,15 @@
 from conan import ConanFile
 from conan.tools.cmake import CMake, CMakeToolchain, CMakeDeps, cmake_layout
 from conan.tools.build import check_min_cppstd
-from conan.tools.files import get, copy
+from conan.tools.files import get
+# cci-strip-begin
+from conan.tools.files import copy
+# cci-strip-end
+from conan.tools.microsoft import is_msvc
 import os
+
+
+required_conan_version = ">=2.0.9"
 
 
 class VanillaPDFConan(ConanFile):
@@ -106,6 +113,8 @@ class VanillaPDFConan(ConanFile):
         # Conan's CMakeDeps generates its own find_package config files
         tc.cache_variables["VANILLAPDF_SKIP_CMAKE_CONFIG_INSTALL"] = True
 
+        tc.cache_variables["VANILLAPDF_INSTALL_LICENSEDIR"] = "licenses"
+
         # Disable developer-only features
         tc.cache_variables["VANILLAPDF_ENABLE_TESTS"] = False
         tc.cache_variables["VANILLAPDF_ENABLE_BENCHMARK"] = False
@@ -121,12 +130,21 @@ class VanillaPDFConan(ConanFile):
         cmake.build()
 
     def package(self):
-        copy(self, "LICENSE.txt", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
+        # Selected components only: skips the command line tool and the debug
+        # symbols. Licenses lands in licenses/ via VANILLAPDF_INSTALL_LICENSEDIR.
         cmake = CMake(self)
-        cmake.install()
+        cmake.install(component="Runtime")
+        cmake.install(component="Development")
+        cmake.install(component="Licenses")
 
     def package_info(self):
-        self.cpp_info.libs = ["vanillapdf"]
+        # PREFIX "lib" keeps the runtime artifact named identically on every
+        # platform, which the .NET bindings rely on. Import libraries follow
+        # IMPORT_PREFIX instead, so only an MSVC static build is libvanillapdf.
+        if is_msvc(self) and not self.options.shared:
+            self.cpp_info.libs = ["libvanillapdf"]
+        else:
+            self.cpp_info.libs = ["vanillapdf"]
         self.cpp_info.set_property("cmake_file_name", "vanillapdf")
         self.cpp_info.set_property("cmake_target_name", "vanillapdf::vanillapdf")
         self.cpp_info.requires = [

--- a/src/vanillapdf/CMakeLists.txt
+++ b/src/vanillapdf/CMakeLists.txt
@@ -826,10 +826,11 @@ if (MSVC AND BUILD_SHARED_LIBS)
     # all of them, including custom ones. The rule is deliberately not OPTIONAL,
     # a missing PDB means an incomplete package and has to fail the installation
     # instead of shipping silently.
+    # Own component so consumers that reject debug symbols can skip them.
     install(FILES
         "$<TARGET_PDB_FILE:vanillapdf>"
         DESTINATION "${CMAKE_INSTALL_BINDIR}"
-        COMPONENT Development
+        COMPONENT Symbols
     )
 
 endif()
@@ -840,13 +841,23 @@ install(FILES ${VANILLAPDF_INCLUDE_SYNTAX_HEADERS} DESTINATION "include/vanillap
 install(FILES ${VANILLAPDF_INCLUDE_SEMANTICS_HEADERS} DESTINATION "include/vanillapdf/semantics" COMPONENT Development)
 install(FILES ${VANILLAPDF_INCLUDE_CONTENTS_HEADERS} DESTINATION "include/vanillapdf/contents" COMPONENT Development)
 
-# Additional metadata for the project, that should be bundled together
+# Split because Apache-2.0 section 4(d) requires LICENSE and NOTICE to be
+# redistributed, while the readme is informational. The destination is
+# overridable for packagers that expect them elsewhere (Conan uses licenses/).
+set(VANILLAPDF_INSTALL_LICENSEDIR "share/vanillapdf" CACHE STRING
+    "Destination for LICENSE.txt and NOTICE.md, relative to the install prefix")
+
 install(FILES
-    "${VANILLAPDF_SOLUTION_SOURCE_DIR}/cmake/README.txt"
     "${VANILLAPDF_SOLUTION_SOURCE_DIR}/LICENSE.txt"
     "${VANILLAPDF_SOLUTION_SOURCE_DIR}/NOTICE.md"
+    DESTINATION "${VANILLAPDF_INSTALL_LICENSEDIR}"
+    COMPONENT Licenses
+)
+
+install(FILES
+    "${VANILLAPDF_SOLUTION_SOURCE_DIR}/cmake/README.txt"
     DESTINATION "share/vanillapdf"
-    COMPONENT Runtime
+    COMPONENT Documentation
 )
 
 # Define installation files and procedures


### PR DESCRIPTION
## Summary

The Conan package shipped three things it should not: the `vanillapdf.tools` CLI, the PDB, and the `share/vanillapdf` copies of README, LICENSE and NOTICE. The cause was that only the CLI had a component of its own, and `cmake.install()` with no argument installs everything.

Rather than deleting files from the package after installing them, this makes the install rules say what belongs where and lets each packager select:

- PDB moves from `Development` to a new `Symbols` component
- the bundled metadata splits into `Licenses` (LICENSE.txt, NOTICE.md) and `Documentation` (README.txt) — Apache-2.0 section 4(d) requires the first to travel with every redistribution, while the readme is informational
- `VANILLAPDF_INSTALL_LICENSEDIR` makes the license destination overridable, so Conan points it at `licenses/` instead of copying the files a second time

The Conan recipe then installs `Runtime`, `Development` and `Licenses`, declares `required_conan_version`, and reports the MSVC static library under its real name.

## Impact on the other packagers

Both new components are added to `CPACK_COMPONENTS_ALL`, so the deb and rpm packages keep byte-identical contents. `Symbols` is deliberately left out — debug symbols are MSVC-only and have no place in a deb or rpm. vcpkg runs a full `cmake --install` with no component filter, so it is unaffected. NuGet assembles from build artifacts rather than the install tree and is likewise untouched.

## The library name

`cpp_info.libs` now depends on the configuration, which looks odd enough to explain. `PREFIX "lib"` is deliberate: it keeps the runtime artifact named `libvanillapdf.{dll,so,dylib}` on every platform, which the NuGet native layout and the .NET bindings depend on. Import libraries follow `IMPORT_PREFIX`, which stays empty, so an MSVC shared build produces `vanillapdf.lib` while an MSVC static build produces `libvanillapdf.lib`. The recipe describes that rather than trying to change it — making the import library symmetric would rename a shipped artifact, which is a breaking change and not something for a patch release.

## Verification

`conan create conan/` on both configurations, inspecting the resulting package:

| Configuration | Package contents |
| --- | --- |
| Release static | `include/`, `lib/libvanillapdf.lib`, `licenses/{LICENSE.txt,NOTICE.md}` |
| Debug shared | `bin/libvanillapdf.dll`, `lib/vanillapdf.lib`, `licenses/{LICENSE.txt,NOTICE.md}` |

No `share/`, no `debug/`, no PDB and no CLI in either. Both test packages link and run.

## Not in this PR

Normalising the mixed `.txt` and `.md` extensions on the distributed files — `NOTICE.md` is verbatim license text and `cmake/README.txt` is actually markdown. That rename touches the vcpkg portfile and the NuGet templates, so it belongs in its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)