### PR TITLE
fix: Tolerate wide generation fields in cross-reference streams

### DIFF
--- a/cmake/testdata.cmake
+++ b/cmake/testdata.cmake
@@ -16,17 +16,17 @@
 include(FetchContent)
 
 FetchContent_Declare(vanillapdf_testdata
-    URL      https://github.com/vanillapdf/vanillapdf-testdata/releases/download/v1.0/corpus.tar.gz
-    URL_HASH SHA256=6b20b3d5548dbc59793cd2364286049b97b27d14e191fa548848ef58f5c0769d
+    URL      https://github.com/vanillapdf/vanillapdf-testdata/releases/download/v1.1/corpus.tar.gz
+    URL_HASH SHA256=057970ac4d6757240476c8ebbce7b662857b78330c6912b5f6d64080ea7e2f81
 )
 FetchContent_MakeAvailable(vanillapdf_testdata)
 
 # The manifest is downloaded next to the extracted corpus/ so it is co-located
 # with the fixtures (consumers can find it relative to the testdata root).
 file(DOWNLOAD
-    https://github.com/vanillapdf/vanillapdf-testdata/releases/download/v1.0/manifest.json
+    https://github.com/vanillapdf/vanillapdf-testdata/releases/download/v1.1/manifest.json
     "${vanillapdf_testdata_SOURCE_DIR}/manifest.json"
-    EXPECTED_HASH SHA256=582220322130ed8a2cca106537900895576079f838eff67f71eb71c5764420ca
+    EXPECTED_HASH SHA256=ac7ffc5a4865b4f27da467599abd583e33c22945e55e109aaa6448510f3e4c12
 )
 
 set(VANILLAPDF_TESTDATA_ROOT "${vanillapdf_testdata_SOURCE_DIR}"

--- a/src/vanillapdf/syntax/parsers/parser.cpp
+++ b/src/vanillapdf/syntax/parsers/parser.cpp
@@ -579,33 +579,55 @@ XrefStreamPtr Parser::ParseXrefStream(
     auto field2_size = fields->GetValue(1);
     auto field3_size = fields->GetValue(2);
 
+    types::big_int field1_width = field1_size->GetIntegerValue();
+    types::big_int field2_width = field2_size->GetIntegerValue();
+    types::big_int field3_width = field3_size->GetIntegerValue();
+
+    // A field can never be wider than the value it is read into. The widths are
+    // stream-level constants declared in /W, so they are validated once here
+    // rather than on every entry, and each field is named so the error points at it.
+    const types::big_int MAXIMUM_FIELD_WIDTH = sizeof(types::big_uint);
+
+    if (field1_width < 0 || field1_width > MAXIMUM_FIELD_WIDTH) {
+        LOG_ERROR_AND_THROW(ParseException, "Unsupported cross-reference stream type field width {}", field1_width);
+    }
+
+    if (field2_width < 0 || field2_width > MAXIMUM_FIELD_WIDTH) {
+        LOG_ERROR_AND_THROW(ParseException, "Unsupported cross-reference stream offset field width {}", field2_width);
+    }
+
+    if (field3_width < 0 || field3_width > MAXIMUM_FIELD_WIDTH) {
+        LOG_ERROR_AND_THROW(ParseException, "Unsupported cross-reference stream generation field width {}", field3_width);
+    }
+
+    // 7.5.8.2 Cross-reference stream dictionary, Table 17
+    // The three widths are the byte lengths of the type, offset and generation
+    // fields, so their sum is the stride of a single entry. A zero stride would
+    // decouple the entry count from the body length: a stream of a few hundred
+    // bytes could then declare millions of entries and force that many
+    // allocations. Every entry occupies at least one byte.
+    if (field1_width + field2_width + field3_width == 0) {
+        LOG_ERROR_AND_THROW(ParseException, "Cross-reference stream declares zero-width entries in /W");
+    }
+
     bool contains_self = false;
 
     // Iterate over entries
     auto it = body.begin();
 
-    // Reads a single big-endian cross-reference field of the width declared in /W.
-    // A width of zero means the field is not present and takes its default value.
+    // Reads a single big-endian cross-reference field of the given width. A width
+    // of zero means the field is not present and takes its default value.
     //
     // The declared entry count and the decoded body length are independent values,
     // both taken from the document, therefore every byte is bounds checked instead
     // of letting the iterator run past the end of the buffer.
-    auto read_field = [&it, &body](const IntegerObjectPtr& field_size, types::big_uint default_value = 0) {
-
-        // A field can never be wider than the value it is read into
-        const types::big_int MAXIMUM_FIELD_WIDTH = sizeof(types::big_uint);
-
-        auto field_width = field_size->GetIntegerValue();
-        if (field_width < 0 || field_width > MAXIMUM_FIELD_WIDTH) {
-            LOG_ERROR_AND_THROW(ParseException, "Unsupported cross-reference stream field width {}", field_width);
-        }
-
-        if (0 == field_width) {
+    auto read_field = [&it, &body](types::big_int width, types::big_uint default_value) {
+        if (width == 0) {
             return default_value;
         }
 
         types::big_uint result = 0;
-        for (decltype(field_width) i = 0; i < field_width; ++i) {
+        for (types::big_int i = 0; i < width; ++i) {
             if (it == body.end()) {
                 LOG_ERROR_AND_THROW(ParseException, "Cross-reference stream body is shorter than the declared entry count");
             }
@@ -629,9 +651,9 @@ XrefStreamPtr Parser::ParseXrefStream(
             // field shall not be present in the stream, and the default value shall be used,
             // if there is one. [...] If the first element is zero, the type field shall not be
             // present, and shall default to Type 1."
-            auto field1 = read_field(field1_size, 1);
-            auto field2 = read_field(field2_size);
-            auto field3 = read_field(field3_size);
+            auto field1 = read_field(field1_width, 1);
+            auto field2 = read_field(field2_width, 0);
+            auto field3 = read_field(field3_width, 0);
 
             types::big_uint obj_number = SafeAddition<types::big_uint, types::big_uint, int>(*subsection_index, idx);
 
@@ -648,19 +670,19 @@ XrefStreamPtr Parser::ParseXrefStream(
             // Field 3 only holds a generation number for types 0 and 1,
             // for type 2 it is an index within the object stream.
             auto gen_number = field3;
-            if ((0 == field1 || 1 == field1) && gen_number > constant::MAX_GENERATION_NUMBER) {
+            if ((field1 == 0 || field1 == 1) && gen_number > constant::MAX_GENERATION_NUMBER) {
                 spdlog::warn("Invalid object generation number {}, converting", gen_number);
                 gen_number = constant::MAX_GENERATION_NUMBER;
             }
 
-            if (0 == field1) {
+            if (field1 == 0) {
                 XrefFreeEntryPtr entry = make_deferred<XrefFreeEntry>(obj_number, ValueConvertUtils::SafeConvert<types::ushort>(gen_number), field2);
                 entry->SetFile(_file);
                 result->Add(entry);
                 continue;
             }
 
-            if (1 == field1) {
+            if (field1 == 1) {
 
                 // 7.5.8.3 Cross-reference stream data, Table 18
                 // Field 2 of a type 1 entry is "The byte offset of the object,
@@ -698,7 +720,7 @@ XrefStreamPtr Parser::ParseXrefStream(
                 continue;
             }
 
-            if (2 == field1) {
+            if (field1 == 2) {
                 XrefCompressedEntryPtr entry = make_deferred<XrefCompressedEntry>(obj_number, static_cast<types::ushort>(0), field2, ValueConvertUtils::SafeConvert<types::size_type>(field3));
                 entry->SetFile(_file);
                 result->Add(entry);

--- a/src/vanillapdf/syntax/parsers/parser.cpp
+++ b/src/vanillapdf/syntax/parsers/parser.cpp
@@ -583,6 +583,40 @@ XrefStreamPtr Parser::ParseXrefStream(
 
     // Iterate over entries
     auto it = body.begin();
+
+    // Reads a single big-endian cross-reference field of the width declared in /W.
+    // A width of zero means the field is not present and takes its default value.
+    //
+    // The declared entry count and the decoded body length are independent values,
+    // both taken from the document, therefore every byte is bounds checked instead
+    // of letting the iterator run past the end of the buffer.
+    auto read_field = [&it, &body](const IntegerObjectPtr& field_size, types::big_uint default_value = 0) {
+
+        // A field can never be wider than the value it is read into
+        const types::big_int MAXIMUM_FIELD_WIDTH = sizeof(types::big_uint);
+
+        auto field_width = field_size->GetIntegerValue();
+        if (field_width < 0 || field_width > MAXIMUM_FIELD_WIDTH) {
+            LOG_ERROR_AND_THROW(ParseException, "Unsupported cross-reference stream field width {}", field_width);
+        }
+
+        if (0 == field_width) {
+            return default_value;
+        }
+
+        types::big_uint result = 0;
+        for (decltype(field_width) i = 0; i < field_width; ++i) {
+            if (it == body.end()) {
+                LOG_ERROR_AND_THROW(ParseException, "Cross-reference stream body is shorter than the declared entry count");
+            }
+
+            result = (result << 8) | static_cast<unsigned char>(*it);
+            it += 1;
+        }
+
+        return result;
+    };
+
     for (decltype(index_size) i = 0; i < index_size; i += 2) {
 
         auto subsection_index = index->GetValue(i);
@@ -590,43 +624,70 @@ XrefStreamPtr Parser::ParseXrefStream(
 
         for (auto idx = 0; idx < *subsection_size; idx++) {
 
-            IntegerObject field1;
-            for (int j = 0; j < *field1_size; ++j) {
-                unsigned char next_value = reinterpret_cast<unsigned char&>(*it);
-                field1 = (field1 << 8) + next_value;
-                it++;
-            }
-
-            assert(field1 == 0 || field1 == 1 || field1 == 2);
-
-            IntegerObject field2;
-            for (int j = 0; j < *field2_size; ++j) {
-                unsigned char next_value = reinterpret_cast<unsigned char&>(*it);
-                field2 = (field2 << 8) + next_value;
-                it++;
-            }
-
-            IntegerObject field3;
-            for (int j = 0; j < *field3_size; ++j) {
-                unsigned char next_value = reinterpret_cast<unsigned char&>(*it);
-                field3 = (field3 << 8) + next_value;
-                it++;
-            }
+            // 7.5.8.2 Cross-reference stream dictionary, Table 17
+            // "A value of zero for an element in the W array indicates that the corresponding
+            // field shall not be present in the stream, and the default value shall be used,
+            // if there is one. [...] If the first element is zero, the type field shall not be
+            // present, and shall default to Type 1."
+            auto field1 = read_field(field1_size, 1);
+            auto field2 = read_field(field2_size);
+            auto field3 = read_field(field3_size);
 
             types::big_uint obj_number = SafeAddition<types::big_uint, types::big_uint, int>(*subsection_index, idx);
 
+            // 7.5.4 Cross-reference table
+            // "The first entry in the table (object number 0) shall always be free and shall have
+            // a generation number of 65,535" and "The maximum generation number is 65,535; when a
+            // cross-reference entry reaches this value, it shall never be reused."
+            //
+            // Producers declaring a generation field wider than two bytes in /W store that value
+            // with all bits set across the whole declared width, which no longer fits the 16-bit
+            // generation number and used to abort the parse of the whole document.
+            // Seen in the wild with /W [1 4 4], where the free list head carries 0xFFFFFFFF.
+            //
+            // Field 3 only holds a generation number for types 0 and 1,
+            // for type 2 it is an index within the object stream.
+            auto gen_number = field3;
+            if ((0 == field1 || 1 == field1) && gen_number > constant::MAX_GENERATION_NUMBER) {
+                spdlog::warn("Invalid object generation number {}, converting", gen_number);
+                gen_number = constant::MAX_GENERATION_NUMBER;
+            }
+
             if (0 == field1) {
-                XrefFreeEntryPtr entry = make_deferred<XrefFreeEntry>(obj_number, field3.SafeConvert<types::ushort>(), field2);
+                XrefFreeEntryPtr entry = make_deferred<XrefFreeEntry>(obj_number, ValueConvertUtils::SafeConvert<types::ushort>(gen_number), field2);
                 entry->SetFile(_file);
                 result->Add(entry);
                 continue;
             }
 
             if (1 == field1) {
-                XrefUsedEntryPtr entry = make_deferred<XrefUsedEntry>(obj_number, field3.SafeConvert<types::ushort>(), field2);
+
+                // 7.5.8.3 Cross-reference stream data, Table 18
+                // Field 2 of a type 1 entry is "The byte offset of the object,
+                // starting from the beginning of the PDF file".
+                //
+                // Annex C.1 states that the standard "does not restrict the size or quantity of
+                // things described in the PDF file format", while "a particular PDF processor
+                // running on a particular device and in a particular operating environment will
+                // always have practical limits". The declared width can therefore carry a value
+                // larger than the signed offset that addresses the whole document, and no seek
+                // could ever reach it. Such an entry is left out, so that reading the object
+                // reports it as missing.
+                //
+                // Reaching this limit takes a document larger than 8 exbibytes, roughly 9.2
+                // exabytes, which no storage in reach produces today. Should documents of that
+                // size ever become real, widening this branch is not enough on its own, the
+                // offset has to grow in the xref entries and in the whole seeking interface.
+                if (!ValueConvertUtils::IsInRange<types::stream_offset>(field2)) {
+                    spdlog::warn("Skipping cross-reference stream entry {}, the offset {} is beyond the addressable range", obj_number, field2);
+                    continue;
+                }
+
+                auto entry_gen_number = ValueConvertUtils::SafeConvert<types::ushort>(gen_number);
+                XrefUsedEntryPtr entry = make_deferred<XrefUsedEntry>(obj_number, entry_gen_number, ValueConvertUtils::SafeConvert<types::stream_offset>(field2));
 
                 // This case is when XrefStream contains reference to itself
-                if (obj_number == stream_obj_number && field3.SafeConvert<types::ushort>() == stream_gen_number) {
+                if (obj_number == stream_obj_number && entry_gen_number == stream_gen_number) {
                     entry->SetReference(stream);
                     entry->SetInitialized();
                     contains_self = true;
@@ -638,13 +699,17 @@ XrefStreamPtr Parser::ParseXrefStream(
             }
 
             if (2 == field1) {
-                XrefCompressedEntryPtr entry = make_deferred<XrefCompressedEntry>(obj_number, static_cast<types::ushort>(0), field2, field3.SafeConvert<types::size_type>());
+                XrefCompressedEntryPtr entry = make_deferred<XrefCompressedEntry>(obj_number, static_cast<types::ushort>(0), field2, ValueConvertUtils::SafeConvert<types::size_type>(field3));
                 entry->SetFile(_file);
                 result->Add(entry);
                 continue;
             }
 
-            throw ParseException("Unknown entry type");
+            // 7.5.8.3 Cross-reference stream data
+            // "In PDF 1.5 through PDF 2.0, only types 0, 1, and 2 are allowed. Any other value
+            // shall be interpreted as a reference to the null object, thus permitting new entry
+            // types to be defined in the future."
+            spdlog::warn("Skipping cross-reference stream entry {} of unknown type {}", obj_number, field1);
         }
     }
 
@@ -878,8 +943,17 @@ XrefChainPtr Parser::FindAllObjects(void) {
                 auto stream_type = stream_header->FindAs<NameObjectPtr>(constant::Name::Type);
 
                 if (constant::Name::XRef == stream_type) {
-                    auto xref_stream = ParseXrefStream(stream, obj_number, gen_number);
-                    result->Append(xref_stream);
+
+                    // This is already the recovery path, every object has been found by scanning
+                    // the whole document. Parsing the cross-reference stream only recovers the
+                    // additional entries for compressed objects, so a damaged one degrades the
+                    // result instead of failing the document that we were asked to repair.
+                    try {
+                        auto xref_stream = ParseXrefStream(stream, obj_number, gen_number);
+                        result->Append(xref_stream);
+                    } catch (ExceptionBase& e) {
+                        spdlog::warn("Could not parse cross-reference stream in object {} {}: {}", obj_number, gen_number, e.what());
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary

A cross-reference stream may declare a generation field wider than two bytes in `/W`. Producers store the free-list head's "never reuse" value across the whole declared width, so `/W [1 4 4]` yields `0xFFFFFFFF` instead of 65535. `ParseXrefStream` converted that field straight into the 16-bit generation number, threw a conversion error, and aborted the parse — and since the recovery path in `FindAllObjects` parses cross-reference streams too, it failed on the very same entry and the document could not be opened at all. The classic table path already clamps out-of-range generation numbers (`ReadTableEntry`); the stream path now does the same.

While in `ParseXrefStream`, the same hardening pass also: bounds-checks every field read against the decoded body length (the declared entry count and body length are independent document-supplied values); validates `/W` widths and honours width zero per Table 17 (field absent, type defaults to 1); skips unknown entry types per 7.5.8.3 instead of failing; skips entries whose offset is beyond the addressable range; and keeps a damaged cross-reference stream from failing the whole `FindAllObjects` recovery.

## Test fixture

Covered by `corpus/custom/xref_stream_wide_generation.pdf`, new in [vanillapdf-testdata v1.1](https://github.com/vanillapdf/vanillapdf-testdata/releases/tag/v1.1) (vanillapdf/vanillapdf-testdata#1) and pinned here via `cmake/testdata.cmake`. It enumerates as an integration test automatically. Verified both directions locally: without the fix, `read` aborts with `Could not convert value 4294967295 of type __int64 to type unsigned short`; with it, the file opens (1 page) and `validate` reports VALID, alongside a passing smoke run of existing corpus tests.

The fixture originally sat in-repo on this branch as `test/xref_stream_wide_generation.pdf`, predating the corpus externalization (#459) — and that copy was corrupted at creation (every byte >= 0x80 mangled into the UTF-8 replacement character). The corpus ships the byte-exact output of the original generator script instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
