### PR TITLE
fix: Support real-number rectangle coordinates

### DIFF
--- a/include/vanillapdf/semantics/c_rectangle.h
+++ b/include/vanillapdf/semantics/c_rectangle.h
@@ -34,43 +34,91 @@ extern "C"
 
     /**
     * \brief Get X-coordinate of lower-left corner
+    * \deprecated Rectangle coordinates are real numbers and fractional values are truncated. Use \ref Rectangle_GetLowerLeftXReal instead.
     */
-    VANILLAPDF_API error_type CALLING_CONVENTION Rectangle_GetLowerLeftX(RectangleHandle* handle, bigint_type* result);
+    VANILLAPDF_DEPRECATED VANILLAPDF_API error_type CALLING_CONVENTION Rectangle_GetLowerLeftX(RectangleHandle* handle, bigint_type* result);
+
+    /**
+    * \brief Get X-coordinate of lower-left corner
+    */
+    VANILLAPDF_API error_type CALLING_CONVENTION Rectangle_GetLowerLeftXReal(RectangleHandle* handle, real_type* result);
+
+    /**
+    * \brief Set X-coordinate of lower-left corner
+    * \deprecated Rectangle coordinates are real numbers. Use \ref Rectangle_SetLowerLeftXReal instead.
+    */
+    VANILLAPDF_DEPRECATED VANILLAPDF_API error_type CALLING_CONVENTION Rectangle_SetLowerLeftX(RectangleHandle* handle, bigint_type data);
 
     /**
     * \brief Set X-coordinate of lower-left corner
     */
-    VANILLAPDF_API error_type CALLING_CONVENTION Rectangle_SetLowerLeftX(RectangleHandle* handle, bigint_type data);
+    VANILLAPDF_API error_type CALLING_CONVENTION Rectangle_SetLowerLeftXReal(RectangleHandle* handle, real_type data);
+
+    /**
+    * \brief Get Y-coordinate of lower-left corner
+    * \deprecated Rectangle coordinates are real numbers and fractional values are truncated. Use \ref Rectangle_GetLowerLeftYReal instead.
+    */
+    VANILLAPDF_DEPRECATED VANILLAPDF_API error_type CALLING_CONVENTION Rectangle_GetLowerLeftY(RectangleHandle* handle, bigint_type* result);
 
     /**
     * \brief Get Y-coordinate of lower-left corner
     */
-    VANILLAPDF_API error_type CALLING_CONVENTION Rectangle_GetLowerLeftY(RectangleHandle* handle, bigint_type* result);
+    VANILLAPDF_API error_type CALLING_CONVENTION Rectangle_GetLowerLeftYReal(RectangleHandle* handle, real_type* result);
+
+    /**
+    * \brief Set Y-coordinate of lower-left corner
+    * \deprecated Rectangle coordinates are real numbers. Use \ref Rectangle_SetLowerLeftYReal instead.
+    */
+    VANILLAPDF_DEPRECATED VANILLAPDF_API error_type CALLING_CONVENTION Rectangle_SetLowerLeftY(RectangleHandle* handle, bigint_type data);
 
     /**
     * \brief Set Y-coordinate of lower-left corner
     */
-    VANILLAPDF_API error_type CALLING_CONVENTION Rectangle_SetLowerLeftY(RectangleHandle* handle, bigint_type data);
+    VANILLAPDF_API error_type CALLING_CONVENTION Rectangle_SetLowerLeftYReal(RectangleHandle* handle, real_type data);
+
+    /**
+    * \brief Get X-coordinate of upper-right corner
+    * \deprecated Rectangle coordinates are real numbers and fractional values are truncated. Use \ref Rectangle_GetUpperRightXReal instead.
+    */
+    VANILLAPDF_DEPRECATED VANILLAPDF_API error_type CALLING_CONVENTION Rectangle_GetUpperRightX(RectangleHandle* handle, bigint_type* result);
 
     /**
     * \brief Get X-coordinate of upper-right corner
     */
-    VANILLAPDF_API error_type CALLING_CONVENTION Rectangle_GetUpperRightX(RectangleHandle* handle, bigint_type* result);
+    VANILLAPDF_API error_type CALLING_CONVENTION Rectangle_GetUpperRightXReal(RectangleHandle* handle, real_type* result);
+
+    /**
+    * \brief Set X-coordinate of upper-right corner
+    * \deprecated Rectangle coordinates are real numbers. Use \ref Rectangle_SetUpperRightXReal instead.
+    */
+    VANILLAPDF_DEPRECATED VANILLAPDF_API error_type CALLING_CONVENTION Rectangle_SetUpperRightX(RectangleHandle* handle, bigint_type data);
 
     /**
     * \brief Set X-coordinate of upper-right corner
     */
-    VANILLAPDF_API error_type CALLING_CONVENTION Rectangle_SetUpperRightX(RectangleHandle* handle, bigint_type data);
+    VANILLAPDF_API error_type CALLING_CONVENTION Rectangle_SetUpperRightXReal(RectangleHandle* handle, real_type data);
+
+    /**
+    * \brief Get Y-coordinate of upper-right corner
+    * \deprecated Rectangle coordinates are real numbers and fractional values are truncated. Use \ref Rectangle_GetUpperRightYReal instead.
+    */
+    VANILLAPDF_DEPRECATED VANILLAPDF_API error_type CALLING_CONVENTION Rectangle_GetUpperRightY(RectangleHandle* handle, bigint_type* result);
 
     /**
     * \brief Get Y-coordinate of upper-right corner
     */
-    VANILLAPDF_API error_type CALLING_CONVENTION Rectangle_GetUpperRightY(RectangleHandle* handle, bigint_type* result);
+    VANILLAPDF_API error_type CALLING_CONVENTION Rectangle_GetUpperRightYReal(RectangleHandle* handle, real_type* result);
+
+    /**
+    * \brief Set Y-coordinate of upper-right corner
+    * \deprecated Rectangle coordinates are real numbers. Use \ref Rectangle_SetUpperRightYReal instead.
+    */
+    VANILLAPDF_DEPRECATED VANILLAPDF_API error_type CALLING_CONVENTION Rectangle_SetUpperRightY(RectangleHandle* handle, bigint_type data);
 
     /**
     * \brief Set Y-coordinate of upper-right corner
     */
