### PR TITLE
fix: Prevent weak references from reviving an object being destroyed

### DIFF
--- a/src/vanillapdf.unittest/thread_safety_test.cpp
+++ b/src/vanillapdf.unittest/thread_safety_test.cpp
@@ -85,6 +85,103 @@ TEST_P(DocumentOpenFileTest, ConcurrentOpenSameFile) {
     }
 }
 
+// Regression test for concurrent open AND release of a document over one
+// shared file.
+//
+// The sibling test above never releases a document while other threads are
+// running - every handle is parked in a vector and released after the join - so
+// the reference counter only ever climbs and never returns to zero during the
+// concurrent phase. That is precisely the window this bug needs, which is why
+// 50 threads x 2000 iterations could not reach it while an open/release cycle
+// reaches it at 2 threads.
+//
+// The failure is a heap corruption, not an assertion: a document whose counter
+// had already reached zero was revived by a weak reference upgrade, leaving two
+// owners of storage that was being torn down. Both eventually delete it. It
+// surfaces as the test host dying (STATUS_HEAP_CORRUPTION / FailFast) with no
+// managed exception, usually while some unrelated test is in flight, so treat
+// any hard crash of this binary as this test failing.
+void OpenReleaseCycleWorker(
+    FileHandle* shared_file,
+    int iterations,
+    std::atomic<int>& success_count,
+    std::atomic<int>& error_count) {
+
+    for (int i = 0; i < iterations; ++i) {
+        DocumentHandle* doc = nullptr;
+        if (Document_OpenFile(shared_file, &doc) != VANILLAPDF_ERROR_SUCCESS || doc == nullptr) {
+            error_count.fetch_add(1);
+            continue;
+        }
+
+        // Touch the document, so a revived instance is actually used
+        // and not merely held
+        CatalogHandle* catalog = nullptr;
+        if (Document_GetCatalog(doc, &catalog) == VANILLAPDF_ERROR_SUCCESS) {
+            Catalog_Release(catalog);
+        }
+
+        Document_Release(doc);
+        success_count.fetch_add(1);
+    }
+}
+
+TEST(DocumentOpenFileThreadSafety, ConcurrentOpenReleaseCycleSameFile) {
+    constexpr int NUM_THREADS = 4;
+    constexpr int ITERATIONS_PER_THREAD = 250;
+
+    HandleGuard<InputOutputStreamHandle, InputOutputStream_Release> io_stream;
+    HandleGuard<FileHandle, File_Release> shared_file;
+
+    ASSERT_EQ(InputOutputStream_CreateFromMemory(io_stream.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(File_CreateStream(io_stream, "shared_open_release_cycle", shared_file.out()), VANILLAPDF_ERROR_SUCCESS);
+
+    // One cycle up front, so the file materializes whatever it builds lazily on
+    // first use - the xref chain among it. Those live as long as the file, well
+    // past the count check below, and would otherwise read as a leak.
+    std::atomic<int> warmup_success{0};
+    std::atomic<int> warmup_errors{0};
+    OpenReleaseCycleWorker(shared_file.get(), 1, warmup_success, warmup_errors);
+    ASSERT_EQ(warmup_errors.load(), 0);
+
+    bigint_type baseline_objects = 0;
+    ASSERT_EQ(ObjectDiagnostics_GetActiveObjectCount(&baseline_objects), VANILLAPDF_ERROR_SUCCESS);
+
+    std::atomic<int> success_count{0};
+    std::atomic<int> error_count{0};
+
+    std::vector<std::thread> threads;
+    threads.reserve(NUM_THREADS);
+
+    for (int t = 0; t < NUM_THREADS; ++t) {
+        threads.emplace_back(
+            OpenReleaseCycleWorker,
+            shared_file.get(),
+            ITERATIONS_PER_THREAD,
+            std::ref(success_count),
+            std::ref(error_count));
+    }
+
+    for (auto& thread : threads) {
+        thread.join();
+    }
+
+    EXPECT_EQ(error_count.load(), 0);
+    EXPECT_EQ(success_count.load(), NUM_THREADS * ITERATIONS_PER_THREAD);
+
+    // Deliberately no assertion that every open returned the same instance.
+    // A document that legitimately reached zero references is dead, and the
+    // next open has to build a fresh one - demanding identity here would be
+    // asserting the resurrection this test exists to prevent.
+
+    // Every document opened above has been released, so the live object count
+    // has to be back where it started. A lower count means something was freed
+    // twice, a higher one means a registry entry outlived its document.
+    bigint_type remaining_objects = 0;
+    ASSERT_EQ(ObjectDiagnostics_GetActiveObjectCount(&remaining_objects), VANILLAPDF_ERROR_SUCCESS);
+    EXPECT_EQ(remaining_objects, baseline_objects);
+}
+
 std::string ThreadTestParamsName(const ::testing::TestParamInfo<ThreadTestParams>& info) {
     return std::to_string(info.param.num_threads) + "threads_" +
            std::to_string(info.param.iterations_per_thread) + "iterations";

--- a/src/vanillapdf/semantics/objects/destinations.cpp
+++ b/src/vanillapdf/semantics/objects/destinations.cpp
@@ -266,14 +266,12 @@ DestinationPtr DestinationBase::ResolveDestination(syntax::ObjectPtr dest_obj) {
     // Handle string name reference to named destinations (via Names dictionary)
     if (syntax::ObjectUtils::IsType<syntax::StringObjectPtr>(dest_obj)) {
         auto weak_file = dest_obj->GetFile();
-        auto document_ref = SemanticUtils::GetMappedDocument(weak_file);
 
-        assert(!document_ref.IsEmpty() && "Document reference was not set");
-        if (!document_ref.IsActive()) {
-            throw syntax::ObjectMissingException("Document reference is not active");
+        OutputDocumentPtr document;
+        if (!SemanticUtils::TryGetMappedDocument(weak_file, document)) {
+            auto file = weak_file.GetReference();
+            LOG_ERROR_AND_THROW(syntax::ObjectMissingException, "Document for file {} is not mapped or is no longer active", file->GetFilenameString());
         }
-
-        DocumentPtr document = document_ref.GetReference();
 
         OutputCatalogPtr catalog_ptr;
         bool has_catalog = document->GetDocumentCatalog(catalog_ptr);
@@ -307,14 +305,12 @@ DestinationPtr DestinationBase::ResolveDestination(syntax::ObjectPtr dest_obj) {
     // Handle name object reference to named destinations (via Destinations dictionary)
     if (syntax::ObjectUtils::IsType<syntax::NameObjectPtr>(dest_obj)) {
         auto weak_file = dest_obj->GetFile();
-        auto document_ref = SemanticUtils::GetMappedDocument(weak_file);
 
-        assert(!document_ref.IsEmpty() && "Document reference was not set");
-        if (!document_ref.IsActive()) {
-            throw syntax::ObjectMissingException("Document reference is not active");
+        OutputDocumentPtr document;
+        if (!SemanticUtils::TryGetMappedDocument(weak_file, document)) {
+            auto file = weak_file.GetReference();
+            LOG_ERROR_AND_THROW(syntax::ObjectMissingException, "Document for file {} is not mapped or is no longer active", file->GetFilenameString());
         }
-
-        DocumentPtr document = document_ref.GetReference();
 
         OutputCatalogPtr catalog;
         bool has_catalog = document->GetDocumentCatalog(catalog);

--- a/src/vanillapdf/semantics/objects/document.cpp
+++ b/src/vanillapdf/semantics/objects/document.cpp
@@ -145,7 +145,11 @@ syntax::FilePtr Document::GetFile() const {
 }
 
 Document::~Document() {
-    SemanticUtils::ReleaseMapping(m_holder);
+
+    // This has to stay the first statement. It takes the registry lock, which
+    // is what stops GetOrCreateDocument from freeing this instance underneath
+    // an upgrade that is already inspecting it.
+    SemanticUtils::ReleaseMapping(m_holder, this);
 }
 
 bool Document::GetDocumentCatalog(OutputCatalogPtr& result) const {

--- a/src/vanillapdf/semantics/utils/semantic_utils.cpp
+++ b/src/vanillapdf/semantics/utils/semantic_utils.cpp
@@ -110,7 +110,7 @@ void SemanticUtils::AddDocumentMapping(WeakReference<syntax::File> file, WeakRef
     (*document_map)[shared.get()] = value;
 }
 
-void SemanticUtils::ReleaseMapping(WeakReference<syntax::File> file) {
+void SemanticUtils::ReleaseMapping(WeakReference<syntax::File> file, const Document* owner) {
     if (!file.IsActive()) {
         throw syntax::FileDisposedException();
     }
@@ -119,21 +119,44 @@ void SemanticUtils::ReleaseMapping(WeakReference<syntax::File> file) {
     auto document_map = GetDocumentMapInstance();
 
     auto shared = file.GetReference();
-    document_map->erase(shared.get());
+    auto found = document_map->find(shared.get());
+    if (found == document_map->end()) {
+        spdlog::debug("File {} had no document mapping to release, a replacement has already claimed and released it", shared->GetFilenameString());
+        return;
+    }
+
+    // While this document was dying, another thread may have failed to upgrade
+    // it, built a replacement and mapped it under the same file. Erasing the
+    // entry then would drop that live document out of the registry, and the
+    // next open would build a second one beside it.
+    if (!found->second.Identity(owner)) {
+        spdlog::warn("File {} is mapped to a different document than the one being released, keeping the mapping", shared->GetFilenameString());
+        return;
+    }
+
+    document_map->erase(found);
 }
 
 DocumentPtr SemanticUtils::GetOrCreateDocument(syntax::FilePtr file) {
     std::lock_guard<std::recursive_mutex> locker(document_map_lock);
     auto document_map = GetDocumentMapInstance();
 
-    // Single lookup to check if document exists
-    auto found = document_map->find(file.get());
-    if (found != document_map->end() && found->second.IsActive()) {
-        return found->second.GetReference();
-    }
-
     // Create new document while still holding the lock
     // The Document constructor calls AddDocumentMapping internally
+    auto found = document_map->find(file.get());
+    if (found == document_map->end()) {
+        return DocumentPtr(pdf_new Document(file));
+    }
+
+    // The upgrade is a single atomic step
+    auto existing = found->second.TryGetReference();
+    if (existing.has_value()) {
+        return existing.value();
+    }
+
+    // The mapped document has already committed to destruction and cannot be
+    // revived. It is unreachable by now, so replacing it never leaves two live
+    // documents sharing one file.
     return DocumentPtr(pdf_new Document(file));
 }
 

--- a/src/vanillapdf/semantics/utils/semantic_utils.cpp
+++ b/src/vanillapdf/semantics/utils/semantic_utils.cpp
@@ -78,7 +78,7 @@ bool SemanticUtils::HasMappedDocument(WeakReference<syntax::File> file) {
     return (found != document_map->end() && found->second.IsActive());
 }
 
-WeakReference<Document> SemanticUtils::GetMappedDocument(WeakReference<syntax::File> file) {
+bool SemanticUtils::TryGetMappedDocument(WeakReference<syntax::File> file, OutputDocumentPtr& result) {
     if (!file.IsActive()) {
         throw syntax::FileDisposedException();
     }
@@ -87,10 +87,23 @@ WeakReference<Document> SemanticUtils::GetMappedDocument(WeakReference<syntax::F
     auto document_map = GetDocumentMapInstance();
 
     auto shared = file.GetReference();
-    auto weak_ref = (*document_map)[shared.get()];
-    assert(weak_ref.IsActive() && !weak_ref.IsEmpty());
+    auto found = document_map->find(shared.get());
+    if (found == document_map->end()) {
+        return false;
+    }
 
-    return weak_ref;
+    // The upgrade has to stay inside the registry critical section. ~Document
+    // acquires this lock before its storage can be freed, so an upgrade under
+    // the lock never touches deallocated memory - handing the weak reference
+    // out and upgrading it after the lock is released would be a use after
+    // free racing the final Release.
+    auto existing = found->second.TryGetReference();
+    if (!existing.has_value()) {
+        return false;
+    }
+
+    result = existing.value();
+    return true;
 }
 
 void SemanticUtils::AddDocumentMapping(WeakReference<syntax::File> file, WeakReference<Document> value) {
@@ -138,25 +151,20 @@ void SemanticUtils::ReleaseMapping(WeakReference<syntax::File> file, const Docum
 }
 
 DocumentPtr SemanticUtils::GetOrCreateDocument(syntax::FilePtr file) {
+
+    // The recursive lock is held across both the lookup and the create, so no
+    // other thread can map a competing document in between
     std::lock_guard<std::recursive_mutex> locker(document_map_lock);
-    auto document_map = GetDocumentMapInstance();
 
-    // Create new document while still holding the lock
-    // The Document constructor calls AddDocumentMapping internally
-    auto found = document_map->find(file.get());
-    if (found == document_map->end()) {
-        return DocumentPtr(pdf_new Document(file));
+    OutputDocumentPtr existing;
+    if (TryGetMappedDocument(file, existing)) {
+        return existing;
     }
 
-    // The upgrade is a single atomic step
-    auto existing = found->second.TryGetReference();
-    if (existing.has_value()) {
-        return existing.value();
-    }
-
-    // The mapped document has already committed to destruction and cannot be
-    // revived. It is unreachable by now, so replacing it never leaves two live
-    // documents sharing one file.
+    // Either the file has no mapping, or the mapped document has already
+    // committed to destruction and cannot be revived. It is unreachable by
+    // now, so replacing it never leaves two live documents sharing one file.
+    // The Document constructor calls AddDocumentMapping internally.
     return DocumentPtr(pdf_new Document(file));
 }
 

--- a/src/vanillapdf/semantics/utils/semantic_utils.h
+++ b/src/vanillapdf/semantics/utils/semantic_utils.h
@@ -15,7 +15,7 @@ public:
     static bool HasMappedDocument(WeakReference<syntax::File> file);
     static WeakReference<Document> GetMappedDocument(WeakReference<syntax::File> file);
     static void AddDocumentMapping(WeakReference<syntax::File> file, WeakReference<Document> value);
-    static void ReleaseMapping(WeakReference<syntax::File> file);
+    static void ReleaseMapping(WeakReference<syntax::File> file, const Document* owner);
 
     /**
      * @brief Atomically get existing or create new document for the given file.

--- a/src/vanillapdf/semantics/utils/semantic_utils.h
+++ b/src/vanillapdf/semantics/utils/semantic_utils.h
@@ -13,7 +13,19 @@ class SemanticUtils {
 public:
     static Version GetVersionFromName(const syntax::NameObjectPtr& name);
     static bool HasMappedDocument(WeakReference<syntax::File> file);
-    static WeakReference<Document> GetMappedDocument(WeakReference<syntax::File> file);
+
+    /**
+     * @brief Atomically find and upgrade the document mapped to the given file.
+     *
+     * The lookup and the weak reference upgrade happen inside one registry
+     * critical section. The upgrade must not escape it: ~Document acquires the
+     * registry lock before its storage can be freed, so only an upgrade under
+     * that lock is guaranteed to never touch deallocated memory (see the
+     * contract on IUnknown::TryAddRef). Returns false when the file has no
+     * mapping or the mapped document has already committed to destruction.
+     */
+    static bool TryGetMappedDocument(WeakReference<syntax::File> file, OutputDocumentPtr& result);
+
     static void AddDocumentMapping(WeakReference<syntax::File> file, WeakReference<Document> value);
     static void ReleaseMapping(WeakReference<syntax::File> file, const Document* owner);
 

--- a/src/vanillapdf/semantics/utils/semantics_fwd.h
+++ b/src/vanillapdf/semantics/utils/semantics_fwd.h
@@ -36,7 +36,7 @@ class NumberTree;
 template <typename ValueT>
 using NumberTreePtr = DeferredContainer<NumberTree<ValueT>>;
 
-class Document; using DocumentPtr = Deferred<Document>;
+class Document; using DocumentPtr = Deferred<Document>; using OutputDocumentPtr = OutputPointer<DocumentPtr>;
 class Catalog; using CatalogPtr = Deferred<Catalog>; using OutputCatalogPtr = OutputPointer<CatalogPtr>;
 class DocumentInfo; using DocumentInfoPtr = Deferred<DocumentInfo>; using OutputDocumentInfoPtr = OutputPointer<DocumentInfoPtr>;
 class PageNodeBase; using PageNodeBasePtr = Deferred<PageNodeBase>;

--- a/src/vanillapdf/utils/unknown_interface.cpp
+++ b/src/vanillapdf/utils/unknown_interface.cpp
@@ -57,6 +57,26 @@ void IUnknown::AddRef() noexcept {
     m_ref_counter++;
 }
 
+bool IUnknown::TryAddRef() noexcept {
+
+    // "Increment, but only if not zero" is a conditional read-modify-write, and
+    // compare_exchange is the only one the hardware offers - there is no atomic
+    // increment-if-not-zero. The exchange fails when another thread modified the
+    // counter in between, writing the value it observed back into current, so
+    // the attempt is repeated against that fresh value. This is not a spin wait:
+    // it re-runs only while the counter is actively being modified, and it stops
+    // as soon as the object reaches zero and is therefore dead.
+    auto current = m_ref_counter.load();
+
+    while (current != 0) {
+        if (m_ref_counter.compare_exchange_weak(current, current + 1)) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 void IUnknown::Release() noexcept {
     if (--m_ref_counter == 0) {
         delete this;

--- a/src/vanillapdf/utils/unknown_interface.h
+++ b/src/vanillapdf/utils/unknown_interface.h
@@ -80,6 +80,10 @@ public:
     // Upgrade to a strong reference in a single step, reporting failure instead
     // of throwing. Prefer this over the IsActive() + GetReference() pair, which
     // leaves a window for the object to reach the end of its life in between.
+    //
+    // The single step is still not self-sufficient: TryAddRef operates on the
+    // object's own storage, so this call is only safe under the external
+    // liveness guarantee described in the contract on IUnknown::TryAddRef.
     std::optional<Deferred<T>> TryGetReference() const {
         if (m_ptr == nullptr || !IsActive() || !m_ptr->TryAddRef()) {
             return std::nullopt;
@@ -170,6 +174,18 @@ public:
     // Raise the counter only if it has not reached zero yet. At zero the object
     // has committed to destruction and reviving it would create a second owner
     // of storage that is already being torn down.
+    //
+    // CONTRACT: the counter lives inside the object, so the caller must
+    // guarantee the storage stays allocated for the whole call - against an
+    // unsynchronized final Release the compare-exchange itself reads freed
+    // memory, and if the allocator has already recycled the storage it can
+    // even succeed against a foreign object's bytes. Upgrade only under a lock
+    // that the destructor acquires before the storage can be freed; the
+    // document registry in SemanticUtils is the canonical pattern (~Document
+    // takes the registry lock as its first statement, and every upgrade stays
+    // inside that lock). Removing this precondition by pinning the storage
+    // from the weak reference control block is tracked in
+    // https://github.com/vanillapdf/vanillapdf/issues/505.
     bool TryAddRef() noexcept;
 
     virtual ~IUnknown() = 0;

--- a/src/vanillapdf/utils/unknown_interface.h
+++ b/src/vanillapdf/utils/unknown_interface.h
@@ -6,6 +6,7 @@
 #include <memory>
 #include <atomic>
 #include <cassert>
+#include <optional>
 
 namespace vanillapdf {
 
@@ -60,6 +61,14 @@ public:
         return (m_ptr == other.m_ptr);
     }
 
+    bool Identity(const T* other) const noexcept {
+        if (m_ptr == nullptr) {
+            return false;
+        }
+
+        return (m_ptr == other);
+    }
+
     bool IsEmpty() const noexcept {
         return (m_ptr == nullptr);
     }
@@ -68,18 +77,29 @@ public:
         return (m_counter ? m_counter->IsActive() : false);
     }
 
-    Deferred<T> GetReference() const {
-        if (!IsActive()) {
-            throw InvalidParameterException("Object has been already disposed");
+    // Upgrade to a strong reference in a single step, reporting failure instead
+    // of throwing. Prefer this over the IsActive() + GetReference() pair, which
+    // leaves a window for the object to reach the end of its life in between.
+    std::optional<Deferred<T>> TryGetReference() const {
+        if (m_ptr == nullptr || !IsActive() || !m_ptr->TryAddRef()) {
+            return std::nullopt;
         }
 
-        // This shall not happen, because IsActive should check m_ptr
-        assert(m_ptr && "Referenced pointer is empty");
-        if (m_ptr == nullptr) {
+        // Adopt the reference TryAddRef has already taken
+        return Deferred<T>(m_ptr, false);
+    }
+
+    Deferred<T> GetReference() const {
+        if (IsEmpty()) {
             throw InvalidParameterException("Pointer object was not set");
         }
 
-        return Deferred<T>(m_ptr);
+        auto acquired = TryGetReference();
+        if (!acquired.has_value()) {
+            throw InvalidParameterException("Object has been already disposed");
+        }
+
+        return acquired.value();
     }
 
     //// The reason why value cannot be const is
@@ -146,6 +166,11 @@ public:
 
     void AddRef() noexcept;
     void Release() noexcept;
+
+    // Raise the counter only if it has not reached zero yet. At zero the object
+    // has committed to destruction and reviving it would create a second owner
+    // of storage that is already being torn down.
+    bool TryAddRef() noexcept;
 
     virtual ~IUnknown() = 0;
 


### PR DESCRIPTION
## Problem

`Document::OpenFile` resolves through a process-wide `File*` -> `WeakReference<Document>` registry, and the upgrade was two separate steps — `IsActive()` followed by `GetReference()`, which called a plain `AddRef()`. A document whose reference counter had already reached zero was therefore **revived**, leaving two owners of storage that was already being torn down. Both eventually delete it, and because every `Document` holds a strong `FilePtr`, the double delete cascades into over-releasing the shared `File`.

The shipped viewer is exposed, not only the test suite: it opens and disposes a document per page render against one shared `PdfFile`, across three concurrent lanes. The reported symptom was the NUnit test host dying with no managed exception and no usable dump — `STATUS_HEAP_CORRUPTION` (`0xC0000374`) or `__fastfail` (`0xC0000409`) — always blaming whichever test happened to be in flight, because the corruption is committed by one thread and detected later by whoever next allocates densely.

## Fix

`IUnknown::TryAddRef` raises the counter only if it has not reached zero yet. This is the increment-if-not-zero step `std::weak_ptr::lock()` performs; `compare_exchange` is the only conditional read-modify-write the hardware offers, so the retry is inherent rather than a spin wait. The reference counter stays inside the object, so `AddRef`, `Release` and `Deferred` are untouched.

`WeakReference::TryGetReference` collapses the liveness check and the upgrade into a single operation, and `GetReference` is rewritten on top of it, so no upgrade anywhere in the library can resurrect an object that has committed to destruction.

`ReleaseMapping` now erases only the entry that still identifies the document being destroyed. This part is required rather than cosmetic: once a failed upgrade legitimately builds a replacement, the dying document would otherwise erase the replacement's registry entry, dropping a live document out of the registry so that the next open builds a second one beside it — precisely the cache splitting the registry exists to prevent. Under load the accompanying warning fires around 60 times per run, so the race is frequent, not theoretical.

## Why the existing tests never caught it

`ConcurrentOpenSameFile` parks every handle in a vector and releases them all after the join, so during the concurrent phase the reference counter only ever climbs and never returns to zero. That is the exact window this bug needs, which is why 50 threads x 2000 iterations stayed green while an open/release cycle reproduces at 4 threads. The same shape holds across the rest of `thread_safety_test.cpp`: every test covers concurrent acquisition and concurrent reads, none covers concurrent release. That is also why ASan and TSan in CI never flagged it — they run these same tests, in which there is genuinely no race to detect.

The new `ConcurrentOpenReleaseCycleSameFile` cycles open and release, and asserts that the live object count returns to its baseline, which catches both a double free and a registry entry outliving its document. It deliberately does **not** assert handle identity: a document that legitimately reached zero references is dead, and the next open must build a fresh one, so asserting identity there would be asserting the resurrection this test exists to prevent.

## Verification

25 Release runs of the new test, same binary, fix toggled:

| | without fix | with fix |
|---|---|---|
| passed | **0** | **25** |
| `0xC0000374` heap corruption | 11 | 0 |
| `0x00000003` abort | 12 | 0 |
| `0xC0000005` access violation | 2 | 0 |

Full suite `windows-x64-msvc-18` Release: 723/723 pass.

Benchmarks (5 repetitions, medians, ~3% noise floor) show no measurable cost, as expected since the hot reference-counting paths are untouched:

| benchmark | delta |
|---|---|
| `BM_FileOpen/Memory_flat_pages` | -2.2% |
| `BM_ContentStreamParse/sample` | +4.8% |
| `BM_PageTreeSingleAccess/500` | -1.8% |
| `BM_FileSaveParse` | -2.5% |

## Scope

This makes the document registry correct and makes resurrection impossible for every weak reference in the library. It does not fully close the read-after-free window for the remaining weak-reference roles (the `File` back-pointer, owner, xref entry, resolved-object cache and observer list), whose referents die only by explicit C API release rather than routinely. Those are strictly improved, not solved; the complete answer is a larger rework of the intrusive counter, which was measured and rejected for this change because moving the counter into a `shared_ptr`-style control block costs +12% on parse and +20% on object-heavy access.

`Catalog::Pages()` — the second defect in the same report, an unsynchronised lazy write to a `mutable` member — is deliberately not included here and follows in its own PR, since `CachedValue` already exists for exactly that pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
