### PR TITLE
fix: Resolve flat page numbers in PageTree Remove and Insert

### DIFF
--- a/fixtures/README.md
+++ b/fixtures/README.md
@@ -16,6 +16,7 @@ corpus with per-file provenance instead.
 | File | Origin | How to regenerate |
 |------|--------|-------------------|
 | `minimalist.pdf` | vanillapdf-authored, a tiny valid PDF (catalog + empty page tree) | hand-authored |
+| `nested-pages.pdf` | vanillapdf-authored, a tiny valid PDF with a nested page tree (root → two intermediate nodes holding 3 + 2 pages), for page-tree tests where flat page numbers diverge from per-node Kids indices | hand-authored |
 | `flat-pages.pdf` | 1,450 empty pages in a flat `/Pages` tree, for the page-tree benchmark | `vanillapdf.tools generate -d fixtures/flat-pages.pdf -p 1450` |
 | `sample-document.pdf` | A feature-rich document: standard PDF fonts (not embedded), a procedurally drawn image, an underline, internal + external links, and a table | `python scripts/generate_sample_documents.py` |
 | `certificates/*.pfx` | Internal test signing certificates (DSA/RSA/EC/Ed25519/Ed448). Not real credentials — no trust path, password `test` | generated test fixtures |
@@ -25,6 +26,7 @@ corpus with per-file provenance instead.
 - `vanillapdf.benchmark` — `flat-pages.pdf` (page tree), `sample-document.pdf`
   (content stream), and all three PDFs for the IO-strategy size range.
 - `vanillapdf.unittest` — `certificates/*.pfx`, compiled into a header.
+- `vanillapdf.tools` ctests — all five PDFs for the `remove_page` sanity tests.
 - `signature-interop-check` workflow — signs a fixture with `certificates/*.pfx`.
 
 ## Notes

--- a/fixtures/nested-pages.pdf
+++ b/fixtures/nested-pages.pdf
@@ -1,0 +1,46 @@
+%PDF-1.7
+1 0 obj
+<</Pages 2 0 R /Type /Catalog>>
+endobj
+2 0 obj
+<</Count 5 /Kids [3 0 R 4 0 R] /Type /Pages>>
+endobj
+3 0 obj
+<</Count 3 /Kids [5 0 R 6 0 R 7 0 R] /Parent 2 0 R /Type /Pages>>
+endobj
+4 0 obj
+<</Count 2 /Kids [8 0 R 9 0 R] /Parent 2 0 R /Type /Pages>>
+endobj
+5 0 obj
+<</MediaBox [0 0 612 792] /Parent 3 0 R /Type /Page>>
+endobj
+6 0 obj
+<</MediaBox [0 0 612 792] /Parent 3 0 R /Type /Page>>
+endobj
+7 0 obj
+<</MediaBox [0 0 612 792] /Parent 3 0 R /Type /Page>>
+endobj
+8 0 obj
+<</MediaBox [0 0 612 792] /Parent 4 0 R /Type /Page>>
+endobj
+9 0 obj
+<</MediaBox [0 0 612 792] /Parent 4 0 R /Type /Page>>
+endobj
+
+xref
+0 10
+0000000000 65535 f 
+0000000009 00000 n 
+0000000056 00000 n 
+0000000117 00000 n 
+0000000198 00000 n 
+0000000273 00000 n 
+0000000342 00000 n 
+0000000411 00000 n 
+0000000480 00000 n 
+0000000549 00000 n 
+trailer
+<</Root 1 0 R /Size 10>>
+startxref
+619
+%%EOF