-    VANILLAPDF_API error_type CALLING_CONVENTION Rectangle_SetUpperRightY(RectangleHandle* handle, bigint_type data);
+    VANILLAPDF_API error_type CALLING_CONVENTION Rectangle_SetUpperRightYReal(RectangleHandle* handle, real_type data);
 
     /**
     * \brief Reinterpret current object as \ref IUnknownHandle

--- a/src/vanillapdf.test/documents.c
+++ b/src/vanillapdf.test/documents.c
@@ -352,23 +352,23 @@ error_type process_resource_dictionary(ResourceDictionaryHandle* obj, int nested
 }
 
 error_type process_rectangle(RectangleHandle* obj, int nested) {
-    bigint_type lower_left_x = 0;
-    bigint_type lower_left_y = 0;
-    bigint_type upper_right_x = 0;
-    bigint_type upper_right_y = 0;
+    real_type lower_left_x = 0;
+    real_type lower_left_y = 0;
+    real_type upper_right_x = 0;
+    real_type upper_right_y = 0;
 
     print_spaces(nested);
     print_text("Rectangle begin\n");
 
-    RETURN_ERROR_IF_NOT_SUCCESS(Rectangle_GetLowerLeftX(obj, &lower_left_x));
-    RETURN_ERROR_IF_NOT_SUCCESS(Rectangle_GetLowerLeftY(obj, &lower_left_y));
-    RETURN_ERROR_IF_NOT_SUCCESS(Rectangle_GetUpperRightX(obj, &upper_right_x));
-    RETURN_ERROR_IF_NOT_SUCCESS(Rectangle_GetUpperRightY(obj, &upper_right_y));
+    RETURN_ERROR_IF_NOT_SUCCESS(Rectangle_GetLowerLeftXReal(obj, &lower_left_x));
+    RETURN_ERROR_IF_NOT_SUCCESS(Rectangle_GetLowerLeftYReal(obj, &lower_left_y));
+    RETURN_ERROR_IF_NOT_SUCCESS(Rectangle_GetUpperRightXReal(obj, &upper_right_x));
+    RETURN_ERROR_IF_NOT_SUCCESS(Rectangle_GetUpperRightYReal(obj, &upper_right_y));
 
-    print_spaces(nested + 1); print_text("Lower left X: %lld\n", lower_left_x);
-    print_spaces(nested + 1); print_text("Lower left Y: %lld\n", lower_left_y);
-    print_spaces(nested + 1); print_text("Upper right X: %lld\n", upper_right_x);
-    print_spaces(nested + 1); print_text("Upper right Y: %lld\n", upper_right_y);
+    print_spaces(nested + 1); print_text("Lower left X: %g\n", lower_left_x);
+    print_spaces(nested + 1); print_text("Lower left Y: %g\n", lower_left_y);
+    print_spaces(nested + 1); print_text("Upper right X: %g\n", upper_right_x);
+    print_spaces(nested + 1); print_text("Upper right Y: %g\n", upper_right_y);
 
     print_spaces(nested);
     print_text("Rectangle end\n");

--- a/src/vanillapdf.unittest/annotations_creation_test.cpp
+++ b/src/vanillapdf.unittest/annotations_creation_test.cpp
@@ -12,10 +12,10 @@ TEST(TextAnnotation, CreateBasic) {
     ASSERT_EQ(Rectangle_Create(&rect), VANILLAPDF_ERROR_SUCCESS);
     ASSERT_NE(rect, nullptr);
 
-    ASSERT_EQ(Rectangle_SetLowerLeftX(rect, 100), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetLowerLeftY(rect, 700), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetUpperRightX(rect, 200), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetUpperRightY(rect, 750), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetLowerLeftXReal(rect, 100), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetLowerLeftYReal(rect, 700), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetUpperRightXReal(rect, 200), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetUpperRightYReal(rect, 750), VANILLAPDF_ERROR_SUCCESS);
 
     // Create text annotation
     ASSERT_EQ(TextAnnotation_Create(rect, &annot), VANILLAPDF_ERROR_SUCCESS);
@@ -45,10 +45,10 @@ TEST(TextAnnotation, CreateWithContents) {
     ASSERT_EQ(Rectangle_Create(&rect), VANILLAPDF_ERROR_SUCCESS);
     ASSERT_NE(rect, nullptr);
 
-    ASSERT_EQ(Rectangle_SetLowerLeftX(rect, 100), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetLowerLeftY(rect, 700), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetUpperRightX(rect, 200), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetUpperRightY(rect, 750), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetLowerLeftXReal(rect, 100), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetLowerLeftYReal(rect, 700), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetUpperRightXReal(rect, 200), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetUpperRightYReal(rect, 750), VANILLAPDF_ERROR_SUCCESS);
 
     // Create contents string
     const char* text = "This is a test comment";
@@ -85,10 +85,10 @@ TEST(HighlightAnnotation, CreateWithQuadPoints) {
     ASSERT_EQ(Rectangle_Create(&rect), VANILLAPDF_ERROR_SUCCESS);
     ASSERT_NE(rect, nullptr);
 
-    ASSERT_EQ(Rectangle_SetLowerLeftX(rect, 100), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetLowerLeftY(rect, 700), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetUpperRightX(rect, 200), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetUpperRightY(rect, 750), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetLowerLeftXReal(rect, 100), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetLowerLeftYReal(rect, 700), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetUpperRightXReal(rect, 200), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetUpperRightYReal(rect, 750), VANILLAPDF_ERROR_SUCCESS);
 
     // Create quad points array (8 numbers for one quadrilateral)
     ASSERT_EQ(ArrayObject_Create(&quad_points), VANILLAPDF_ERROR_SUCCESS);
@@ -138,10 +138,10 @@ TEST(FreeTextAnnotation, CreateWithDefaultAppearance) {
     ASSERT_EQ(Rectangle_Create(&rect), VANILLAPDF_ERROR_SUCCESS);
     ASSERT_NE(rect, nullptr);
 
-    ASSERT_EQ(Rectangle_SetLowerLeftX(rect, 100), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetLowerLeftY(rect, 700), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetUpperRightX(rect, 300), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetUpperRightY(rect, 750), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetLowerLeftXReal(rect, 100), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetLowerLeftYReal(rect, 700), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetUpperRightXReal(rect, 300), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetUpperRightYReal(rect, 750), VANILLAPDF_ERROR_SUCCESS);
 
     // Create contents and default appearance strings
     ASSERT_EQ(LiteralStringObject_CreateFromDecodedString("Free text content", &contents), VANILLAPDF_ERROR_SUCCESS);
@@ -211,10 +211,10 @@ TEST(PageAnnotations, AppendAnnotation) {
     // Set media box
     RectangleHandle* media_box = nullptr;
     ASSERT_EQ(Rectangle_Create(&media_box), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetLowerLeftX(media_box, 0), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetLowerLeftY(media_box, 0), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetUpperRightX(media_box, 612), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetUpperRightY(media_box, 792), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetLowerLeftXReal(media_box, 0), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetLowerLeftYReal(media_box, 0), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetUpperRightXReal(media_box, 612), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetUpperRightYReal(media_box, 792), VANILLAPDF_ERROR_SUCCESS);
     ASSERT_EQ(PageObject_SetMediaBox(page, media_box), VANILLAPDF_ERROR_SUCCESS);
 
     // Append page to tree
@@ -227,10 +227,10 @@ TEST(PageAnnotations, AppendAnnotation) {
 
     // Create rectangle for annotation
     ASSERT_EQ(Rectangle_Create(&rect), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetLowerLeftX(rect, 100), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetLowerLeftY(rect, 700), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetUpperRightX(rect, 200), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetUpperRightY(rect, 750), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetLowerLeftXReal(rect, 100), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetLowerLeftYReal(rect, 700), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetUpperRightXReal(rect, 200), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetUpperRightYReal(rect, 750), VANILLAPDF_ERROR_SUCCESS);
 
     // Create text annotation
     ASSERT_EQ(TextAnnotation_Create(rect, &text_annot), VANILLAPDF_ERROR_SUCCESS);
@@ -311,10 +311,10 @@ TEST(AnnotationIntegration, CreateAndSave) {
     // Set media box
     RectangleHandle* media_box = nullptr;
     ASSERT_EQ(Rectangle_Create(&media_box), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetLowerLeftX(media_box, 0), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetLowerLeftY(media_box, 0), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetUpperRightX(media_box, 612), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetUpperRightY(media_box, 792), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetLowerLeftXReal(media_box, 0), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetLowerLeftYReal(media_box, 0), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetUpperRightXReal(media_box, 612), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetUpperRightYReal(media_box, 792), VANILLAPDF_ERROR_SUCCESS);
     ASSERT_EQ(PageObject_SetMediaBox(page, media_box), VANILLAPDF_ERROR_SUCCESS);
 
     // Append page to tree
@@ -327,10 +327,10 @@ TEST(AnnotationIntegration, CreateAndSave) {
 
     // Create rectangle for annotation
     ASSERT_EQ(Rectangle_Create(&rect), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetLowerLeftX(rect, 100), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetLowerLeftY(rect, 700), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetUpperRightX(rect, 200), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetUpperRightY(rect, 750), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetLowerLeftXReal(rect, 100), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetLowerLeftYReal(rect, 700), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetUpperRightXReal(rect, 200), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetUpperRightYReal(rect, 750), VANILLAPDF_ERROR_SUCCESS);
 
     // Create contents string
     ASSERT_EQ(LiteralStringObject_CreateFromDecodedString("Test annotation", &contents), VANILLAPDF_ERROR_SUCCESS);
@@ -446,10 +446,10 @@ TEST(AnnotationIntegration, CreateAndSaveToSeparateStream) {
     // Set media box
     RectangleHandle* media_box = nullptr;
     ASSERT_EQ(Rectangle_Create(&media_box), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetLowerLeftX(media_box, 0), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetLowerLeftY(media_box, 0), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetUpperRightX(media_box, 612), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetUpperRightY(media_box, 792), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetLowerLeftXReal(media_box, 0), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetLowerLeftYReal(media_box, 0), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetUpperRightXReal(media_box, 612), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetUpperRightYReal(media_box, 792), VANILLAPDF_ERROR_SUCCESS);
     ASSERT_EQ(PageObject_SetMediaBox(page, media_box), VANILLAPDF_ERROR_SUCCESS);
 
     // Append page to tree
@@ -462,10 +462,10 @@ TEST(AnnotationIntegration, CreateAndSaveToSeparateStream) {
 
     // Create rectangle for annotation
     ASSERT_EQ(Rectangle_Create(&rect), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetLowerLeftX(rect, 100), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetLowerLeftY(rect, 700), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetUpperRightX(rect, 200), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetUpperRightY(rect, 750), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetLowerLeftXReal(rect, 100), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetLowerLeftYReal(rect, 700), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetUpperRightXReal(rect, 200), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetUpperRightYReal(rect, 750), VANILLAPDF_ERROR_SUCCESS);
 
     // Create contents string
     ASSERT_EQ(LiteralStringObject_CreateFromDecodedString("Test annotation", &contents), VANILLAPDF_ERROR_SUCCESS);
@@ -550,14 +550,14 @@ TEST(Annotation, GetAndSetRect) {
     AnnotationHandle* base_annot = nullptr;
     RectangleHandle* retrieved_rect = nullptr;
     RectangleHandle* new_rect = nullptr;
-    bigint_type value = 0;
+    real_type value = 0;
 
     // Create rectangle
     ASSERT_EQ(Rectangle_Create(&rect), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetLowerLeftX(rect, 100), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetLowerLeftY(rect, 200), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetUpperRightX(rect, 300), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetUpperRightY(rect, 400), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetLowerLeftXReal(rect, 100), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetLowerLeftYReal(rect, 200), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetUpperRightXReal(rect, 300), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetUpperRightYReal(rect, 400), VANILLAPDF_ERROR_SUCCESS);
 
     // Create annotation
     ASSERT_EQ(TextAnnotation_Create(rect, &annot), VANILLAPDF_ERROR_SUCCESS);
@@ -567,15 +567,15 @@ TEST(Annotation, GetAndSetRect) {
     ASSERT_EQ(Annotation_GetRect(base_annot, &retrieved_rect), VANILLAPDF_ERROR_SUCCESS);
     ASSERT_NE(retrieved_rect, nullptr);
 
-    ASSERT_EQ(Rectangle_GetLowerLeftX(retrieved_rect, &value), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_GetLowerLeftXReal(retrieved_rect, &value), VANILLAPDF_ERROR_SUCCESS);
     EXPECT_EQ(value, 100);
 
     // Set new rect
     ASSERT_EQ(Rectangle_Create(&new_rect), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetLowerLeftX(new_rect, 50), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetLowerLeftY(new_rect, 60), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetUpperRightX(new_rect, 150), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetUpperRightY(new_rect, 160), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetLowerLeftXReal(new_rect, 50), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetLowerLeftYReal(new_rect, 60), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetUpperRightXReal(new_rect, 150), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetUpperRightYReal(new_rect, 160), VANILLAPDF_ERROR_SUCCESS);
 
     ASSERT_EQ(Annotation_SetRect(base_annot, new_rect), VANILLAPDF_ERROR_SUCCESS);
 
@@ -596,10 +596,10 @@ TEST(Annotation, SetContents) {
 
     // Create rectangle and annotation
     ASSERT_EQ(Rectangle_Create(&rect), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetLowerLeftX(rect, 100), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetLowerLeftY(rect, 700), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetUpperRightX(rect, 200), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetUpperRightY(rect, 750), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetLowerLeftXReal(rect, 100), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetLowerLeftYReal(rect, 700), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetUpperRightXReal(rect, 200), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetUpperRightYReal(rect, 750), VANILLAPDF_ERROR_SUCCESS);
 
     ASSERT_EQ(TextAnnotation_Create(rect, &annot), VANILLAPDF_ERROR_SUCCESS);
     ASSERT_EQ(TextAnnotation_ToBaseAnnotation(annot, &base_annot), VANILLAPDF_ERROR_SUCCESS);
@@ -630,10 +630,10 @@ TEST(Annotation, GetAndSetColor) {
 
     // Create rectangle and annotation
     ASSERT_EQ(Rectangle_Create(&rect), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetLowerLeftX(rect, 100), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetLowerLeftY(rect, 700), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetUpperRightX(rect, 200), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetUpperRightY(rect, 750), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetLowerLeftXReal(rect, 100), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetLowerLeftYReal(rect, 700), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetUpperRightXReal(rect, 200), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetUpperRightYReal(rect, 750), VANILLAPDF_ERROR_SUCCESS);
 
     ASSERT_EQ(TextAnnotation_Create(rect, &annot), VANILLAPDF_ERROR_SUCCESS);
     ASSERT_EQ(TextAnnotation_ToBaseAnnotation(annot, &base_annot), VANILLAPDF_ERROR_SUCCESS);
@@ -666,10 +666,10 @@ TEST(TextAnnotation, GetAndSetAuthor) {
 
     // Create rectangle and annotation
     ASSERT_EQ(Rectangle_Create(&rect), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetLowerLeftX(rect, 100), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetLowerLeftY(rect, 700), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetUpperRightX(rect, 200), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetUpperRightY(rect, 750), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetLowerLeftXReal(rect, 100), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetLowerLeftYReal(rect, 700), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetUpperRightXReal(rect, 200), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetUpperRightYReal(rect, 750), VANILLAPDF_ERROR_SUCCESS);
 
     ASSERT_EQ(TextAnnotation_Create(rect, &annot), VANILLAPDF_ERROR_SUCCESS);
 
@@ -699,10 +699,10 @@ TEST(TextAnnotation, GetAndSetModificationDate) {
 
     // Create rectangle and annotation
     ASSERT_EQ(Rectangle_Create(&rect), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetLowerLeftX(rect, 100), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetLowerLeftY(rect, 700), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetUpperRightX(rect, 200), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetUpperRightY(rect, 750), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetLowerLeftXReal(rect, 100), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetLowerLeftYReal(rect, 700), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetUpperRightXReal(rect, 200), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetUpperRightYReal(rect, 750), VANILLAPDF_ERROR_SUCCESS);
 
     ASSERT_EQ(TextAnnotation_Create(rect, &annot), VANILLAPDF_ERROR_SUCCESS);
 
@@ -734,10 +734,10 @@ TEST(TextAnnotation, GetAndSetCreationDate) {
 
     // Create rectangle and annotation
     ASSERT_EQ(Rectangle_Create(&rect), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetLowerLeftX(rect, 100), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetLowerLeftY(rect, 700), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetUpperRightX(rect, 200), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetUpperRightY(rect, 750), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetLowerLeftXReal(rect, 100), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetLowerLeftYReal(rect, 700), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetUpperRightXReal(rect, 200), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetUpperRightYReal(rect, 750), VANILLAPDF_ERROR_SUCCESS);
 
     ASSERT_EQ(TextAnnotation_Create(rect, &annot), VANILLAPDF_ERROR_SUCCESS);
 
@@ -768,10 +768,10 @@ TEST(Annotation, GetAndSetFlags) {
 
     // Create rectangle and annotation
     ASSERT_EQ(Rectangle_Create(&rect), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetLowerLeftX(rect, 100), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetLowerLeftY(rect, 700), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetUpperRightX(rect, 200), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetUpperRightY(rect, 750), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetLowerLeftXReal(rect, 100), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetLowerLeftYReal(rect, 700), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetUpperRightXReal(rect, 200), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetUpperRightYReal(rect, 750), VANILLAPDF_ERROR_SUCCESS);
 
     ASSERT_EQ(TextAnnotation_Create(rect, &annot), VANILLAPDF_ERROR_SUCCESS);
     ASSERT_EQ(TextAnnotation_ToBaseAnnotation(annot, &base_annot), VANILLAPDF_ERROR_SUCCESS);
@@ -801,10 +801,10 @@ TEST(Annotation, ToAndFromUnknown) {
 
     // Create rectangle and annotation
     ASSERT_EQ(Rectangle_Create(&rect), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetLowerLeftX(rect, 100), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetLowerLeftY(rect, 700), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetUpperRightX(rect, 200), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetUpperRightY(rect, 750), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetLowerLeftXReal(rect, 100), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetLowerLeftYReal(rect, 700), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetUpperRightXReal(rect, 200), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetUpperRightYReal(rect, 750), VANILLAPDF_ERROR_SUCCESS);
 
     ASSERT_EQ(TextAnnotation_Create(rect, &annot), VANILLAPDF_ERROR_SUCCESS);
     ASSERT_EQ(TextAnnotation_ToBaseAnnotation(annot, &base_annot), VANILLAPDF_ERROR_SUCCESS);
@@ -837,10 +837,10 @@ TEST(TextAnnotation, FromBaseAnnotation) {
 
     // Create rectangle and annotation
     ASSERT_EQ(Rectangle_Create(&rect), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetLowerLeftX(rect, 100), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetLowerLeftY(rect, 700), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetUpperRightX(rect, 200), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetUpperRightY(rect, 750), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetLowerLeftXReal(rect, 100), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetLowerLeftYReal(rect, 700), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetUpperRightXReal(rect, 200), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetUpperRightYReal(rect, 750), VANILLAPDF_ERROR_SUCCESS);
 
     ASSERT_EQ(TextAnnotation_Create(rect, &annot), VANILLAPDF_ERROR_SUCCESS);
     ASSERT_EQ(TextAnnotation_ToBaseAnnotation(annot, &base_annot), VANILLAPDF_ERROR_SUCCESS);
@@ -866,10 +866,10 @@ TEST(HighlightAnnotation, GetAndSetQuadPoints) {
 
     // Create rectangle
     ASSERT_EQ(Rectangle_Create(&rect), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetLowerLeftX(rect, 100), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetLowerLeftY(rect, 700), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetUpperRightX(rect, 200), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetUpperRightY(rect, 750), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetLowerLeftXReal(rect, 100), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetLowerLeftYReal(rect, 700), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetUpperRightXReal(rect, 200), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetUpperRightYReal(rect, 750), VANILLAPDF_ERROR_SUCCESS);
 
     // Create quad points array
     ASSERT_EQ(ArrayObject_Create(&quad_points), VANILLAPDF_ERROR_SUCCESS);
@@ -930,10 +930,10 @@ TEST(HighlightAnnotation, FromBaseAnnotation) {
 
     // Create rectangle
     ASSERT_EQ(Rectangle_Create(&rect), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetLowerLeftX(rect, 100), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetLowerLeftY(rect, 700), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetUpperRightX(rect, 200), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetUpperRightY(rect, 750), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetLowerLeftXReal(rect, 100), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetLowerLeftYReal(rect, 700), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetUpperRightXReal(rect, 200), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetUpperRightYReal(rect, 750), VANILLAPDF_ERROR_SUCCESS);
 
     // Create quad points array
     ASSERT_EQ(ArrayObject_Create(&quad_points), VANILLAPDF_ERROR_SUCCESS);
@@ -975,10 +975,10 @@ TEST(FreeTextAnnotation, SetDefaultAppearance) {
 
     // Create rectangle
     ASSERT_EQ(Rectangle_Create(&rect), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetLowerLeftX(rect, 100), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetLowerLeftY(rect, 700), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetUpperRightX(rect, 300), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetUpperRightY(rect, 750), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetLowerLeftXReal(rect, 100), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetLowerLeftYReal(rect, 700), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetUpperRightXReal(rect, 300), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetUpperRightYReal(rect, 750), VANILLAPDF_ERROR_SUCCESS);
 
     // Create strings
     ASSERT_EQ(LiteralStringObject_CreateFromDecodedString("Free text content", &contents), VANILLAPDF_ERROR_SUCCESS);
@@ -1014,10 +1014,10 @@ TEST(FreeTextAnnotation, FromBaseAnnotation) {
 
     // Create rectangle
     ASSERT_EQ(Rectangle_Create(&rect), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetLowerLeftX(rect, 100), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetLowerLeftY(rect, 700), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetUpperRightX(rect, 300), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetUpperRightY(rect, 750), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetLowerLeftXReal(rect, 100), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetLowerLeftYReal(rect, 700), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetUpperRightXReal(rect, 300), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetUpperRightYReal(rect, 750), VANILLAPDF_ERROR_SUCCESS);
 
     // Create strings
     ASSERT_EQ(LiteralStringObject_CreateFromDecodedString("Free text content", &contents), VANILLAPDF_ERROR_SUCCESS);
@@ -1064,10 +1064,10 @@ TEST(PageAnnotations, ToAndFromUnknown) {
     // Set media box
     RectangleHandle* media_box = nullptr;
     ASSERT_EQ(Rectangle_Create(&media_box), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetLowerLeftX(media_box, 0), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetLowerLeftY(media_box, 0), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetUpperRightX(media_box, 612), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetUpperRightY(media_box, 792), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetLowerLeftXReal(media_box, 0), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetLowerLeftYReal(media_box, 0), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetUpperRightXReal(media_box, 612), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetUpperRightYReal(media_box, 792), VANILLAPDF_ERROR_SUCCESS);
     ASSERT_EQ(PageObject_SetMediaBox(page, media_box), VANILLAPDF_ERROR_SUCCESS);
 
     ASSERT_EQ(PageTree_AppendPage(page_tree, page), VANILLAPDF_ERROR_SUCCESS);
@@ -1106,10 +1106,10 @@ TEST(UnderlineAnnotation, CreateWithQuadPoints) {
 
     // Create rectangle
     ASSERT_EQ(Rectangle_Create(&rect), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetLowerLeftX(rect, 100), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetLowerLeftY(rect, 700), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetUpperRightX(rect, 200), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetUpperRightY(rect, 750), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetLowerLeftXReal(rect, 100), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetLowerLeftYReal(rect, 700), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetUpperRightXReal(rect, 200), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetUpperRightYReal(rect, 750), VANILLAPDF_ERROR_SUCCESS);
 
     // Create quad points array
     ASSERT_EQ(ArrayObject_Create(&quad_points), VANILLAPDF_ERROR_SUCCESS);
@@ -1164,10 +1164,10 @@ TEST(StrikeOutAnnotation, CreateWithQuadPoints) {
 
     // Create rectangle
     ASSERT_EQ(Rectangle_Create(&rect), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetLowerLeftX(rect, 100), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetLowerLeftY(rect, 700), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetUpperRightX(rect, 200), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetUpperRightY(rect, 750), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetLowerLeftXReal(rect, 100), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetLowerLeftYReal(rect, 700), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetUpperRightXReal(rect, 200), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetUpperRightYReal(rect, 750), VANILLAPDF_ERROR_SUCCESS);
 
     // Create quad points array
     ASSERT_EQ(ArrayObject_Create(&quad_points), VANILLAPDF_ERROR_SUCCESS);
@@ -1210,10 +1210,10 @@ TEST(SquigglyAnnotation, CreateWithQuadPoints) {
 
     // Create rectangle
     ASSERT_EQ(Rectangle_Create(&rect), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetLowerLeftX(rect, 100), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetLowerLeftY(rect, 700), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetUpperRightX(rect, 200), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetUpperRightY(rect, 750), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetLowerLeftXReal(rect, 100), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetLowerLeftYReal(rect, 700), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetUpperRightXReal(rect, 200), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetUpperRightYReal(rect, 750), VANILLAPDF_ERROR_SUCCESS);
 
     // Create quad points array
     ASSERT_EQ(ArrayObject_Create(&quad_points), VANILLAPDF_ERROR_SUCCESS);
@@ -1257,10 +1257,10 @@ TEST(InkAnnotation, CreateWithInkList) {
 
     // Create rectangle
     ASSERT_EQ(Rectangle_Create(&rect), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetLowerLeftX(rect, 100), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetLowerLeftY(rect, 700), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetUpperRightX(rect, 200), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetUpperRightY(rect, 750), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetLowerLeftXReal(rect, 100), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetLowerLeftYReal(rect, 700), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetUpperRightXReal(rect, 200), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetUpperRightYReal(rect, 750), VANILLAPDF_ERROR_SUCCESS);
 
     // Create ink list (array of stroke arrays)
     ASSERT_EQ(ArrayObject_Create(&ink_list), VANILLAPDF_ERROR_SUCCESS);
@@ -1342,10 +1342,10 @@ TEST(PageAnnotations, RemoveAnnotation) {
     ASSERT_EQ(PageObject_CreateFromDocument(doc, &page), VANILLAPDF_ERROR_SUCCESS);
     RectangleHandle* media_box = nullptr;
     ASSERT_EQ(Rectangle_Create(&media_box), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetLowerLeftX(media_box, 0), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetLowerLeftY(media_box, 0), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetUpperRightX(media_box, 612), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetUpperRightY(media_box, 792), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetLowerLeftXReal(media_box, 0), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetLowerLeftYReal(media_box, 0), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetUpperRightXReal(media_box, 612), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetUpperRightYReal(media_box, 792), VANILLAPDF_ERROR_SUCCESS);
     ASSERT_EQ(PageObject_SetMediaBox(page, media_box), VANILLAPDF_ERROR_SUCCESS);
     ASSERT_EQ(PageTree_AppendPage(page_tree, page), VANILLAPDF_ERROR_SUCCESS);
 
@@ -1355,10 +1355,10 @@ TEST(PageAnnotations, RemoveAnnotation) {
 
     // Create rectangle for annotations
     ASSERT_EQ(Rectangle_Create(&rect), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetLowerLeftX(rect, 100), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetLowerLeftY(rect, 700), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetUpperRightX(rect, 200), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetUpperRightY(rect, 750), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetLowerLeftXReal(rect, 100), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetLowerLeftYReal(rect, 700), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetUpperRightXReal(rect, 200), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetUpperRightYReal(rect, 750), VANILLAPDF_ERROR_SUCCESS);
 
     // Add two annotations
     ASSERT_EQ(TextAnnotation_Create(rect, &text_annot1), VANILLAPDF_ERROR_SUCCESS);
@@ -1406,10 +1406,10 @@ TEST(HighlightAnnotation, GetAndSetAuthor) {
 
     // Create rectangle
     ASSERT_EQ(Rectangle_Create(&rect), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetLowerLeftX(rect, 100), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetLowerLeftY(rect, 700), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetUpperRightX(rect, 200), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetUpperRightY(rect, 750), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetLowerLeftXReal(rect, 100), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetLowerLeftYReal(rect, 700), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetUpperRightXReal(rect, 200), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetUpperRightYReal(rect, 750), VANILLAPDF_ERROR_SUCCESS);
 
     // Create quad points array
     ASSERT_EQ(ArrayObject_Create(&quad_points), VANILLAPDF_ERROR_SUCCESS);
@@ -1456,10 +1456,10 @@ TEST(HighlightAnnotation, GetAndSetModificationDate) {
 
     // Create rectangle
     ASSERT_EQ(Rectangle_Create(&rect), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetLowerLeftX(rect, 100), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetLowerLeftY(rect, 700), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetUpperRightX(rect, 200), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetUpperRightY(rect, 750), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetLowerLeftXReal(rect, 100), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetLowerLeftYReal(rect, 700), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetUpperRightXReal(rect, 200), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetUpperRightYReal(rect, 750), VANILLAPDF_ERROR_SUCCESS);
 
     // Create quad points array
     ASSERT_EQ(ArrayObject_Create(&quad_points), VANILLAPDF_ERROR_SUCCESS);
@@ -1508,10 +1508,10 @@ TEST(HighlightAnnotation, GetAndSetCreationDate) {
 
     // Create rectangle
     ASSERT_EQ(Rectangle_Create(&rect), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetLowerLeftX(rect, 100), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetLowerLeftY(rect, 700), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetUpperRightX(rect, 200), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetUpperRightY(rect, 750), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetLowerLeftXReal(rect, 100), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetLowerLeftYReal(rect, 700), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetUpperRightXReal(rect, 200), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetUpperRightYReal(rect, 750), VANILLAPDF_ERROR_SUCCESS);
 
     // Create quad points array
     ASSERT_EQ(ArrayObject_Create(&quad_points), VANILLAPDF_ERROR_SUCCESS);
@@ -1561,10 +1561,10 @@ TEST(FreeTextAnnotation, GetAndSetAuthor) {
 
     // Create rectangle
     ASSERT_EQ(Rectangle_Create(&rect), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetLowerLeftX(rect, 100), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetLowerLeftY(rect, 700), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetUpperRightX(rect, 300), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetUpperRightY(rect, 750), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetLowerLeftXReal(rect, 100), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetLowerLeftYReal(rect, 700), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetUpperRightXReal(rect, 300), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetUpperRightYReal(rect, 750), VANILLAPDF_ERROR_SUCCESS);
 
     // Create strings
     ASSERT_EQ(LiteralStringObject_CreateFromDecodedString("Free text content", &contents), VANILLAPDF_ERROR_SUCCESS);
@@ -1603,10 +1603,10 @@ TEST(FreeTextAnnotation, GetAndSetModificationDate) {
 
     // Create rectangle
     ASSERT_EQ(Rectangle_Create(&rect), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetLowerLeftX(rect, 100), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetLowerLeftY(rect, 700), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetUpperRightX(rect, 300), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetUpperRightY(rect, 750), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetLowerLeftXReal(rect, 100), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetLowerLeftYReal(rect, 700), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetUpperRightXReal(rect, 300), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetUpperRightYReal(rect, 750), VANILLAPDF_ERROR_SUCCESS);
 
     // Create strings
     ASSERT_EQ(LiteralStringObject_CreateFromDecodedString("Free text content", &contents), VANILLAPDF_ERROR_SUCCESS);
@@ -1647,10 +1647,10 @@ TEST(FreeTextAnnotation, GetAndSetCreationDate) {
 
     // Create rectangle
     ASSERT_EQ(Rectangle_Create(&rect), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetLowerLeftX(rect, 100), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetLowerLeftY(rect, 700), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetUpperRightX(rect, 300), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetUpperRightY(rect, 750), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetLowerLeftXReal(rect, 100), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetLowerLeftYReal(rect, 700), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetUpperRightXReal(rect, 300), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetUpperRightYReal(rect, 750), VANILLAPDF_ERROR_SUCCESS);
 
     // Create strings
     ASSERT_EQ(LiteralStringObject_CreateFromDecodedString("Free text content", &contents), VANILLAPDF_ERROR_SUCCESS);
@@ -1690,10 +1690,10 @@ TEST(UnderlineAnnotation, GetAndSetAuthor) {
 
     // Create rectangle
     ASSERT_EQ(Rectangle_Create(&rect), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetLowerLeftX(rect, 100), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetLowerLeftY(rect, 700), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetUpperRightX(rect, 200), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetUpperRightY(rect, 750), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetLowerLeftXReal(rect, 100), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetLowerLeftYReal(rect, 700), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetUpperRightXReal(rect, 200), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetUpperRightYReal(rect, 750), VANILLAPDF_ERROR_SUCCESS);
 
     // Create quad points array
     ASSERT_EQ(ArrayObject_Create(&quad_points), VANILLAPDF_ERROR_SUCCESS);
@@ -1740,10 +1740,10 @@ TEST(UnderlineAnnotation, GetAndSetModificationDate) {
 
     // Create rectangle
     ASSERT_EQ(Rectangle_Create(&rect), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetLowerLeftX(rect, 100), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetLowerLeftY(rect, 700), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetUpperRightX(rect, 200), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetUpperRightY(rect, 750), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetLowerLeftXReal(rect, 100), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetLowerLeftYReal(rect, 700), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetUpperRightXReal(rect, 200), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetUpperRightYReal(rect, 750), VANILLAPDF_ERROR_SUCCESS);
 
     // Create quad points array
     ASSERT_EQ(ArrayObject_Create(&quad_points), VANILLAPDF_ERROR_SUCCESS);
@@ -1792,10 +1792,10 @@ TEST(UnderlineAnnotation, GetAndSetCreationDate) {
 
     // Create rectangle
     ASSERT_EQ(Rectangle_Create(&rect), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetLowerLeftX(rect, 100), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetLowerLeftY(rect, 700), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetUpperRightX(rect, 200), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetUpperRightY(rect, 750), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetLowerLeftXReal(rect, 100), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetLowerLeftYReal(rect, 700), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetUpperRightXReal(rect, 200), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetUpperRightYReal(rect, 750), VANILLAPDF_ERROR_SUCCESS);
 
     // Create quad points array
     ASSERT_EQ(ArrayObject_Create(&quad_points), VANILLAPDF_ERROR_SUCCESS);
@@ -1843,10 +1843,10 @@ TEST(UnderlineAnnotation, FromBaseAnnotation) {
 
     // Create rectangle
     ASSERT_EQ(Rectangle_Create(&rect), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetLowerLeftX(rect, 100), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetLowerLeftY(rect, 700), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetUpperRightX(rect, 200), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetUpperRightY(rect, 750), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetLowerLeftXReal(rect, 100), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetLowerLeftYReal(rect, 700), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetUpperRightXReal(rect, 200), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetUpperRightYReal(rect, 750), VANILLAPDF_ERROR_SUCCESS);
 
     // Create quad points array
     ASSERT_EQ(ArrayObject_Create(&quad_points), VANILLAPDF_ERROR_SUCCESS);
@@ -1888,10 +1888,10 @@ TEST(StrikeOutAnnotation, GetAndSetAuthor) {
 
     // Create rectangle
     ASSERT_EQ(Rectangle_Create(&rect), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetLowerLeftX(rect, 100), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetLowerLeftY(rect, 700), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetUpperRightX(rect, 200), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetUpperRightY(rect, 750), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetLowerLeftXReal(rect, 100), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetLowerLeftYReal(rect, 700), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetUpperRightXReal(rect, 200), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetUpperRightYReal(rect, 750), VANILLAPDF_ERROR_SUCCESS);
 
     // Create quad points array
     ASSERT_EQ(ArrayObject_Create(&quad_points), VANILLAPDF_ERROR_SUCCESS);
@@ -1938,10 +1938,10 @@ TEST(StrikeOutAnnotation, GetAndSetModificationDate) {
 
     // Create rectangle
     ASSERT_EQ(Rectangle_Create(&rect), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetLowerLeftX(rect, 100), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetLowerLeftY(rect, 700), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetUpperRightX(rect, 200), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetUpperRightY(rect, 750), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetLowerLeftXReal(rect, 100), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetLowerLeftYReal(rect, 700), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetUpperRightXReal(rect, 200), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetUpperRightYReal(rect, 750), VANILLAPDF_ERROR_SUCCESS);
 
     // Create quad points array
     ASSERT_EQ(ArrayObject_Create(&quad_points), VANILLAPDF_ERROR_SUCCESS);
@@ -1990,10 +1990,10 @@ TEST(StrikeOutAnnotation, GetAndSetCreationDate) {
 
     // Create rectangle
     ASSERT_EQ(Rectangle_Create(&rect), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetLowerLeftX(rect, 100), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetLowerLeftY(rect, 700), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetUpperRightX(rect, 200), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetUpperRightY(rect, 750), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetLowerLeftXReal(rect, 100), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetLowerLeftYReal(rect, 700), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetUpperRightXReal(rect, 200), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetUpperRightYReal(rect, 750), VANILLAPDF_ERROR_SUCCESS);
 
     // Create quad points array
     ASSERT_EQ(ArrayObject_Create(&quad_points), VANILLAPDF_ERROR_SUCCESS);
@@ -2041,10 +2041,10 @@ TEST(StrikeOutAnnotation, FromBaseAnnotation) {
 
     // Create rectangle
     ASSERT_EQ(Rectangle_Create(&rect), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetLowerLeftX(rect, 100), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetLowerLeftY(rect, 700), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetUpperRightX(rect, 200), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetUpperRightY(rect, 750), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetLowerLeftXReal(rect, 100), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetLowerLeftYReal(rect, 700), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetUpperRightXReal(rect, 200), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetUpperRightYReal(rect, 750), VANILLAPDF_ERROR_SUCCESS);
 
     // Create quad points array
     ASSERT_EQ(ArrayObject_Create(&quad_points), VANILLAPDF_ERROR_SUCCESS);
@@ -2086,10 +2086,10 @@ TEST(StrikeOutAnnotation, GetAndSetQuadPoints) {
 
     // Create rectangle
     ASSERT_EQ(Rectangle_Create(&rect), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetLowerLeftX(rect, 100), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetLowerLeftY(rect, 700), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetUpperRightX(rect, 200), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetUpperRightY(rect, 750), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetLowerLeftXReal(rect, 100), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetLowerLeftYReal(rect, 700), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetUpperRightXReal(rect, 200), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetUpperRightYReal(rect, 750), VANILLAPDF_ERROR_SUCCESS);
 
     // Create quad points array
     ASSERT_EQ(ArrayObject_Create(&quad_points), VANILLAPDF_ERROR_SUCCESS);
@@ -2150,10 +2150,10 @@ TEST(SquigglyAnnotation, GetAndSetAuthor) {
 
     // Create rectangle
     ASSERT_EQ(Rectangle_Create(&rect), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetLowerLeftX(rect, 100), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetLowerLeftY(rect, 700), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetUpperRightX(rect, 200), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetUpperRightY(rect, 750), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetLowerLeftXReal(rect, 100), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetLowerLeftYReal(rect, 700), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetUpperRightXReal(rect, 200), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetUpperRightYReal(rect, 750), VANILLAPDF_ERROR_SUCCESS);
 
     // Create quad points array
     ASSERT_EQ(ArrayObject_Create(&quad_points), VANILLAPDF_ERROR_SUCCESS);
@@ -2200,10 +2200,10 @@ TEST(SquigglyAnnotation, GetAndSetModificationDate) {
 
     // Create rectangle
     ASSERT_EQ(Rectangle_Create(&rect), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetLowerLeftX(rect, 100), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetLowerLeftY(rect, 700), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetUpperRightX(rect, 200), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetUpperRightY(rect, 750), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetLowerLeftXReal(rect, 100), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetLowerLeftYReal(rect, 700), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetUpperRightXReal(rect, 200), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetUpperRightYReal(rect, 750), VANILLAPDF_ERROR_SUCCESS);
 
     // Create quad points array
     ASSERT_EQ(ArrayObject_Create(&quad_points), VANILLAPDF_ERROR_SUCCESS);
@@ -2252,10 +2252,10 @@ TEST(SquigglyAnnotation, GetAndSetCreationDate) {
 
     // Create rectangle
     ASSERT_EQ(Rectangle_Create(&rect), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetLowerLeftX(rect, 100), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetLowerLeftY(rect, 700), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetUpperRightX(rect, 200), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetUpperRightY(rect, 750), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetLowerLeftXReal(rect, 100), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetLowerLeftYReal(rect, 700), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetUpperRightXReal(rect, 200), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetUpperRightYReal(rect, 750), VANILLAPDF_ERROR_SUCCESS);
 
     // Create quad points array
     ASSERT_EQ(ArrayObject_Create(&quad_points), VANILLAPDF_ERROR_SUCCESS);
@@ -2303,10 +2303,10 @@ TEST(SquigglyAnnotation, FromBaseAnnotation) {
 
     // Create rectangle
     ASSERT_EQ(Rectangle_Create(&rect), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetLowerLeftX(rect, 100), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetLowerLeftY(rect, 700), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetUpperRightX(rect, 200), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetUpperRightY(rect, 750), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetLowerLeftXReal(rect, 100), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetLowerLeftYReal(rect, 700), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetUpperRightXReal(rect, 200), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetUpperRightYReal(rect, 750), VANILLAPDF_ERROR_SUCCESS);
 
     // Create quad points array
     ASSERT_EQ(ArrayObject_Create(&quad_points), VANILLAPDF_ERROR_SUCCESS);
@@ -2348,10 +2348,10 @@ TEST(SquigglyAnnotation, GetAndSetQuadPoints) {
 
     // Create rectangle
     ASSERT_EQ(Rectangle_Create(&rect), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetLowerLeftX(rect, 100), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetLowerLeftY(rect, 700), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetUpperRightX(rect, 200), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetUpperRightY(rect, 750), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetLowerLeftXReal(rect, 100), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetLowerLeftYReal(rect, 700), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetUpperRightXReal(rect, 200), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetUpperRightYReal(rect, 750), VANILLAPDF_ERROR_SUCCESS);
 
     // Create quad points array
     ASSERT_EQ(ArrayObject_Create(&quad_points), VANILLAPDF_ERROR_SUCCESS);
@@ -2413,10 +2413,10 @@ TEST(InkAnnotation, GetAndSetAuthor) {
 
     // Create rectangle
     ASSERT_EQ(Rectangle_Create(&rect), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetLowerLeftX(rect, 100), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetLowerLeftY(rect, 700), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetUpperRightX(rect, 200), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetUpperRightY(rect, 750), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetLowerLeftXReal(rect, 100), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetLowerLeftYReal(rect, 700), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetUpperRightXReal(rect, 200), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetUpperRightYReal(rect, 750), VANILLAPDF_ERROR_SUCCESS);
 
     // Create ink list
     ASSERT_EQ(ArrayObject_Create(&ink_list), VANILLAPDF_ERROR_SUCCESS);
@@ -2470,10 +2470,10 @@ TEST(InkAnnotation, GetAndSetModificationDate) {
 
     // Create rectangle
     ASSERT_EQ(Rectangle_Create(&rect), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetLowerLeftX(rect, 100), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetLowerLeftY(rect, 700), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetUpperRightX(rect, 200), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetUpperRightY(rect, 750), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetLowerLeftXReal(rect, 100), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetLowerLeftYReal(rect, 700), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetUpperRightXReal(rect, 200), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetUpperRightYReal(rect, 750), VANILLAPDF_ERROR_SUCCESS);
 
     // Create ink list
     ASSERT_EQ(ArrayObject_Create(&ink_list), VANILLAPDF_ERROR_SUCCESS);
@@ -2529,10 +2529,10 @@ TEST(InkAnnotation, GetAndSetCreationDate) {
 
     // Create rectangle
     ASSERT_EQ(Rectangle_Create(&rect), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetLowerLeftX(rect, 100), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetLowerLeftY(rect, 700), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetUpperRightX(rect, 200), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetUpperRightY(rect, 750), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetLowerLeftXReal(rect, 100), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetLowerLeftYReal(rect, 700), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetUpperRightXReal(rect, 200), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetUpperRightYReal(rect, 750), VANILLAPDF_ERROR_SUCCESS);
 
     // Create ink list
     ASSERT_EQ(ArrayObject_Create(&ink_list), VANILLAPDF_ERROR_SUCCESS);
@@ -2589,10 +2589,10 @@ TEST(InkAnnotation, SetInkList) {
 
     // Create rectangle
     ASSERT_EQ(Rectangle_Create(&rect), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetLowerLeftX(rect, 100), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetLowerLeftY(rect, 700), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetUpperRightX(rect, 200), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetUpperRightY(rect, 750), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetLowerLeftXReal(rect, 100), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetLowerLeftYReal(rect, 700), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetUpperRightXReal(rect, 200), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetUpperRightYReal(rect, 750), VANILLAPDF_ERROR_SUCCESS);
 
     // Create initial ink list with one stroke
     ASSERT_EQ(ArrayObject_Create(&ink_list), VANILLAPDF_ERROR_SUCCESS);
@@ -2665,10 +2665,10 @@ TEST(InkAnnotation, FromBaseAnnotation) {
 
     // Create rectangle
     ASSERT_EQ(Rectangle_Create(&rect), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetLowerLeftX(rect, 100), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetLowerLeftY(rect, 700), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetUpperRightX(rect, 200), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetUpperRightY(rect, 750), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetLowerLeftXReal(rect, 100), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetLowerLeftYReal(rect, 700), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetUpperRightXReal(rect, 200), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetUpperRightYReal(rect, 750), VANILLAPDF_ERROR_SUCCESS);
 
     // Create ink list
     ASSERT_EQ(ArrayObject_Create(&ink_list), VANILLAPDF_ERROR_SUCCESS);
@@ -2732,10 +2732,10 @@ TEST(PageAnnotations, AtAnnotation) {
     ASSERT_EQ(PageObject_CreateFromDocument(doc, &page), VANILLAPDF_ERROR_SUCCESS);
     RectangleHandle* media_box = nullptr;
     ASSERT_EQ(Rectangle_Create(&media_box), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetLowerLeftX(media_box, 0), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetLowerLeftY(media_box, 0), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetUpperRightX(media_box, 612), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetUpperRightY(media_box, 792), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetLowerLeftXReal(media_box, 0), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetLowerLeftYReal(media_box, 0), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetUpperRightXReal(media_box, 612), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetUpperRightYReal(media_box, 792), VANILLAPDF_ERROR_SUCCESS);
     ASSERT_EQ(PageObject_SetMediaBox(page, media_box), VANILLAPDF_ERROR_SUCCESS);
     ASSERT_EQ(PageTree_AppendPage(page_tree, page), VANILLAPDF_ERROR_SUCCESS);
 
@@ -2745,10 +2745,10 @@ TEST(PageAnnotations, AtAnnotation) {
 
     // Create rectangle for annotation
     ASSERT_EQ(Rectangle_Create(&rect), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetLowerLeftX(rect, 100), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetLowerLeftY(rect, 700), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetUpperRightX(rect, 200), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetUpperRightY(rect, 750), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetLowerLeftXReal(rect, 100), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetLowerLeftYReal(rect, 700), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetUpperRightXReal(rect, 200), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetUpperRightYReal(rect, 750), VANILLAPDF_ERROR_SUCCESS);
 
     // Add annotation
     ASSERT_EQ(TextAnnotation_Create(rect, &text_annot), VANILLAPDF_ERROR_SUCCESS);
@@ -2792,10 +2792,10 @@ TEST(UnderlineAnnotation, SetQuadPoints) {
 
     // Create rectangle
     ASSERT_EQ(Rectangle_Create(&rect), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetLowerLeftX(rect, 100), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetLowerLeftY(rect, 700), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetUpperRightX(rect, 200), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetUpperRightY(rect, 750), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetLowerLeftXReal(rect, 100), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetLowerLeftYReal(rect, 700), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetUpperRightXReal(rect, 200), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetUpperRightYReal(rect, 750), VANILLAPDF_ERROR_SUCCESS);
 
     // Create quad points array
     ASSERT_EQ(ArrayObject_Create(&quad_points), VANILLAPDF_ERROR_SUCCESS);
@@ -2841,6 +2841,126 @@ TEST(UnderlineAnnotation, SetQuadPoints) {
     ASSERT_EQ(UnderlineAnnotation_Release(annot), VANILLAPDF_ERROR_SUCCESS);
     ASSERT_EQ(ArrayObject_Release(quad_points), VANILLAPDF_ERROR_SUCCESS);
     ASSERT_EQ(Rectangle_Release(rect), VANILLAPDF_ERROR_SUCCESS);
+}
+
+TEST(Annotation, RealValuedRect) {
+    RectangleHandle* rect = nullptr;
+    TextAnnotationHandle* annot = nullptr;
+    AnnotationHandle* base_annot = nullptr;
+    RectangleHandle* retrieved_rect = nullptr;
+    real_type value = 0;
+
+    // Create rectangle with fractional coordinates
+    ASSERT_EQ(Rectangle_Create(&rect), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetLowerLeftXReal(rect, 100.25), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetLowerLeftYReal(rect, 700.5), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetUpperRightXReal(rect, 200.75), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetUpperRightYReal(rect, 750.125), VANILLAPDF_ERROR_SUCCESS);
+
+    // Create annotation and read the rectangle back
+    ASSERT_EQ(TextAnnotation_Create(rect, &annot), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(TextAnnotation_ToBaseAnnotation(annot, &base_annot), VANILLAPDF_ERROR_SUCCESS);
+
+    ASSERT_EQ(Annotation_GetRect(base_annot, &retrieved_rect), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_NE(retrieved_rect, nullptr);
+
+    ASSERT_EQ(Rectangle_GetLowerLeftXReal(retrieved_rect, &value), VANILLAPDF_ERROR_SUCCESS);
+    EXPECT_EQ(value, 100.25);
+
+    ASSERT_EQ(Rectangle_GetLowerLeftYReal(retrieved_rect, &value), VANILLAPDF_ERROR_SUCCESS);
+    EXPECT_EQ(value, 700.5);
+
+    ASSERT_EQ(Rectangle_GetUpperRightXReal(retrieved_rect, &value), VANILLAPDF_ERROR_SUCCESS);
+    EXPECT_EQ(value, 200.75);
+
+    ASSERT_EQ(Rectangle_GetUpperRightYReal(retrieved_rect, &value), VANILLAPDF_ERROR_SUCCESS);
+    EXPECT_EQ(value, 750.125);
+
+    // Cleanup
+    ASSERT_EQ(Rectangle_Release(retrieved_rect), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Annotation_Release(base_annot), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(TextAnnotation_Release(annot), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_Release(rect), VANILLAPDF_ERROR_SUCCESS);
+}
+
+TEST(PageObject, MediaBoxRealCoordinates) {
+    FileHandle* file = nullptr;
+    DocumentHandle* doc = nullptr;
+    InputOutputStreamHandle* io_stream = nullptr;
+    PageObjectHandle* page = nullptr;
+    DictionaryObjectHandle* page_dict = nullptr;
+    ArrayObjectHandle* media_box_array = nullptr;
+    NameObjectHandle* media_box_key = nullptr;
+    RectangleHandle* media_box = nullptr;
+    real_type value = 0;
+
+    // Create in-memory document with a single page
+    ASSERT_EQ(InputOutputStream_CreateFromMemory(&io_stream), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(File_CreateStream(io_stream, "temp", &file), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Document_CreateFile(file, &doc), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(PageObject_CreateFromDocument(doc, &page), VANILLAPDF_ERROR_SUCCESS);
+
+    // Build an A4 media box with mixed integer and real elements,
+    // mirroring the object layout produced by parsing [ 0 0 595.276 841.89 ]
+    ASSERT_EQ(ArrayObject_Create(&media_box_array), VANILLAPDF_ERROR_SUCCESS);
+
+    for (int i = 0; i < 2; i++) {
+        IntegerObjectHandle* integer_value = nullptr;
+        ObjectHandle* obj = nullptr;
+        ASSERT_EQ(IntegerObject_Create(&integer_value), VANILLAPDF_ERROR_SUCCESS);
+        ASSERT_EQ(IntegerObject_SetIntegerValue(integer_value, 0), VANILLAPDF_ERROR_SUCCESS);
+        ASSERT_EQ(IntegerObject_ToObject(integer_value, &obj), VANILLAPDF_ERROR_SUCCESS);
+        ASSERT_EQ(ArrayObject_Append(media_box_array, obj), VANILLAPDF_ERROR_SUCCESS);
+        ASSERT_EQ(Object_Release(obj), VANILLAPDF_ERROR_SUCCESS);
+        ASSERT_EQ(IntegerObject_Release(integer_value), VANILLAPDF_ERROR_SUCCESS);
+    }
+
+    double real_values[] = {595.276, 841.89};
+    for (int i = 0; i < 2; i++) {
+        RealObjectHandle* real_value = nullptr;
+        ObjectHandle* obj = nullptr;
+        ASSERT_EQ(RealObject_Create(&real_value), VANILLAPDF_ERROR_SUCCESS);
+        ASSERT_EQ(RealObject_SetValue(real_value, real_values[i]), VANILLAPDF_ERROR_SUCCESS);
+        ASSERT_EQ(RealObject_ToObject(real_value, &obj), VANILLAPDF_ERROR_SUCCESS);
+        ASSERT_EQ(ArrayObject_Append(media_box_array, obj), VANILLAPDF_ERROR_SUCCESS);
+        ASSERT_EQ(Object_Release(obj), VANILLAPDF_ERROR_SUCCESS);
+        ASSERT_EQ(RealObject_Release(real_value), VANILLAPDF_ERROR_SUCCESS);
+    }
+
+    // Insert the media box into the page dictionary directly
+    ASSERT_EQ(PageObject_GetBaseObject(page, &page_dict), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(NameObject_CreateFromDecodedString("MediaBox", &media_box_key), VANILLAPDF_ERROR_SUCCESS);
+
+    ObjectHandle* media_box_obj = nullptr;
+    ASSERT_EQ(ArrayObject_ToObject(media_box_array, &media_box_obj), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(DictionaryObject_Insert(page_dict, media_box_key, media_box_obj, VANILLAPDF_RV_TRUE), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Object_Release(media_box_obj), VANILLAPDF_ERROR_SUCCESS);
+
+    // Reading the media box has to preserve the fractional coordinates
+    ASSERT_EQ(PageObject_GetMediaBox(page, &media_box), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_NE(media_box, nullptr);
+
+    ASSERT_EQ(Rectangle_GetLowerLeftXReal(media_box, &value), VANILLAPDF_ERROR_SUCCESS);
+    EXPECT_EQ(value, 0);
+
+    ASSERT_EQ(Rectangle_GetLowerLeftYReal(media_box, &value), VANILLAPDF_ERROR_SUCCESS);
+    EXPECT_EQ(value, 0);
+
+    ASSERT_EQ(Rectangle_GetUpperRightXReal(media_box, &value), VANILLAPDF_ERROR_SUCCESS);
+    EXPECT_EQ(value, 595.276);
+
+    ASSERT_EQ(Rectangle_GetUpperRightYReal(media_box, &value), VANILLAPDF_ERROR_SUCCESS);
+    EXPECT_EQ(value, 841.89);
+
+    // Cleanup
+    ASSERT_EQ(Rectangle_Release(media_box), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(NameObject_Release(media_box_key), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(DictionaryObject_Release(page_dict), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(ArrayObject_Release(media_box_array), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(PageObject_Release(page), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Document_Release(doc), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(File_Release(file), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(InputOutputStream_Release(io_stream), VANILLAPDF_ERROR_SUCCESS);
 }
 
 } // namespace annotations

--- a/src/vanillapdf.unittest/main.cpp
+++ b/src/vanillapdf.unittest/main.cpp
@@ -200,6 +200,54 @@ TEST(Rectangle, GetSet) {
     EXPECT_EQ(real_value, CHECK_VALUE);
 }
 
+TEST(Rectangle, GetSetAllCoordinates) {
+
+    real_type real_value = 0;
+    HandleGuard<RectangleHandle, Rectangle_Release> rectangle_ptr;
+
+    ASSERT_EQ(Rectangle_Create(rectangle_ptr.out()), VANILLAPDF_ERROR_SUCCESS);
+
+    ASSERT_EQ(Rectangle_SetLowerLeftXReal(rectangle_ptr, 10.5), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetLowerLeftYReal(rectangle_ptr, 20.5), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetUpperRightXReal(rectangle_ptr, 30.5), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetUpperRightYReal(rectangle_ptr, 40.5), VANILLAPDF_ERROR_SUCCESS);
+
+    ASSERT_EQ(Rectangle_GetLowerLeftXReal(rectangle_ptr, &real_value), VANILLAPDF_ERROR_SUCCESS);
+    EXPECT_EQ(real_value, 10.5);
+
+    ASSERT_EQ(Rectangle_GetLowerLeftYReal(rectangle_ptr, &real_value), VANILLAPDF_ERROR_SUCCESS);
+    EXPECT_EQ(real_value, 20.5);
+
+    ASSERT_EQ(Rectangle_GetUpperRightXReal(rectangle_ptr, &real_value), VANILLAPDF_ERROR_SUCCESS);
+    EXPECT_EQ(real_value, 30.5);
+
+    ASSERT_EQ(Rectangle_GetUpperRightYReal(rectangle_ptr, &real_value), VANILLAPDF_ERROR_SUCCESS);
+    EXPECT_EQ(real_value, 40.5);
+}
+
+TEST(Rectangle, RealAccessorNullChecks) {
+
+    real_type real_value = 0;
+    HandleGuard<RectangleHandle, Rectangle_Release> rectangle_ptr;
+
+    ASSERT_EQ(Rectangle_Create(rectangle_ptr.out()), VANILLAPDF_ERROR_SUCCESS);
+
+    EXPECT_EQ(Rectangle_GetLowerLeftXReal(nullptr, &real_value), VANILLAPDF_ERROR_PARAMETER_VALUE);
+    EXPECT_EQ(Rectangle_GetLowerLeftYReal(nullptr, &real_value), VANILLAPDF_ERROR_PARAMETER_VALUE);
+    EXPECT_EQ(Rectangle_GetUpperRightXReal(nullptr, &real_value), VANILLAPDF_ERROR_PARAMETER_VALUE);
+    EXPECT_EQ(Rectangle_GetUpperRightYReal(nullptr, &real_value), VANILLAPDF_ERROR_PARAMETER_VALUE);
+
+    EXPECT_EQ(Rectangle_GetLowerLeftXReal(rectangle_ptr, nullptr), VANILLAPDF_ERROR_PARAMETER_VALUE);
+    EXPECT_EQ(Rectangle_GetLowerLeftYReal(rectangle_ptr, nullptr), VANILLAPDF_ERROR_PARAMETER_VALUE);
+    EXPECT_EQ(Rectangle_GetUpperRightXReal(rectangle_ptr, nullptr), VANILLAPDF_ERROR_PARAMETER_VALUE);
+    EXPECT_EQ(Rectangle_GetUpperRightYReal(rectangle_ptr, nullptr), VANILLAPDF_ERROR_PARAMETER_VALUE);
+
+    EXPECT_EQ(Rectangle_SetLowerLeftXReal(nullptr, 0), VANILLAPDF_ERROR_PARAMETER_VALUE);
+    EXPECT_EQ(Rectangle_SetLowerLeftYReal(nullptr, 0), VANILLAPDF_ERROR_PARAMETER_VALUE);
+    EXPECT_EQ(Rectangle_SetUpperRightXReal(nullptr, 0), VANILLAPDF_ERROR_PARAMETER_VALUE);
+    EXPECT_EQ(Rectangle_SetUpperRightYReal(nullptr, 0), VANILLAPDF_ERROR_PARAMETER_VALUE);
+}
+
 TEST(File, LoadEmptyError) {
 
     HandleGuard<FileHandle, File_Release> file;

--- a/src/vanillapdf.unittest/main.cpp
+++ b/src/vanillapdf.unittest/main.cpp
@@ -186,18 +186,18 @@ TEST(Rectangle, NullCheck) {
 
 TEST(Rectangle, GetSet) {
 
-    const bigint_type CHECK_VALUE = 123456;
+    const real_type CHECK_VALUE = 123456.789;
 
-    bigint_type int_value = 0;
+    real_type real_value = 0;
     HandleGuard<RectangleHandle, Rectangle_Release> rectangle_ptr;
 
     ASSERT_EQ(Rectangle_Create(rectangle_ptr.out()), VANILLAPDF_ERROR_SUCCESS);
     ASSERT_NE(rectangle_ptr.get(), nullptr);
 
-    ASSERT_EQ(Rectangle_SetLowerLeftX(rectangle_ptr, CHECK_VALUE), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_GetLowerLeftX(rectangle_ptr, &int_value), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetLowerLeftXReal(rectangle_ptr, CHECK_VALUE), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_GetLowerLeftXReal(rectangle_ptr, &real_value), VANILLAPDF_ERROR_SUCCESS);
 
-    EXPECT_EQ(int_value, CHECK_VALUE);
+    EXPECT_EQ(real_value, CHECK_VALUE);
 }
 
 TEST(File, LoadEmptyError) {

--- a/src/vanillapdf.unittest/page_tree_test.cpp
+++ b/src/vanillapdf.unittest/page_tree_test.cpp
@@ -65,10 +65,10 @@ TEST(PageTree, InsertAndRemovePage) {
     // Set media box
     RectangleHandle* media_box = nullptr;
     ASSERT_EQ(Rectangle_Create(&media_box), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetLowerLeftX(media_box, 0), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetLowerLeftY(media_box, 0), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetUpperRightX(media_box, 612), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Rectangle_SetUpperRightY(media_box, 792), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetLowerLeftXReal(media_box, 0), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetLowerLeftYReal(media_box, 0), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetUpperRightXReal(media_box, 612), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Rectangle_SetUpperRightYReal(media_box, 792), VANILLAPDF_ERROR_SUCCESS);
     ASSERT_EQ(PageObject_SetMediaBox(new_page, media_box), VANILLAPDF_ERROR_SUCCESS);
 
     // Insert page at position 1

--- a/src/vanillapdf/implementation/semantics/c_rectangle.cpp
+++ b/src/vanillapdf/implementation/semantics/c_rectangle.cpp
@@ -1,6 +1,8 @@
 #include "precompiled.h"
 #include "semantics/objects/rectangle.h"
 
+#include "utils/conversion_utils.h"
+
 #include "vanillapdf/semantics/c_rectangle.h"
 #include "implementation/c_helper.h"
 
@@ -27,12 +29,38 @@ VANILLAPDF_API error_type CALLING_CONVENTION Rectangle_GetLowerLeftX(RectangleHa
 
     try
     {
+        auto converted_value = ValueConvertUtils::SafeConvert<bigint_type>(obj->GetLowerLeftX());
+        *result = converted_value;
+        return VANILLAPDF_ERROR_SUCCESS;
+    } CATCH_VANILLAPDF_EXCEPTIONS
+}
+
+VANILLAPDF_API error_type CALLING_CONVENTION Rectangle_GetLowerLeftXReal(RectangleHandle* handle, real_type* result)
+{
+    Rectangle* obj = reinterpret_cast<Rectangle*>(handle);
+    RETURN_ERROR_PARAM_VALUE_IF_NULL(obj);
+    RETURN_ERROR_PARAM_VALUE_IF_NULL(result);
+
+    try
+    {
         *result = obj->GetLowerLeftX();
         return VANILLAPDF_ERROR_SUCCESS;
     } CATCH_VANILLAPDF_EXCEPTIONS
 }
 
 VANILLAPDF_API error_type CALLING_CONVENTION Rectangle_SetLowerLeftX(RectangleHandle* handle, bigint_type data) {
+    Rectangle* obj = reinterpret_cast<Rectangle*>(handle);
+    RETURN_ERROR_PARAM_VALUE_IF_NULL(obj);
+
+    try
+    {
+        auto converted_value = ValueConvertUtils::SafeConvert<types::real>(data);
+        obj->SetLowerLeftX(converted_value);
+        return VANILLAPDF_ERROR_SUCCESS;
+    } CATCH_VANILLAPDF_EXCEPTIONS
+}
+
+VANILLAPDF_API error_type CALLING_CONVENTION Rectangle_SetLowerLeftXReal(RectangleHandle* handle, real_type data) {
     Rectangle* obj = reinterpret_cast<Rectangle*>(handle);
     RETURN_ERROR_PARAM_VALUE_IF_NULL(obj);
 
@@ -51,12 +79,38 @@ VANILLAPDF_API error_type CALLING_CONVENTION Rectangle_GetLowerLeftY(RectangleHa
 
     try
     {
+        auto converted_value = ValueConvertUtils::SafeConvert<bigint_type>(obj->GetLowerLeftY());
+        *result = converted_value;
+        return VANILLAPDF_ERROR_SUCCESS;
+    } CATCH_VANILLAPDF_EXCEPTIONS
+}
+
+VANILLAPDF_API error_type CALLING_CONVENTION Rectangle_GetLowerLeftYReal(RectangleHandle* handle, real_type* result)
+{
+    Rectangle* obj = reinterpret_cast<Rectangle*>(handle);
+    RETURN_ERROR_PARAM_VALUE_IF_NULL(obj);
+    RETURN_ERROR_PARAM_VALUE_IF_NULL(result);
+
+    try
+    {
         *result = obj->GetLowerLeftY();
         return VANILLAPDF_ERROR_SUCCESS;
     } CATCH_VANILLAPDF_EXCEPTIONS
 }
 
 VANILLAPDF_API error_type CALLING_CONVENTION Rectangle_SetLowerLeftY(RectangleHandle* handle, bigint_type data) {
+    Rectangle* obj = reinterpret_cast<Rectangle*>(handle);
+    RETURN_ERROR_PARAM_VALUE_IF_NULL(obj);
+
+    try
+    {
+        auto converted_value = ValueConvertUtils::SafeConvert<types::real>(data);
+        obj->SetLowerLeftY(converted_value);
+        return VANILLAPDF_ERROR_SUCCESS;
+    } CATCH_VANILLAPDF_EXCEPTIONS
+}
+
+VANILLAPDF_API error_type CALLING_CONVENTION Rectangle_SetLowerLeftYReal(RectangleHandle* handle, real_type data) {
     Rectangle* obj = reinterpret_cast<Rectangle*>(handle);
     RETURN_ERROR_PARAM_VALUE_IF_NULL(obj);
 
@@ -75,12 +129,38 @@ VANILLAPDF_API error_type CALLING_CONVENTION Rectangle_GetUpperRightX(RectangleH
 
     try
     {
+        auto converted_value = ValueConvertUtils::SafeConvert<bigint_type>(obj->GetUpperRightX());
+        *result = converted_value;
+        return VANILLAPDF_ERROR_SUCCESS;
+    } CATCH_VANILLAPDF_EXCEPTIONS
+}
+
+VANILLAPDF_API error_type CALLING_CONVENTION Rectangle_GetUpperRightXReal(RectangleHandle* handle, real_type* result)
+{
+    Rectangle* obj = reinterpret_cast<Rectangle*>(handle);
+    RETURN_ERROR_PARAM_VALUE_IF_NULL(obj);
+    RETURN_ERROR_PARAM_VALUE_IF_NULL(result);
+
+    try
+    {
         *result = obj->GetUpperRightX();
         return VANILLAPDF_ERROR_SUCCESS;
     } CATCH_VANILLAPDF_EXCEPTIONS
 }
 
 VANILLAPDF_API error_type CALLING_CONVENTION Rectangle_SetUpperRightX(RectangleHandle* handle, bigint_type data) {
+    Rectangle* obj = reinterpret_cast<Rectangle*>(handle);
+    RETURN_ERROR_PARAM_VALUE_IF_NULL(obj);
+
+    try
+    {
+        auto converted_value = ValueConvertUtils::SafeConvert<types::real>(data);
+        obj->SetUpperRightX(converted_value);
+        return VANILLAPDF_ERROR_SUCCESS;
+    } CATCH_VANILLAPDF_EXCEPTIONS
+}
+
+VANILLAPDF_API error_type CALLING_CONVENTION Rectangle_SetUpperRightXReal(RectangleHandle* handle, real_type data) {
     Rectangle* obj = reinterpret_cast<Rectangle*>(handle);
     RETURN_ERROR_PARAM_VALUE_IF_NULL(obj);
 
@@ -99,12 +179,38 @@ VANILLAPDF_API error_type CALLING_CONVENTION Rectangle_GetUpperRightY(RectangleH
 
     try
     {
+        auto converted_value = ValueConvertUtils::SafeConvert<bigint_type>(obj->GetUpperRightY());
+        *result = converted_value;
+        return VANILLAPDF_ERROR_SUCCESS;
+    } CATCH_VANILLAPDF_EXCEPTIONS
+}
+
+VANILLAPDF_API error_type CALLING_CONVENTION Rectangle_GetUpperRightYReal(RectangleHandle* handle, real_type* result)
+{
+    Rectangle* obj = reinterpret_cast<Rectangle*>(handle);
+    RETURN_ERROR_PARAM_VALUE_IF_NULL(obj);
+    RETURN_ERROR_PARAM_VALUE_IF_NULL(result);
+
+    try
+    {
         *result = obj->GetUpperRightY();
         return VANILLAPDF_ERROR_SUCCESS;
     } CATCH_VANILLAPDF_EXCEPTIONS
 }
 
 VANILLAPDF_API error_type CALLING_CONVENTION Rectangle_SetUpperRightY(RectangleHandle* handle, bigint_type data) {
+    Rectangle* obj = reinterpret_cast<Rectangle*>(handle);
+    RETURN_ERROR_PARAM_VALUE_IF_NULL(obj);
+
+    try
+    {
+        auto converted_value = ValueConvertUtils::SafeConvert<types::real>(data);
+        obj->SetUpperRightY(converted_value);
+        return VANILLAPDF_ERROR_SUCCESS;
+    } CATCH_VANILLAPDF_EXCEPTIONS
+}
+
+VANILLAPDF_API error_type CALLING_CONVENTION Rectangle_SetUpperRightYReal(RectangleHandle* handle, real_type data) {
     Rectangle* obj = reinterpret_cast<Rectangle*>(handle);
     RETURN_ERROR_PARAM_VALUE_IF_NULL(obj);
 

--- a/src/vanillapdf/implementation/semantics/c_rectangle.cpp
+++ b/src/vanillapdf/implementation/semantics/c_rectangle.cpp
@@ -29,8 +29,7 @@ VANILLAPDF_API error_type CALLING_CONVENTION Rectangle_GetLowerLeftX(RectangleHa
 
     try
     {
-        auto converted_value = ValueConvertUtils::SafeConvert<bigint_type>(obj->GetLowerLeftX());
-        *result = converted_value;
+        *result = ValueConvertUtils::SafeConvert<bigint_type>(obj->GetLowerLeftX());
         return VANILLAPDF_ERROR_SUCCESS;
     } CATCH_VANILLAPDF_EXCEPTIONS
 }
@@ -54,8 +53,7 @@ VANILLAPDF_API error_type CALLING_CONVENTION Rectangle_SetLowerLeftX(RectangleHa
 
     try
     {
-        auto converted_value = ValueConvertUtils::SafeConvert<types::real>(data);
-        obj->SetLowerLeftX(converted_value);
+        obj->SetLowerLeftX(ValueConvertUtils::SafeConvert<types::real>(data));
         return VANILLAPDF_ERROR_SUCCESS;
     } CATCH_VANILLAPDF_EXCEPTIONS
 }
@@ -79,8 +77,7 @@ VANILLAPDF_API error_type CALLING_CONVENTION Rectangle_GetLowerLeftY(RectangleHa
 
     try
     {
-        auto converted_value = ValueConvertUtils::SafeConvert<bigint_type>(obj->GetLowerLeftY());
-        *result = converted_value;
+        *result = ValueConvertUtils::SafeConvert<bigint_type>(obj->GetLowerLeftY());
         return VANILLAPDF_ERROR_SUCCESS;
     } CATCH_VANILLAPDF_EXCEPTIONS
 }
@@ -104,8 +101,7 @@ VANILLAPDF_API error_type CALLING_CONVENTION Rectangle_SetLowerLeftY(RectangleHa
 
     try
     {
-        auto converted_value = ValueConvertUtils::SafeConvert<types::real>(data);
-        obj->SetLowerLeftY(converted_value);
+        obj->SetLowerLeftY(ValueConvertUtils::SafeConvert<types::real>(data));
         return VANILLAPDF_ERROR_SUCCESS;
     } CATCH_VANILLAPDF_EXCEPTIONS
 }
@@ -129,8 +125,7 @@ VANILLAPDF_API error_type CALLING_CONVENTION Rectangle_GetUpperRightX(RectangleH
 
     try
     {
-        auto converted_value = ValueConvertUtils::SafeConvert<bigint_type>(obj->GetUpperRightX());
-        *result = converted_value;
+        *result = ValueConvertUtils::SafeConvert<bigint_type>(obj->GetUpperRightX());
         return VANILLAPDF_ERROR_SUCCESS;
     } CATCH_VANILLAPDF_EXCEPTIONS
 }
@@ -154,8 +149,7 @@ VANILLAPDF_API error_type CALLING_CONVENTION Rectangle_SetUpperRightX(RectangleH
 
     try
     {
-        auto converted_value = ValueConvertUtils::SafeConvert<types::real>(data);
-        obj->SetUpperRightX(converted_value);
+        obj->SetUpperRightX(ValueConvertUtils::SafeConvert<types::real>(data));
         return VANILLAPDF_ERROR_SUCCESS;
     } CATCH_VANILLAPDF_EXCEPTIONS
 }
@@ -179,8 +173,7 @@ VANILLAPDF_API error_type CALLING_CONVENTION Rectangle_GetUpperRightY(RectangleH
 
     try
     {
-        auto converted_value = ValueConvertUtils::SafeConvert<bigint_type>(obj->GetUpperRightY());
-        *result = converted_value;
+        *result = ValueConvertUtils::SafeConvert<bigint_type>(obj->GetUpperRightY());
         return VANILLAPDF_ERROR_SUCCESS;
     } CATCH_VANILLAPDF_EXCEPTIONS
 }
@@ -204,8 +197,7 @@ VANILLAPDF_API error_type CALLING_CONVENTION Rectangle_SetUpperRightY(RectangleH
 
     try
     {
-        auto converted_value = ValueConvertUtils::SafeConvert<types::real>(data);
-        obj->SetUpperRightY(converted_value);
+        obj->SetUpperRightY(ValueConvertUtils::SafeConvert<types::real>(data));
         return VANILLAPDF_ERROR_SUCCESS;
     } CATCH_VANILLAPDF_EXCEPTIONS
 }

--- a/src/vanillapdf/semantics/objects/annotations.cpp
+++ b/src/vanillapdf/semantics/objects/annotations.cpp
@@ -229,7 +229,7 @@ bool AnnotationBase::GetRect(OutputRectanglePtr& result) const {
         return false;
     }
 
-    auto rect_obj = _obj->FindAs<syntax::ArrayObjectPtr<syntax::IntegerObjectPtr>>(constant::Name::Rect);
+    auto rect_obj = _obj->FindAs<syntax::ArrayObjectPtr<syntax::RealObjectPtr>>(constant::Name::Rect);
     auto rect = make_deferred<Rectangle>(rect_obj);
     result = rect;
     return true;

--- a/src/vanillapdf/semantics/objects/page_object.cpp
+++ b/src/vanillapdf/semantics/objects/page_object.cpp
@@ -52,7 +52,7 @@ bool PageObject::GetMediaBox(OutputRectanglePtr& result) const {
         return false;
     }
 
-    auto box_obj = _obj->FindAs<syntax::ArrayObjectPtr<syntax::IntegerObjectPtr>>(Name::MediaBox);
+    auto box_obj = _obj->FindAs<syntax::ArrayObjectPtr<syntax::RealObjectPtr>>(Name::MediaBox);
     auto box = make_deferred<Rectangle>(box_obj);
     result = box;
     return true;

--- a/src/vanillapdf/semantics/objects/rectangle.cpp
+++ b/src/vanillapdf/semantics/objects/rectangle.cpp
@@ -11,7 +11,7 @@ Rectangle::Rectangle() {
     _obj->Append(m_ury);
 }
 
-Rectangle::Rectangle(syntax::ArrayObjectPtr<syntax::IntegerObjectPtr> list) : HighLevelObject(list) {
+Rectangle::Rectangle(syntax::ArrayObjectPtr<syntax::RealObjectPtr> list) : HighLevelObject(list) {
     assert(list->GetSize() == 4 && "Only fully specified rectangles are yet supported");
     if (list->GetSize() != 4) {
         throw InvalidParameterException("Invalid rectangle size: " + std::to_string(list->GetSize()));

--- a/src/vanillapdf/semantics/objects/rectangle.h
+++ b/src/vanillapdf/semantics/objects/rectangle.h
@@ -4,29 +4,31 @@
 #include "semantics/utils/semantics_fwd.h"
 #include "semantics/objects/high_level_object.h"
 
+#include "syntax/objects/real_object.h"
+
 namespace vanillapdf {
 namespace semantics {
 
-class Rectangle : public HighLevelObject<syntax::ArrayObjectPtr<syntax::IntegerObjectPtr>> {
+class Rectangle : public HighLevelObject<syntax::ArrayObjectPtr<syntax::RealObjectPtr>> {
 public:
     Rectangle();
-    explicit Rectangle(syntax::ArrayObjectPtr<syntax::IntegerObjectPtr> list);
+    explicit Rectangle(syntax::ArrayObjectPtr<syntax::RealObjectPtr> list);
 
-    types::big_int GetLowerLeftX() const { return m_llx->GetIntegerValue(); }
-    types::big_int GetLowerLeftY() const { return m_lly->GetIntegerValue(); }
-    types::big_int GetUpperRightX() const { return m_urx->GetIntegerValue(); }
-    types::big_int GetUpperRightY() const { return m_ury->GetIntegerValue(); }
+    types::real GetLowerLeftX() const { return m_llx->GetValue(); }
+    types::real GetLowerLeftY() const { return m_lly->GetValue(); }
+    types::real GetUpperRightX() const { return m_urx->GetValue(); }
+    types::real GetUpperRightY() const { return m_ury->GetValue(); }
 
-    void SetLowerLeftX(types::big_int value) { m_llx->SetValue(value); }
-    void SetLowerLeftY(types::big_int value) { m_lly->SetValue(value); }
-    void SetUpperRightX(types::big_int value) { m_urx->SetValue(value); }
-    void SetUpperRightY(types::big_int value) { m_ury->SetValue(value); }
+    void SetLowerLeftX(types::real value) { m_llx->SetValue(value); }
+    void SetLowerLeftY(types::real value) { m_lly->SetValue(value); }
+    void SetUpperRightX(types::real value) { m_urx->SetValue(value); }
+    void SetUpperRightY(types::real value) { m_ury->SetValue(value); }
 
 private:
-    syntax::IntegerObjectPtr m_llx;
-    syntax::IntegerObjectPtr m_lly;
-    syntax::IntegerObjectPtr m_urx;
-    syntax::IntegerObjectPtr m_ury;
+    syntax::RealObjectPtr m_llx;
+    syntax::RealObjectPtr m_lly;
+    syntax::RealObjectPtr m_urx;
+    syntax::RealObjectPtr m_ury;
 };
 
 } // semantics


### PR DESCRIPTION
## Summary

Fixes #512.

`Rectangle` was backed by `ArrayObjectPtr<IntegerObjectPtr>`, so real-valued coordinates — the common case in practice (A4 `/MediaBox [0 0 595.276 841.89]`, fractional widget `/Rect` entries) — were silently truncated on read and could not be written at all. This blocks the visible-signature work (#315 Phase 6), which needs user-supplied fractional rects.

## Changes

- **`Rectangle` is now real-backed**: `ArrayObjectPtr<RealObjectPtr>` with `types::real` accessors. Mixed integer/real arrays keep working through the shared `NumericObjectBackend` (`ConversionHelper` cross-converts by sharing the backend), and parsed integer coordinates keep their integer representation when left untouched. Setters follow the ecosystem norm (iText, MuPDF, PDFium, QPDF all model rect coordinates as always-real from float-typed APIs); whole values still serialize without a decimal point because `NumericObjectBackend::RealString` uses fmt shortest round-trip formatting.
- **Read sites widened**: `PageObject::GetMediaBox` and `AnnotationBase::GetRect` read `/MediaBox` and `/Rect` as real-typed arrays instead of integer-typed ones.
- **C API (additive, no ABI break)**: new `Rectangle_{Get,Set}{LowerLeft,UpperRight}{X,Y}Real` functions taking `real_type`; the eight `bigint_type` originals are marked `VANILLAPDF_DEPRECATED` and remain as compatibility shims (getters range-check and truncate via `ValueConvertUtils::SafeConvert`, setters convert to real). Removal is planned for 3.0.
- **Internal migration sweep**: all internal callers (unit tests, integration test printer) moved to the Real variants; the integration printer now prints coordinates with `%g`.

## Precision note

Moving the API to `double` bounds exactly-representable integers at 2^53. Per ISO 32000-1 Annex C, coordinate values are limited to ±2^31 in practice (and meaningful page coordinates are orders of magnitude below even that), so no spec-valid rectangle loses precision.

## Tests

- New `Annotation.RealValuedRect` — fractional `/Rect` roundtrip through an annotation.
- New `PageObject.MediaBoxRealCoordinates` — A4 media box with mixed integer/real elements, mirroring the object layout produced by parsing, read through `PageObject_GetMediaBox`.
- 70/70 targeted unit tests (Rectangle/Annotation/PageObject/PageAnnotations/PageTree) and annotation-related integration PDFs pass locally in Debug.

## Follow-up

The value-canonical hash/equality inconsistency between `IntegerObject` and `RealObject` discovered during this work (equal values hash differently; `Equals` is asymmetric under truncation) is intentionally out of scope and tracked in #522.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
