### PR TITLE
docs: Substitute the release version into versioned snippets

### DIFF
--- a/doc/sphinx/conf.py
+++ b/doc/sphinx/conf.py
@@ -48,7 +48,15 @@ extensions = [
     "breathe",
     "sphinx_copybutton",
     "sphinxext.opengraph",
+    "sphinx_substitution_extensions",
 ]
+
+# Make |release| resolvable inside literal blocks: code-block directives
+# marked with :substitutions: and the :substitution-code: inline role
+# (sphinx-substitution-extensions) read definitions from rst_prolog.
+rst_prolog = """
+.. |release| replace:: {}
+""".format(_version)
 
 breathe_projects = {
     "vanillapdf": "_build/doxygen/xml",

--- a/doc/sphinx/installation.rst
+++ b/doc/sphinx/installation.rst
@@ -58,6 +58,7 @@ CMake FetchContent
 Self-contained approach without external package managers:
 
 .. code-block:: cmake
+   :substitutions:
 
    cmake_minimum_required(VERSION 3.20)
    project(MyApp)
@@ -66,7 +67,7 @@ Self-contained approach without external package managers:
    FetchContent_Declare(
        vanillapdf
        GIT_REPOSITORY https://github.com/vanillapdf/vanillapdf.git
-       GIT_TAG        main  # or "v2.1.0" for a specific release
+       GIT_TAG        main  # or "v|release|" for a specific release
    )
    FetchContent_MakeAvailable(vanillapdf)
 
@@ -114,13 +115,15 @@ Conan
 Install via `Conan <https://conan.io/>`_:
 
 .. code-block:: bash
+   :substitutions:
 
    pip install conan
-   conan install --requires="vanillapdf/2.3.0" --build=missing
+   conan install --requires="vanillapdf/|release|" --build=missing
 
 Or add a ``conanfile.py`` to your project:
 
 .. code-block:: python
+   :substitutions:
 
    from conan import ConanFile
    from conan.tools.cmake import cmake_layout
@@ -130,7 +133,7 @@ Or add a ``conanfile.py`` to your project:
        generators = "CMakeDeps", "CMakeToolchain"
 
        def requirements(self):
-           self.requires("vanillapdf/2.3.0")
+           self.requires("vanillapdf/|release|")
 
        def layout(self):
            cmake_layout(self)

--- a/doc/sphinx/overview.rst
+++ b/doc/sphinx/overview.rst
@@ -266,7 +266,7 @@ Package availability
      - ``FetchContent_Declare(vanillapdf ...)``
      - No external tools; caller manages dependencies
    * - Conan
-     - ``conan install --requires="vanillapdf/2.3.0"``
+     - :substitution-code:`conan install --requires="vanillapdf/|release|"`
      - Coming soon; not yet on Conan Center
    * - Homebrew
      - ``brew install vanillapdf``

--- a/doc/sphinx/requirements.txt
+++ b/doc/sphinx/requirements.txt
@@ -3,3 +3,4 @@ sphinx-rtd-theme>=3.0,<4
 breathe>=4.35,<5
 sphinx-copybutton>=0.5,<1
 sphinxext-opengraph>=0.9,<1
+sphinx-substitution-extensions>=2024.2,<2026


### PR DESCRIPTION
## Summary

Versioned snippets in the Sphinx docs (the Conan install examples and the FetchContent tag hint) hardcoded the release version, so they went stale on every bump. They now reference `|release|`, which `conf.py` derives from `cmake/version.cmake` — making a version bump a single-file change again.

## Approach

Uses [sphinx-substitution-extensions](https://pypi.org/project/sphinx-substitution-extensions/) (new pinned entry in `doc/sphinx/requirements.txt`), which makes the standard `|release|` substitution work inside literal blocks:

- `code-block` directives opt in explicitly with the `:substitutions:` option, keeping syntax highlighting.
- The inline literal in `overview.rst`'s functionality table uses the `:substitution-code:` role.
- `conf.py` defines `|release|` in `rst_prolog` from the version it already parses out of `cmake/version.cmake`.

The pin `>=2024.2,<2026` resolves to 2025.2.19, the newest version compatible with the existing `sphinx>=7.4,<8` constraint.

## Verification

Built the docs locally with the pinned requirements: all four spots render the current version (`2.3.0`), no unresolved `|release|` tokens leak into the HTML, and syntax highlighting is unchanged. Rebuilt after temporarily setting the minor version to 4 in `cmake/version.cmake` — all four spots followed to `2.4.0` with zero doc edits. Only pre-existing Doxygen/Breathe warnings appear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