--- a/src/vanillapdf.tools/CMakeLists.txt
+++ b/src/vanillapdf.tools/CMakeLists.txt
@@ -17,6 +17,7 @@ set(VANILLAPDF_TOOLS_SOURCES
     merge.c
     read.c
     resave.c
+    remove_page.c
     sign.c
     sign_custom.c
     verify.c
@@ -256,5 +257,57 @@ if(VANILLAPDF_ENABLE_TESTS)
     add_test(
         NAME "Tools.read.chinese_names_中文的名字-2"
         COMMAND $<TARGET_FILE:vanillapdf.tools> read -f "${VANILLAPDF_SOLUTION_SOURCE_DIR}/fixtures/chinese_names_中文的名字-2.pdf"
+    )
+
+    # remove_page sanity tests on the in-repo fixtures. The tool itself checks
+    # that the page count dropped by exactly one, so each test only asserts
+    # the reported counts.
+
+    # nested-pages.pdf: root -> [3-page node, 2-page node]. Page 4 is the
+    # first page of the second subtree - the regression case where the flat
+    # page number used to be applied directly to the root Kids array.
+    add_test(
+        NAME "Tools.remove_page.nested-pages.subtree-boundary"
+        COMMAND $<TARGET_FILE:vanillapdf.tools> remove_page -s "${VANILLAPDF_SOLUTION_SOURCE_DIR}/fixtures/nested-pages.pdf" -d "${CMAKE_CURRENT_BINARY_DIR}/remove_page-nested-pages.pdf" -n 4
+    )
+    set_tests_properties("Tools.remove_page.nested-pages.subtree-boundary" PROPERTIES
+        PASS_REGULAR_EXPRESSION "Removed page 4 \\(5 -> 4 pages\\)"
+    )
+
+    # Flat single-node tree, removal from the middle of the wide Kids array
+    add_test(
+        NAME "Tools.remove_page.flat-pages.middle"
+        COMMAND $<TARGET_FILE:vanillapdf.tools> remove_page -s "${VANILLAPDF_SOLUTION_SOURCE_DIR}/fixtures/flat-pages.pdf" -d "${CMAKE_CURRENT_BINARY_DIR}/remove_page-flat-pages.pdf" -n 725
+    )
+    set_tests_properties("Tools.remove_page.flat-pages.middle" PROPERTIES
+        PASS_REGULAR_EXPRESSION "Removed page 725 \\(1451 -> 1450 pages\\)"
+    )
+
+    # First page of a document with real content
+    add_test(
+        NAME "Tools.remove_page.sample-document.first"
+        COMMAND $<TARGET_FILE:vanillapdf.tools> remove_page -s "${VANILLAPDF_SOLUTION_SOURCE_DIR}/fixtures/sample-document.pdf" -d "${CMAKE_CURRENT_BINARY_DIR}/remove_page-sample-document.pdf" -n 1
+    )
+    set_tests_properties("Tools.remove_page.sample-document.first" PROPERTIES
+        PASS_REGULAR_EXPRESSION "Removed page 1 \\(2 -> 1 pages\\)"
+    )
+
+    # Removing the only page leaves a document with an empty page tree
+    add_test(
+        NAME "Tools.remove_page.chinese_names.only-page"
+        COMMAND $<TARGET_FILE:vanillapdf.tools> remove_page -s "${VANILLAPDF_SOLUTION_SOURCE_DIR}/fixtures/chinese_names_中文的名字-2.pdf" -d "${CMAKE_CURRENT_BINARY_DIR}/remove_page-chinese_names.pdf" -n 1
+    )
+    set_tests_properties("Tools.remove_page.chinese_names.only-page" PROPERTIES
+        PASS_REGULAR_EXPRESSION "Removed page 1 \\(1 -> 0 pages\\)"
+    )
+
+    # Removing from an empty document reports a clean out-of-range error
+    # instead of the historical silent success
+    add_test(
+        NAME "Tools.remove_page.minimalist.out-of-range"
+        COMMAND $<TARGET_FILE:vanillapdf.tools> remove_page -s "${VANILLAPDF_SOLUTION_SOURCE_DIR}/fixtures/minimalist.pdf" -d "${CMAKE_CURRENT_BINARY_DIR}/remove_page-minimalist.pdf" -n 1
+    )
+    set_tests_properties("Tools.remove_page.minimalist.out-of-range" PROPERTIES
+        PASS_REGULAR_EXPRESSION "out of range, the document has 0 pages"
     )
 endif()

--- a/src/vanillapdf.tools/main.c
+++ b/src/vanillapdf.tools/main.c
@@ -27,6 +27,7 @@ void print_help() {
     printf("  decrypt         Decrypt a PDF document\n");
     printf("  read            Read a PDF using memory IO strategy\n");
     printf("  resave          Re-save a PDF document\n");
+    printf("  remove_page     Remove a page from a PDF document\n");
     printf("  write_custom    Write PDF with custom handler\n");
     printf("  generate        Generate a PDF with N empty pages\n");
     printf("\nOptions:\n");
@@ -102,6 +103,10 @@ int main(int argc, char *argv[]) {
 
     if (0 == strcmp(argv[1], "resave")) {
         return process_resave(argc - 2, &argv[2]);
+    }
+
+    if (0 == strcmp(argv[1], "remove_page")) {
+        return process_remove_page(argc - 2, &argv[2]);
     }
 
     if (0 == strcmp(argv[1], "write_custom")) {

--- a/src/vanillapdf.tools/remove_page.c
+++ b/src/vanillapdf.tools/remove_page.c
@@ -1,0 +1,104 @@
+#include "tools.h"
+
+void print_remove_page_help() {
+    printf("Usage: remove_page -s [source file] -d [destination file] -n [page number] -p [password]");
+}
+
+// Removes the page at the given 1-based page number and saves the result
+// into the destination file. Page numbers count leaf pages across the whole
+// page tree, matching PageTree_GetPage, so nested intermediate nodes are
+// handled transparently.
+int process_remove_page(int argc, char *argv[]) {
+    FileHandle* source_file = NULL;
+    DocumentHandle* document = NULL;
+    CatalogHandle* catalog = NULL;
+    PageTreeHandle* page_tree = NULL;
+
+    string_type password = NULL;
+    string_type source_file_path = NULL;
+    string_type destination_file_path = NULL;
+    integer_type page_number = 0;
+
+    size_type page_count_before = 0;
+    size_type page_count_after = 0;
+
+    unsigned long long page_count_before_converted = 0;
+    unsigned long long page_count_after_converted = 0;
+
+    integer_type i = 0;
+
+    for (i = 0; i < argc; ++i) {
+
+        // source file path
+        if (strcmp(argv[i], "-s") == 0 && (i + 1 < argc)) {
+            source_file_path = argv[i + 1];
+            i++;
+
+            // destination file path
+        } else if (strcmp(argv[i], "-d") == 0 && (i + 1 < argc)) {
+            destination_file_path = argv[i + 1];
+            i++;
+
+            // page number to be removed
+        } else if (strcmp(argv[i], "-n") == 0 && (i + 1 < argc)) {
+            page_number = atoi(argv[i + 1]);
+            i++;
+
+            // encryption password
+        } else if (strcmp(argv[i], "-p") == 0 && (i + 1 < argc)) {
+            password = argv[i + 1];
+            i++;
+        } else {
+            print_remove_page_help();
+            return VANILLAPDF_TOOLS_ERROR_INVALID_PARAMETERS;
+        }
+    }
+
+    if (source_file_path == NULL || destination_file_path == NULL || page_number <= 0) {
+        print_remove_page_help();
+        return VANILLAPDF_TOOLS_ERROR_INVALID_PARAMETERS;
+    }
+
+    RETURN_ERROR_IF_NOT_SUCCESS(File_Open(source_file_path, &source_file));
+    RETURN_ERROR_IF_NOT_SUCCESS(Document_OpenFile(source_file, &document));
+
+    if (password != NULL) {
+        RETURN_ERROR_IF_NOT_SUCCESS(File_SetEncryptionPassword(source_file, password));
+    }
+
+    RETURN_ERROR_IF_NOT_SUCCESS(Document_GetCatalog(document, &catalog));
+    RETURN_ERROR_IF_NOT_SUCCESS(Catalog_GetPages(catalog, &page_tree));
+
+    RETURN_ERROR_IF_NOT_SUCCESS(PageTree_GetPageCount(page_tree, &page_count_before));
+
+    page_count_before_converted = page_count_before;
+
+    if ((size_type) page_number > page_count_before) {
+        printf("Page number %d is out of range, the document has %llu pages\n",
+            page_number, page_count_before_converted);
+        return VANILLAPDF_TOOLS_ERROR_INVALID_PARAMETERS;
+    }
+
+    RETURN_ERROR_IF_NOT_SUCCESS(PageTree_RemovePage(page_tree, (size_type) page_number));
+    RETURN_ERROR_IF_NOT_SUCCESS(PageTree_GetPageCount(page_tree, &page_count_after));
+
+    page_count_after_converted = page_count_after;
+
+    if (page_count_after != page_count_before - 1) {
+        printf("Page count mismatch after removal: %llu -> %llu\n",
+            page_count_before_converted, page_count_after_converted);
+        return VANILLAPDF_TOOLS_ERROR_FAILURE;
+    }
+
+    RETURN_ERROR_IF_NOT_SUCCESS(Document_Save(document, destination_file_path));
+
+    RETURN_ERROR_IF_NOT_SUCCESS(PageTree_Release(page_tree));
+    RETURN_ERROR_IF_NOT_SUCCESS(Catalog_Release(catalog));
+    RETURN_ERROR_IF_NOT_SUCCESS(Document_Release(document));
+    RETURN_ERROR_IF_NOT_SUCCESS(File_Release(source_file));
+
+    printf("Removed page %d (%llu -> %llu pages): %s\n",
+        page_number, page_count_before_converted, page_count_after_converted, destination_file_path);
+
+    return VANILLAPDF_TOOLS_ERROR_SUCCESS;
+}

--- a/src/vanillapdf.tools/tools.h
+++ b/src/vanillapdf.tools/tools.h
@@ -28,6 +28,7 @@ int process_decrypt(int argc, char *argv[]);
 int process_write_custom(int argc, char *argv[]);
 int process_read(int argc, char *argv[]);
 int process_resave(int argc, char *argv[]);
+int process_remove_page(int argc, char *argv[]);
 int process_verify(int argc, char *argv[]);
 int process_validate(int argc, char *argv[]);
 int process_generate(int argc, char *argv[]);

--- a/src/vanillapdf/semantics/objects/page_tree.cpp
+++ b/src/vanillapdf/semantics/objects/page_tree.cpp
@@ -126,17 +126,67 @@ bool PageTree::FindPageIndexInternal(PageTreeNodePtr node, DictionaryObjectPtr p
 }
 
 
+PageTreeNodePtr PageTree::FindPageParent(types::size_type page_number, types::size_type& kid_index) const {
+    auto root = make_deferred<PageTreeNode>(_obj);
+
+    // The result placeholder is overwritten on success and unused on failure
+    auto parent_node = root;
+
+    types::size_type current_page_number = 0;
+    if (!FindPageParentInternal(root, page_number, current_page_number, parent_node, kid_index)) {
+        LOG_ERROR_AND_THROW(ObjectMissingException, "Page number was not found: {}", page_number);
+    }
+
+    return parent_node;
+}
+
+bool PageTree::FindPageParentInternal(PageTreeNodePtr node, types::size_type page_number, types::size_type& current_page_number, PageTreeNodePtr& parent_node, types::size_type& kid_index) const {
+    auto kids = node->Kids();
+    auto count = kids->GetSize();
+    for (decltype(count) i = 0; i < count; ++i) {
+        auto kid = kids->GetValue(i);
+
+        if (kid->GetNodeType() == PageNodeBase::NodeType::Tree) {
+            auto tree_node = ConvertUtils<PageNodeBasePtr>::ConvertTo<PageTreeNodePtr>(kid);
+            if (FindPageParentInternal(tree_node, page_number, current_page_number, parent_node, kid_index)) {
+                return true;
+            }
+            continue;
+        }
+
+        current_page_number += 1;
+        if (current_page_number == page_number) {
+            parent_node = node;
+            kid_index = i;
+            return true;
+        }
+    }
+
+    return false;
+}
+
 void PageTree::Insert(PageObjectPtr object, types::size_type page_index) {
     if (page_index < 1) {
         throw InvalidParameterException(fmt::format("Invalid page index: {}. Page indices are 1-based", page_index));
     }
 
-    auto array_index = page_index - 1;
-
     auto raw_obj = object->GetObject();
-    auto kids = GetKidsInternal();
-    kids->Insert(array_index, make_deferred<IndirectReferenceObject>(raw_obj));
-    object->SetParent(make_deferred<PageTreeNode>(_obj));
+    auto page_reference = make_deferred<IndirectReferenceObject>(raw_obj);
+
+    // Inserting after the current last page appends to the root Kids array.
+    // Any other position lands in the node that currently holds the page at
+    // the target flat position, so the new page takes that page number.
+    if (page_index == PageCount() + 1) {
+        auto root_kids = GetKidsInternal(_obj);
+        root_kids->Append(page_reference);
+        object->SetParent(make_deferred<PageTreeNode>(_obj));
+    } else {
+        types::size_type kid_index = 0;
+        auto parent_node = FindPageParent(page_index, kid_index);
+        auto parent_kids = GetKidsInternal(parent_node->GetObject());
+        parent_kids->Insert(kid_index, page_reference);
+        object->SetParent(parent_node);
+    }
 
     UpdateKidsCount();
     InvalidatePageCache();
@@ -144,10 +194,8 @@ void PageTree::Insert(PageObjectPtr object, types::size_type page_index) {
 
 void PageTree::Append(PageObjectPtr object) {
 
-    auto kids = GetKidsInternal();
-
-    // Insert at the end of kids array
-    Insert(object, kids->GetSize() + 1);
+    // Insert after the current last page
+    Insert(object, PageCount() + 1);
 }
 
 void PageTree::Remove(types::size_type page_index) {
@@ -155,11 +203,43 @@ void PageTree::Remove(types::size_type page_index) {
         throw InvalidParameterException(fmt::format("Invalid page index: {}. Page indices are 1-based", page_index));
     }
 
-    auto array_index = page_index - 1;
+    types::size_type kid_index = 0;
+    auto parent_node = FindPageParent(page_index, kid_index);
+    auto parent_dictionary = parent_node->GetObject();
 
-    auto kids = GetKidsInternal();
-    bool removed = kids->Remove(array_index);
-    assert(removed && "Could not remove page"); UNUSED(removed);
+    auto parent_kids = GetKidsInternal(parent_dictionary);
+    bool removed = parent_kids->Remove(kid_index);
+    if (!removed) {
+        LOG_ERROR_AND_THROW_GENERAL("Could not remove page {} from its parent node", page_index);
+    }
+
+    // Prune intermediate nodes left empty by the removal, so the tree does
+    // not accumulate childless Pages nodes. The root node always stays.
+    auto current_dictionary = parent_dictionary;
+    while (!current_dictionary->Identity(_obj) && GetKidsInternal(current_dictionary)->GetSize() == 0) {
+        if (!current_dictionary->Contains(constant::Name::Parent)) {
+            break;
+        }
+
+        auto node_parent_dictionary = current_dictionary->FindAs<DictionaryObjectPtr>(constant::Name::Parent);
+        auto node_parent_kids = GetKidsInternal(node_parent_dictionary);
+
+        bool pruned = false;
+        auto node_parent_kids_size = node_parent_kids->GetSize();
+        for (decltype(node_parent_kids_size) i = 0; i < node_parent_kids_size; ++i) {
+            auto kid_reference = node_parent_kids->GetValue(i);
+            if (kid_reference->GetReferencedObject()->Identity(current_dictionary)) {
+                pruned = node_parent_kids->Remove(i);
+                break;
+            }
+        }
+
+        if (!pruned) {
+            break;
+        }
+
+        current_dictionary = node_parent_dictionary;
+    }
 
     UpdateKidsCount();
     InvalidatePageCache();
@@ -196,14 +276,14 @@ types::size_type PageTree::UpdateKidsCount(PageNodeBasePtr node) {
     throw syntax::ParseException("Unknown page object type");
 }
 
-ArrayObjectPtr<IndirectReferenceObjectPtr> PageTree::GetKidsInternal() {
+ArrayObjectPtr<IndirectReferenceObjectPtr> PageTree::GetKidsInternal(DictionaryObjectPtr node_dictionary) {
 
-    if (!_obj->Contains(constant::Name::Kids)) {
+    if (!node_dictionary->Contains(constant::Name::Kids)) {
         ArrayObjectPtr<IndirectReferenceObjectPtr> empty_kids_obj;
-        _obj->Insert(constant::Name::Kids, empty_kids_obj);
+        node_dictionary->Insert(constant::Name::Kids, empty_kids_obj);
     }
 
-    return _obj->FindAs<ArrayObjectPtr<IndirectReferenceObjectPtr>>(constant::Name::Kids);
+    return node_dictionary->FindAs<ArrayObjectPtr<IndirectReferenceObjectPtr>>(constant::Name::Kids);
 }
 
 } // semantics

--- a/src/vanillapdf/semantics/objects/page_tree.cpp
+++ b/src/vanillapdf/semantics/objects/page_tree.cpp
@@ -170,23 +170,23 @@ void PageTree::Insert(PageObjectPtr object, types::size_type page_index) {
         throw InvalidParameterException(fmt::format("Invalid page index: {}. Page indices are 1-based", page_index));
     }
 
+    // Inserting after the current last page is an append
+    if (page_index == PageCount() + 1) {
+        Append(object);
+        return;
+    }
+
+    // The new page lands in the node that currently holds the page at the
+    // target flat position, so it takes that page number. A page's Parent
+    // entry must reference the node whose Kids array contains it.
     auto raw_obj = object->GetObject();
     auto page_reference = make_deferred<IndirectReferenceObject>(raw_obj);
 
-    // Inserting after the current last page appends to the root Kids array.
-    // Any other position lands in the node that currently holds the page at
-    // the target flat position, so the new page takes that page number.
-    if (page_index == PageCount() + 1) {
-        auto root_kids = GetKidsInternal(_obj);
-        root_kids->Append(page_reference);
-        object->SetParent(make_deferred<PageTreeNode>(_obj));
-    } else {
-        types::size_type kid_index = 0;
-        auto parent_node = FindPageParent(page_index, kid_index);
-        auto parent_kids = GetKidsInternal(parent_node->GetObject());
-        parent_kids->Insert(kid_index, page_reference);
-        object->SetParent(parent_node);
-    }
+    types::size_type kid_index = 0;
+    auto parent_node = FindPageParent(page_index, kid_index);
+    auto parent_kids = GetKidsInternal(parent_node->GetObject());
+    parent_kids->Insert(kid_index, page_reference);
+    object->SetParent(parent_node);
 
     UpdateKidsCount();
     InvalidatePageCache();
@@ -194,8 +194,18 @@ void PageTree::Insert(PageObjectPtr object, types::size_type page_index) {
 
 void PageTree::Append(PageObjectPtr object) {
 
-    // Insert after the current last page
-    Insert(object, PageCount() + 1);
+    // Appended pages become direct children of the root node - the position
+    // after the last page always coincides with the end of the root Kids
+    // array, and without tree balancing there is no benefit in nesting deeper
+    auto raw_obj = object->GetObject();
+    auto page_reference = make_deferred<IndirectReferenceObject>(raw_obj);
+
+    auto root_kids = GetKidsInternal(_obj);
+    root_kids->Append(page_reference);
+    object->SetParent(make_deferred<PageTreeNode>(_obj));
+
+    UpdateKidsCount();
+    InvalidatePageCache();
 }
 
 void PageTree::Remove(types::size_type page_index) {

--- a/src/vanillapdf/semantics/objects/page_tree.h
+++ b/src/vanillapdf/semantics/objects/page_tree.h
@@ -46,10 +46,17 @@ private:
     void InvalidatePageCache();
     void BuildPageCache() const;
 
+    // Page numbers count leaf pages across the whole tree, while Kids arrays
+    // are per node - the two only coincide on a completely flat tree. This
+    // returns the node holding the given page and the position of the page
+    // within its Kids array. Throws when the document has no such page.
+    PageTreeNodePtr FindPageParent(types::size_type page_number, types::size_type& kid_index) const;
+    bool FindPageParentInternal(PageTreeNodePtr node, types::size_type page_number, types::size_type& current_page_number, PageTreeNodePtr& parent_node, types::size_type& kid_index) const;
+
     bool FindPageIndexInternal(PageTreeNodePtr node, syntax::DictionaryObjectPtr page_dict, types::size_type& current_index) const;
     void UpdateKidsCount();
-    syntax::ArrayObjectPtr<syntax::IndirectReferenceObjectPtr> GetKidsInternal();
 
+    static syntax::ArrayObjectPtr<syntax::IndirectReferenceObjectPtr> GetKidsInternal(syntax::DictionaryObjectPtr node_dictionary);
     static types::size_type UpdateKidsCount(PageNodeBasePtr node);
 
 };


### PR DESCRIPTION
## Summary

`PageTree::Remove` and `PageTree::Insert` applied the flat 1-based page number directly to the root `/Kids` array, while `GetPage`, `PageCount` and `FindPageIndex` count leaf pages across the whole tree. The two indexings only coincide on a completely flat page tree, which is why the bug stayed invisible: on a nested tree (e.g. Granizo.pdf, root -> [6-page node, 4-page node]), `RemovePage(1)` deleted the entire 6-page subtree, `RemovePage(3..10)` returned success while removing nothing (the failed array removal was only guarded by an `assert`, compiled out in Release), and `InsertPage` placed pages at the wrong flat position with a `/Parent` entry always pointing at the root.

## Changes

- `PageTree::Remove` and `PageTree::Insert` resolve the flat page number through a new `FindPageParent` traversal (recursive, mirroring `FindPageIndexInternal`) and mutate the `/Kids` array of the node that actually holds the target position; `Insert` sets the new page's `/Parent` to that node, as required by the spec.
- Removal prunes intermediate nodes left empty by the removal (the root always stays) and reports out-of-range page numbers as `OBJECT_MISSING` instead of silently succeeding.
- `Insert` delegates the one-past-the-end position to `Append`, which remains a plain root-level `/Kids` append - the position after the last page always coincides with the end of the root `/Kids` array, and without tree balancing there is no benefit in nesting deeper.
- New `vanillapdf.tools remove_page` command (`-s` source, `-d` destination, `-n` page number, optional `-p` password) that verifies the page count drops by exactly one and reports a clean out-of-range error for invalid page numbers.
- New hand-authored `fixtures/nested-pages.pdf` (root -> two intermediate nodes holding 3 + 2 pages), the minimal in-repo document where flat page numbers diverge from per-node `/Kids` indices.
- Five ctest sanity cases over the in-repo fixtures: nested subtree-boundary removal (the regression case), flat middle removal, first-page removal, only-page removal, and the out-of-range error on an empty document.

## Test plan

- [x] `PageTree.*` unit tests (existing flat-tree coverage) pass
- [x] New `Tools.remove_page.*` ctests pass, including the nested boundary case that fails on the previous implementation
- [x] Manually verified against corpus documents with diverse tree shapes (Granizo.pdf, tracemonkey.pdf, freeculture.pdf, acro6_cg_ue.pdf, encrypted samples); outputs re-validated with `vanillapdf.tools validate`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
