### PR TITLE
fix: Resolve inheritable field type through the /Parent chain

### DIFF
--- a/src/vanillapdf.unittest/fields_test.cpp
+++ b/src/vanillapdf.unittest/fields_test.cpp
@@ -54,6 +54,39 @@ static void InsertIntegerEntry(
     ASSERT_EQ(DictionaryObject_Insert(dict, key, reinterpret_cast<ObjectHandle*>(integer.get()), VANILLAPDF_RV_TRUE), VANILLAPDF_ERROR_SUCCESS);
 }
 
+// Creates an in-memory document, needed to register parent fields as
+// indirect objects
+static void CreateMemoryDocument(
+    HandleGuard<InputOutputStreamHandle, InputOutputStream_Release>& io_stream,
+    HandleGuard<FileHandle, File_Release>& file,
+    HandleGuard<DocumentHandle, Document_Release>& document
+) {
+    ASSERT_EQ(InputOutputStream_CreateFromMemory(io_stream.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(File_CreateStream(io_stream, "temp", file.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Document_CreateFile(file, document.out()), VANILLAPDF_ERROR_SUCCESS);
+}
+
+// Helper to link a child dictionary to its parent through the /Parent entry.
+// /Parent shall be an indirect reference (Table 220), so the parent is first
+// registered as an indirect object within the file.
+static void InsertParentEntry(
+    FileHandle* file,
+    DictionaryObjectHandle* child,
+    DictionaryObjectHandle* parent
+) {
+    HandleGuard<XrefUsedEntryHandle, XrefUsedEntry_Release> parent_entry;
+    ASSERT_EQ(File_AllocateNewEntry(file, parent_entry.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(XrefUsedEntry_SetReference(parent_entry, reinterpret_cast<ObjectHandle*>(parent)), VANILLAPDF_ERROR_SUCCESS);
+
+    HandleGuard<IndirectReferenceObjectHandle, IndirectReferenceObject_Release> parent_reference;
+    ASSERT_EQ(IndirectReferenceObject_Create(parent_reference.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(IndirectReferenceObject_SetReferencedObject(parent_reference, reinterpret_cast<ObjectHandle*>(parent)), VANILLAPDF_ERROR_SUCCESS);
+
+    HandleGuard<NameObjectHandle, NameObject_Release> key;
+    ASSERT_EQ(NameObject_CreateFromDecodedString("Parent", key.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(DictionaryObject_Insert(child, key, reinterpret_cast<ObjectHandle*>(parent_reference.get()), VANILLAPDF_RV_TRUE), VANILLAPDF_ERROR_SUCCESS);
+}
+
 // --- Field base class tests ---
 
 TEST(Field, GetName) {
@@ -144,6 +177,144 @@ TEST(Field, SetFieldFlagsOverwrite) {
     ASSERT_EQ(Field_SetFieldFlags(field, FieldFlags_Multiline), VANILLAPDF_ERROR_SUCCESS);
     ASSERT_EQ(Field_GetFieldFlags(field, &flags), VANILLAPDF_ERROR_SUCCESS);
     EXPECT_EQ(flags, FieldFlags_Multiline);
+}
+
+// --- Field type inheritance tests (Table 220 - /FT is inheritable) ---
+
+TEST(Field, TypeInheritedFromParent) {
+    HandleGuard<InputOutputStreamHandle, InputOutputStream_Release> io_stream;
+    HandleGuard<FileHandle, File_Release> file;
+    HandleGuard<DocumentHandle, Document_Release> document;
+    CreateMemoryDocument(io_stream, file, document);
+
+    HandleGuard<DictionaryObjectHandle, DictionaryObject_Release> parent;
+    CreateFieldDict(parent, "Tx");
+
+    // A terminal field merged into its widget annotation carries no /FT of its own
+    HandleGuard<DictionaryObjectHandle, DictionaryObject_Release> child;
+    ASSERT_EQ(DictionaryObject_Create(child.out()), VANILLAPDF_ERROR_SUCCESS);
+    InsertParentEntry(file, child, parent);
+
+    HandleGuard<FieldHandle, Field_Release> field;
+    ASSERT_EQ(Field_CreateFromDictionary(child, field.out()), VANILLAPDF_ERROR_SUCCESS);
+
+    FieldType type = FieldType_Undefined;
+    ASSERT_EQ(Field_GetType(field, &type), VANILLAPDF_ERROR_SUCCESS);
+    EXPECT_EQ(type, FieldType_Text);
+}
+
+TEST(Field, TypeInheritedFromGrandparent) {
+    HandleGuard<InputOutputStreamHandle, InputOutputStream_Release> io_stream;
+    HandleGuard<FileHandle, File_Release> file;
+    HandleGuard<DocumentHandle, Document_Release> document;
+    CreateMemoryDocument(io_stream, file, document);
+
+    HandleGuard<DictionaryObjectHandle, DictionaryObject_Release> grandparent;
+    CreateFieldDict(grandparent, "Btn");
+
+    HandleGuard<DictionaryObjectHandle, DictionaryObject_Release> parent;
+    ASSERT_EQ(DictionaryObject_Create(parent.out()), VANILLAPDF_ERROR_SUCCESS);
+    InsertParentEntry(file, parent, grandparent);
+
+    HandleGuard<DictionaryObjectHandle, DictionaryObject_Release> child;
+    ASSERT_EQ(DictionaryObject_Create(child.out()), VANILLAPDF_ERROR_SUCCESS);
+    InsertParentEntry(file, child, parent);
+
+    HandleGuard<FieldHandle, Field_Release> field;
+    ASSERT_EQ(Field_CreateFromDictionary(child, field.out()), VANILLAPDF_ERROR_SUCCESS);
+
+    FieldType type = FieldType_Undefined;
+    ASSERT_EQ(Field_GetType(field, &type), VANILLAPDF_ERROR_SUCCESS);
+    EXPECT_EQ(type, FieldType_Button);
+}
+
+TEST(Field, OwnTypeTakesPrecedenceOverParent) {
+    HandleGuard<InputOutputStreamHandle, InputOutputStream_Release> io_stream;
+    HandleGuard<FileHandle, File_Release> file;
+    HandleGuard<DocumentHandle, Document_Release> document;
+    CreateMemoryDocument(io_stream, file, document);
+
+    HandleGuard<DictionaryObjectHandle, DictionaryObject_Release> parent;
+    CreateFieldDict(parent, "Tx");
+
+    HandleGuard<DictionaryObjectHandle, DictionaryObject_Release> child;
+    CreateFieldDict(child, "Ch");
+    InsertParentEntry(file, child, parent);
+
+    HandleGuard<FieldHandle, Field_Release> field;
+    ASSERT_EQ(Field_CreateFromDictionary(child, field.out()), VANILLAPDF_ERROR_SUCCESS);
+
+    FieldType type = FieldType_Undefined;
+    ASSERT_EQ(Field_GetType(field, &type), VANILLAPDF_ERROR_SUCCESS);
+    EXPECT_EQ(type, FieldType_Choice);
+}
+
+TEST(Field, TypeMissingThroughoutChainIsNonTerminal) {
+    HandleGuard<InputOutputStreamHandle, InputOutputStream_Release> io_stream;
+    HandleGuard<FileHandle, File_Release> file;
+    HandleGuard<DocumentHandle, Document_Release> document;
+    CreateMemoryDocument(io_stream, file, document);
+
+    HandleGuard<DictionaryObjectHandle, DictionaryObject_Release> parent;
+    ASSERT_EQ(DictionaryObject_Create(parent.out()), VANILLAPDF_ERROR_SUCCESS);
+
+    HandleGuard<DictionaryObjectHandle, DictionaryObject_Release> child;
+    ASSERT_EQ(DictionaryObject_Create(child.out()), VANILLAPDF_ERROR_SUCCESS);
+    InsertParentEntry(file, child, parent);
+
+    HandleGuard<FieldHandle, Field_Release> field;
+    ASSERT_EQ(Field_CreateFromDictionary(child, field.out()), VANILLAPDF_ERROR_SUCCESS);
+
+    FieldType type = FieldType_Undefined;
+    ASSERT_EQ(Field_GetType(field, &type), VANILLAPDF_ERROR_SUCCESS);
+    EXPECT_EQ(type, FieldType_NonTerminal);
+}
+
+TEST(Field, CyclicParentChainTerminates) {
+    HandleGuard<InputOutputStreamHandle, InputOutputStream_Release> io_stream;
+    HandleGuard<FileHandle, File_Release> file;
+    HandleGuard<DocumentHandle, Document_Release> document;
+    CreateMemoryDocument(io_stream, file, document);
+
+    HandleGuard<DictionaryObjectHandle, DictionaryObject_Release> first;
+    HandleGuard<DictionaryObjectHandle, DictionaryObject_Release> second;
+    ASSERT_EQ(DictionaryObject_Create(first.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(DictionaryObject_Create(second.out()), VANILLAPDF_ERROR_SUCCESS);
+
+    // Neither dictionary declares /FT, so the resolution has to recognize the
+    // cycle and give up instead of looping forever
+    InsertParentEntry(file, first, second);
+    InsertParentEntry(file, second, first);
+
+    HandleGuard<FieldHandle, Field_Release> field;
+    ASSERT_EQ(Field_CreateFromDictionary(first, field.out()), VANILLAPDF_ERROR_SUCCESS);
+
+    FieldType type = FieldType_Undefined;
+    ASSERT_EQ(Field_GetType(field, &type), VANILLAPDF_ERROR_SUCCESS);
+    EXPECT_EQ(type, FieldType_NonTerminal);
+}
+
+TEST(Field, DirectParentEndsResolution) {
+
+    // Table 220 requires /Parent to be an indirect reference. A direct
+    // dictionary in its place is an embedded copy rather than a link to the
+    // actual parent node, so the resolution refuses to follow it.
+    HandleGuard<DictionaryObjectHandle, DictionaryObject_Release> parent;
+    CreateFieldDict(parent, "Tx");
+
+    HandleGuard<DictionaryObjectHandle, DictionaryObject_Release> child;
+    ASSERT_EQ(DictionaryObject_Create(child.out()), VANILLAPDF_ERROR_SUCCESS);
+
+    HandleGuard<NameObjectHandle, NameObject_Release> parent_key;
+    ASSERT_EQ(NameObject_CreateFromDecodedString("Parent", parent_key.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(DictionaryObject_Insert(child, parent_key, reinterpret_cast<ObjectHandle*>(parent.get()), VANILLAPDF_RV_TRUE), VANILLAPDF_ERROR_SUCCESS);
+
+    HandleGuard<FieldHandle, Field_Release> field;
+    ASSERT_EQ(Field_CreateFromDictionary(child, field.out()), VANILLAPDF_ERROR_SUCCESS);
+
+    FieldType type = FieldType_Undefined;
+    ASSERT_EQ(Field_GetType(field, &type), VANILLAPDF_ERROR_SUCCESS);
+    EXPECT_EQ(type, FieldType_NonTerminal);
 }
 
 // --- TextField tests ---

--- a/src/vanillapdf/semantics/objects/fields.cpp
+++ b/src/vanillapdf/semantics/objects/fields.cpp
@@ -8,12 +8,70 @@
 namespace vanillapdf {
 namespace semantics {
 
+bool Field::FindInheritedEntry(
+    const syntax::DictionaryObjectPtr& dictionary,
+    const syntax::NameObject& key,
+    syntax::OutputObjectPtr& result) {
+
+    // Every hop is an indirect reference (see below), so visited parents are
+    // tracked by their object identity, the same way DereferenceHelper guards
+    // a single dereference against cycles.
+    std::map<syntax::IndirectReferenceId, bool> visited;
+
+    syntax::DictionaryObjectPtr current = dictionary;
+
+    for (;;) {
+        if (current->Contains(key)) {
+            result = current->Find(key);
+            return true;
+        }
+
+        if (!current->Contains(constant::Name::Parent)) {
+            return false;
+        }
+
+        // Table 220: /Parent shall be an indirect reference. A direct object
+        // in its place is an embedded copy, not a link - the actual parent
+        // node is reachable from /Fields as an indirect object - so following
+        // it would inspect the wrong dictionary.
+        auto parent_obj = current->Find(constant::Name::Parent);
+        if (!syntax::ObjectUtils::IsType<syntax::IndirectReferenceObjectPtr>(parent_obj)) {
+            spdlog::warn("Field /Parent is not an indirect reference while resolving inherited entry {}", key.ToString());
+            return false;
+        }
+
+        auto parent_reference = syntax::ObjectUtils::ConvertTo<syntax::IndirectReferenceObjectPtr>(parent_obj);
+
+        auto object_number = parent_reference->GetReferencedObjectNumber();
+        auto generation_number = parent_reference->GetReferencedGenerationNumber();
+        syntax::IndirectReferenceId parent_id(object_number, generation_number);
+
+        auto found = visited.find(parent_id);
+        if (found != visited.end() && found->second) {
+            spdlog::warn("Cyclic /Parent chain while resolving inherited entry {}", key.ToString());
+            return false;
+        }
+
+        visited[parent_id] = true;
+
+        current = parent_reference->GetReferencedObjectAs<syntax::DictionaryObjectPtr>();
+    }
+}
+
+bool Field::GetInheritedEntry(const syntax::NameObject& key, syntax::OutputObjectPtr& result) const {
+    return FindInheritedEntry(_obj, key, result);
+}
+
 FieldPtr Field::Create(syntax::DictionaryObjectPtr root) {
-    if (!root->Contains(constant::Name::FT)) {
+
+    // /FT is inheritable - a terminal field merged into its widget annotation
+    // frequently carries the field type only on the parent field
+    syntax::OutputObjectPtr type_entry;
+    if (!FindInheritedEntry(root, constant::Name::FT, type_entry)) {
         return make_deferred<NonTerminalField>(root);
     }
 
-    syntax::ObjectPtr type_obj = root->Find(constant::Name::FT);
+    syntax::ObjectPtr type_obj = type_entry;
     if (!syntax::ObjectUtils::IsType<syntax::NameObjectPtr>(type_obj)) {
         LOG_ERROR_AND_THROW(syntax::ObjectMissingException, "Invalid field type: {}", static_cast<int32_t>(type_obj->GetObjectType()));
     }

--- a/src/vanillapdf/semantics/objects/fields.h
+++ b/src/vanillapdf/semantics/objects/fields.h
@@ -41,6 +41,20 @@ public:
     bool GetAlternateName(syntax::OutputStringObjectPtr& result) const;
     bool GetFieldFlags(types::big_int& result) const;
     void SetFieldFlags(types::big_int value);
+
+protected:
+    // Resolves an inheritable field attribute - /FT, /Ff, /V and /DV per Table 220,
+    // /DA and /Q per 12.7.3.3 - by searching the field dictionary and then walking
+    // the /Parent chain. Returns false when the key is present in none of them.
+    // Each /Parent shall be an indirect reference (Table 220); a chain hop
+    // that is not one ends the search. Visited parent references are tracked
+    // by object identity, so a cyclic chain terminates instead of looping.
+    static bool FindInheritedEntry(
+        const syntax::DictionaryObjectPtr& dictionary,
+        const syntax::NameObject& key,
+        syntax::OutputObjectPtr& result);
+
+    bool GetInheritedEntry(const syntax::NameObject& key, syntax::OutputObjectPtr& result) const;
 };
 
 class NonTerminalField : public Field {

--- a/src/vanillapdf/syntax/utils/syntax_fwd.h
+++ b/src/vanillapdf/syntax/utils/syntax_fwd.h
@@ -123,7 +123,7 @@ using DictionaryObjectBasePtr = DeferredContainer<DictionaryObjectBase<KeyT, Val
 using DictionaryObjectPtr = DeferredContainer<DictionaryObject>; using OutputDictionaryObjectPtr = OutputPointer<DictionaryObjectPtr>;
 using MixedArrayObjectPtr = DeferredContainer<MixedArrayObject>; using OutputMixedArrayObjectPtr = OutputPointer<MixedArrayObjectPtr>;
 
-class ObjectPtr;
+class ObjectPtr; using OutputObjectPtr = OutputPointer<ObjectPtr>;
 class StringObjectPtr; using OutputStringObjectPtr = OutputPointer<StringObjectPtr>;
 //using ObjectPtr = Deferred<Object>;
 using ContainableObjectPtr = Deferred<ContainableObject>; using OutputContainableObjectPtr = OutputPointer<ContainableObjectPtr>;


### PR DESCRIPTION
## Problem

`Field::Create` decided the field type from the `/FT` entry of the field dictionary alone. `/FT` is an **inheritable** attribute (PDF 32000-1:2008, Table 220), so a terminal field that omits it was reported as `FieldType_NonTerminal` instead of its real type.

This is the common case, not an edge case. A single-widget field is usually merged into its widget annotation, and the kids of a radio group carry no `/FT` of their own — both inherit it from the parent field. Any consumer enumerating a form through `FieldCollection` and switching on `Field_GetType` silently skipped them.

## Change

Type resolution now walks the `/Parent` chain. The lookup is a `protected` helper, `Field::FindInheritedEntry`, so the remaining inheritable entries — `/Ff`, `/V`, `/DV` per Table 220, and `/DA`, `/Q` per 12.7.3.3 — can reuse it rather than each reimplementing the walk. It is deliberately not public API: the resolved-field design in #510 decides its eventual surface.

Two properties of the walk, both following the spec rather than adding defensive machinery:

- **Each `/Parent` shall be an indirect reference** (Table 220). A direct object in its place is an embedded copy, not a link to the actual parent node — the real parent is reachable from `/Fields` as an indirect object — so the walk logs a warning and ends the resolution instead of following the wrong dictionary.
- **Cycle handling is exact, with no arbitrary depth limit.** Serialized direct objects always nest as a tree, so a cyclic chain can only be expressed through indirect references. Visited parent references are tracked by object identity (`IndirectReferenceId`), the same way `DereferenceHelper` guards a single dereference, and a repeated reference ends the search.

## Behaviour change

This changes the observable result of `Field_GetType`: a field that inherits `/FT` is no longer reported as `FieldType_NonTerminal`. That is the point of the fix, but it is a visible change to shipped API and worth calling out in review. Under the design agreed in #510, `FieldType_NonTerminal` is on the path to retirement anyway — this fix makes the legacy path correct in the meantime.

## Tests

Six cases added to `fields_test.cpp`: inheritance from a parent, inheritance across two levels, own `/FT` taking precedence, no `/FT` anywhere in the chain, a cyclic chain that must terminate, and a direct (non-reference) `/Parent` that must end resolution. Parent links are built spec-conformantly — a shared helper registers the parent as an indirect object (`File_AllocateNewEntry` + `XrefUsedEntry_SetReference`) and inserts a real `IndirectReferenceObject` as `/Parent`.

Verified with `ctest --preset windows-x64-msvc-18 --build-config Debug`:

- `-R "Field\."` — 22/22 passed (6 new, 16 pre-existing)
- `-R "InteractiveForm\.|SignatureFlags\.|Catalog\.|DigitalSignature\."` — 25/25 passed, covering the other consumers of `Field::Create`

## Context

Groundwork for #510 (flatten the interactive form API to resolved terminal fields) — the inheritance walk introduced here is the seed of the shared resolution helper that #510 and #511 build on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)