### PR TITLE
build(docs): Upgrade docs toolchain to Sphinx 9

### DIFF
--- a/doc/sphinx/requirements.txt
+++ b/doc/sphinx/requirements.txt
@@ -1,6 +1,6 @@
-sphinx>=7.4,<8
+sphinx>=9,<10
 sphinx-rtd-theme>=3.0,<4
-breathe>=4.35,<5
+breathe>=4.36,<5
 sphinx-copybutton>=0.5,<1
 sphinxext-opengraph>=0.9,<1
-sphinx-substitution-extensions>=2024.2,<2026
+sphinx-substitution-extensions>=2024.2,<2027


### PR DESCRIPTION
## Summary

Upgrade the docs toolchain in `doc/sphinx/requirements.txt` from Sphinx 7.4 to Sphinx 9, bringing every docs dependency to its current latest release:

| Package | Old pin | New pin | Resolves to |
| ------- | ------- | ------- | ----------- |
| sphinx | `>=7.4,<8` | `>=9,<10` | 9.1.0 |
| breathe | `>=4.35,<5` | `>=4.36,<5` | 4.36.0 |
| sphinx-substitution-extensions | `>=2024.2,<2026` | `>=2024.2,<2027` | 2026.8.13.1 |

## Why the `sphinx<8` cap existed

Breathe under-declares its Sphinx constraint: 4.35's metadata allows any Sphinx `>=4.0`, but it predates and breaks at runtime with newer Sphinx majors. The old cap kept pip from pairing them. Raising the breathe floor to 4.36 (`Sphinx>=7.2`, actively resolvable with 8/9) addresses the same hazard from the other side, so every combination pip can resolve actually works.

## Verification

Full local docs builds in fresh venvs: Sphinx 9.1.0 exits 0 and produces exactly the same set of 218 unique Sphinx-level warnings as the 7.4 baseline on identical sources — zero new warnings, which matters because Read the Docs builds with `fail_on_warning: true`. The `|release|` substitutions from #515 render correctly (no leaked tokens, syntax highlighting intact), and RTD's Python 3.14 satisfies Sphinx 9's floor. RTD's older Doxygen produces a different warning baseline than the local Doxygen 1.18, so the RTD build on this PR is the definitive check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
