### PR TITLE
ci: Update supported platforms in nightly matrix

### DIFF
--- a/.claude/rules/ci-cd.md
+++ b/.claude/rules/ci-cd.md
@@ -25,7 +25,7 @@
 
 ## Build Matrix
 
-Windows 2022/2025 (x86/x64), Linux Ubuntu 22.04/24.04, Rocky 8/9, Fedora 41/42 (x64/ARM64), macOS 13 (x64), 14/15 (ARM64), Android (arm64, armv7, x86, x86_64)
+Windows 2022/2025 (x86/x64), Windows 11 (ARM64), Linux Ubuntu 22.04/24.04/26.04, Rocky 8/9/10, Fedora 43/44 (x64/ARM64), macOS 15/26 (x64/ARM64)
 
 ## Release Process
 

--- a/.github/workflows/nightly-check.yml
+++ b/.github/workflows/nightly-check.yml
@@ -129,30 +129,6 @@ jobs:
             platform: linux/arm64
             preset: linux-arm64-gcc
 
-          - name: fedora.41-x64
-            os: ubuntu-24.04
-            image: ghcr.io/vanillapdf/vanillapdf-fedora-amd64:41
-            platform: linux/amd64
-            preset: linux-x64-gcc
-
-          - name: fedora.41-arm64
-            os: ubuntu-24.04-arm
-            image: ghcr.io/vanillapdf/vanillapdf-fedora-arm64v8:41
-            platform: linux/arm64
-            preset: linux-arm64-gcc
-
-          - name: fedora.42-x64
-            os: ubuntu-24.04
-            image: ghcr.io/vanillapdf/vanillapdf-fedora-amd64:42
-            platform: linux/amd64
-            preset: linux-x64-gcc
-
-          - name: fedora.42-arm64
-            os: ubuntu-24.04-arm
-            image: ghcr.io/vanillapdf/vanillapdf-fedora-arm64v8:42
-            platform: linux/arm64
-            preset: linux-arm64-gcc
-
           - name: fedora.43-x64
             os: ubuntu-24.04
             image: ghcr.io/vanillapdf/vanillapdf-fedora:43
@@ -162,6 +138,18 @@ jobs:
           - name: fedora.43-arm64
             os: ubuntu-24.04-arm
             image: ghcr.io/vanillapdf/vanillapdf-fedora:43
+            platform: linux/arm64
+            preset: linux-arm64-gcc
+
+          - name: fedora.44-x64
+            os: ubuntu-24.04
+            image: ghcr.io/vanillapdf/vanillapdf-fedora:44
+            platform: linux/amd64
+            preset: linux-x64-gcc
+
+          - name: fedora.44-arm64
+            os: ubuntu-24.04-arm
+            image: ghcr.io/vanillapdf/vanillapdf-fedora:44
             platform: linux/arm64
             preset: linux-arm64-gcc
 
@@ -259,7 +247,6 @@ jobs:
         build_type: [Debug, Release]
 
         config:
-          - { name: "osx.14-arm64", runner: macos-14, preset: "macos-arm64" }
           - { name: "osx.15-x64", runner: macos-15-intel, preset: "macos-x64" }
           - { name: "osx.15-arm64", runner: macos-15, preset: "macos-arm64" }
           - { name: "osx.26-x64", runner: macos-26-intel, preset: "macos-x64" }
@@ -271,7 +258,7 @@ jobs:
           submodules: recursive
 
       # Note: vcpkg caching disabled for macOS weekly scan to reduce cache storage usage.
-      # macOS 14 and 15 have different compiler versions, so caches cannot be shared.
+      # Different macOS versions have different compiler versions, so caches cannot be shared.
 
       - name: Install build tools (macOS)
         run: brew install --quiet autoconf automake autoconf-archive


### PR DESCRIPTION
## Summary

Refreshes the supported platform matrix in the nightly full scan to match current upstream support windows.

- **Fedora**: drop 41 and 42 (both EOL — Fedora 42 reached end of life in May 2026), keep 43, add 44 (x64 + arm64) using the unified `ghcr.io/vanillapdf/vanillapdf-fedora:44` image (already published on GHCR).
- **macOS**: drop the `macos-14` job — the GitHub-hosted runner image entered deprecation on 2026-07-06 and retires on 2026-11-02 ([actions/runner-images#13518](https://github.com/actions/runner-images/issues/13518)). macOS coverage is now 15 and 26, each on both x64 (Intel runners) and arm64.
- Refresh the build matrix summary in `.claude/rules/ci-cd.md` to match the actual matrix (adds Windows 11 ARM64, Ubuntu 26.04, Rocky 10, macOS 26; removes retired macOS 13/14 and the no-longer-present Android CI entry).

Left unchanged after review: Windows 2022/2025 + Windows 11 ARM (all current), Ubuntu 22.04/24.04/26.04 (22.04 runs in our own container on a `ubuntu-24.04` host, so the upcoming `ubuntu-22.04` runner deprecation does not affect it; the OS is supported until April 2027), Rocky 8/9/10 (all in support).

## Test plan

- YAML validated locally.
- `nightly-check.yml` triggers on pull requests that modify it, so this PR runs the full updated matrix as its own verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
