### PR TITLE
feat: Add the FieldTree API over the interactive form field hierarchy

### DIFF
--- a/include/files.cmake
+++ b/include/files.cmake
@@ -75,6 +75,7 @@ set(VANILLAPDF_INCLUDE_SEMANTICS_HEADERS
     "${VANILLAPDF_SOLUTION_SOURCE_DIR}/include/vanillapdf/semantics/c_document_info.h"
     "${VANILLAPDF_SOLUTION_SOURCE_DIR}/include/vanillapdf/semantics/c_document_signature_settings.h"
     "${VANILLAPDF_SOLUTION_SOURCE_DIR}/include/vanillapdf/semantics/c_fields.h"
+    "${VANILLAPDF_SOLUTION_SOURCE_DIR}/include/vanillapdf/semantics/c_field_tree.h"
     "${VANILLAPDF_SOLUTION_SOURCE_DIR}/include/vanillapdf/semantics/c_font.h"
     "${VANILLAPDF_SOLUTION_SOURCE_DIR}/include/vanillapdf/semantics/c_font_map.h"
     "${VANILLAPDF_SOLUTION_SOURCE_DIR}/include/vanillapdf/semantics/c_interactive_forms.h"

--- a/include/vanillapdf/c_handles.h
+++ b/include/vanillapdf/c_handles.h
@@ -204,6 +204,7 @@ extern "C"
 
     DECLARE_OBJECT_HANDLE(Field);
     DECLARE_OBJECT_HANDLE(FieldCollection);
+    DECLARE_OBJECT_HANDLE(FieldTree);
     DECLARE_OBJECT_HANDLE(ButtonField);
     DECLARE_OBJECT_HANDLE(TextField);
     DECLARE_OBJECT_HANDLE(ChoiceField);

--- a/include/vanillapdf/c_vanillapdf_api.h
+++ b/include/vanillapdf/c_vanillapdf_api.h
@@ -55,6 +55,7 @@
 #include "vanillapdf/semantics/c_interactive_forms.h"
 #include "vanillapdf/semantics/c_signature_flags.h"
 #include "vanillapdf/semantics/c_fields.h"
+#include "vanillapdf/semantics/c_field_tree.h"
 #include "vanillapdf/semantics/c_byte_range.h"
 #include "vanillapdf/semantics/c_digital_signature.h"
 #include "vanillapdf/semantics/c_digital_signature_extensions.h"

--- a/include/vanillapdf/semantics/c_catalog.h
+++ b/include/vanillapdf/semantics/c_catalog.h
@@ -150,6 +150,11 @@ extern "C"
     * \brief
     * The document's interactive form
     * (see 12.7, "Interactive Forms").
+    *
+    * The same form instance is returned for the lifetime of this catalog
+    * handle, so the field hierarchy it owns - and the cache behind it - is
+    * shared by everyone reaching the form this way, \ref Document_Sign
+    * included.
     */
     VANILLAPDF_API error_type CALLING_CONVENTION Catalog_GetAcroForm(CatalogHandle* handle, InteractiveFormHandle** result);
 
@@ -159,7 +164,10 @@ extern "C"
     *
     * The catalog stores an indirect reference, so the form has to be
     * registered within the document - use
-    * \ref InteractiveForm_CreateFromDocument to obtain one.
+    * \ref InteractiveForm_CreateFromDocument to obtain one. The instance
+    * to work with afterwards is the one \ref Catalog_GetAcroForm hands
+    * out, which is resolved over the installed dictionary; the handle
+    * passed here is not the one shared through the catalog.
     */
     VANILLAPDF_API error_type CALLING_CONVENTION Catalog_SetAcroForm(CatalogHandle* handle, InteractiveFormHandle* value);
 

--- a/include/vanillapdf/semantics/c_catalog.h
+++ b/include/vanillapdf/semantics/c_catalog.h
@@ -164,10 +164,10 @@ extern "C"
     *
     * The catalog stores an indirect reference, so the form has to be
     * registered within the document - use
-    * \ref InteractiveForm_CreateFromDocument to obtain one. The instance
-    * to work with afterwards is the one \ref Catalog_GetAcroForm hands
-    * out, which is resolved over the installed dictionary; the handle
-    * passed here is not the one shared through the catalog.
+    * \ref InteractiveForm_CreateFromDocument to obtain one. The attached
+    * instance becomes the one \ref Catalog_GetAcroForm returns, so the
+    * caller's handle and everyone reaching the form through the catalog
+    * share a single form and a single field hierarchy.
     */
     VANILLAPDF_API error_type CALLING_CONVENTION Catalog_SetAcroForm(CatalogHandle* handle, InteractiveFormHandle* value);
 

--- a/include/vanillapdf/semantics/c_field_tree.h
+++ b/include/vanillapdf/semantics/c_field_tree.h
@@ -131,6 +131,14 @@ extern "C"
     * that may legitimately contain U+0000, which UTF-8 encodes as a NUL
     * byte.
     *
+    * The names are the ones the hierarchy walk produces - each field's
+    * partial name appended to the name of the node whose /Kids reached it
+    * - so they agree with the enumeration by construction.
+    * Field_GetQualifiedName has nothing but the field's /Parent entries to
+    * follow; in a well-formed file the two are the same, in a file whose
+    * /Parent entries are missing or wrong they differ, and the walk's name
+    * is the one to look up.
+    *
     * Fully qualified names shall be unique (12.7.3.2), but existing documents
     * do not always honor that. Duplicates are tolerated when reading - a
     * warning is logged when the hierarchy is first enumerated, and the lookup

--- a/include/vanillapdf/semantics/c_field_tree.h
+++ b/include/vanillapdf/semantics/c_field_tree.h
@@ -138,10 +138,13 @@ extern "C"
     /**
     * \brief
     * Get the number of top-level fields - the entries of the root /Fields
-    * array, groups included.
+    * array that are field dictionaries, groups included.
     *
-    * This is the first level of the structural view; \ref Field_GetChildCount
-    * continues below it.
+    * The root array holds fields only (Table 218); a stray dictionary in it
+    * - a widget annotation, say - is not a field and is skipped with a
+    * warning, the same way a widget among a field's /Kids is skipped by
+    * \ref Field_GetChildCount. This is the first level of the structural
+    * view; Field_GetChildCount continues below it.
     */
     VANILLAPDF_API error_type CALLING_CONVENTION FieldTree_GetRootChildCount(FieldTreeHandle* handle, size_type* result);
 
@@ -180,9 +183,9 @@ extern "C"
     * Insert a top-level field at the given zero-based position among the
     * root /Fields entries.
     *
-    * The index counts the /Fields entries - the same space as
-    * \ref FieldTree_GetRootChild, not the flat view - and an index equal to
-    * \ref FieldTree_GetRootChildCount appends. The order of the container
+    * The index is a position in the /Fields array itself - the same space
+    * as \ref FieldTree_GetRootChild as long as every entry is a field, not
+    * the flat view - and an index equal to the array size appends. The order of the container
     * arrays affects the enumeration order of the hierarchy only; the tab
     * order of a page comes from its /Annots array. Otherwise identical to
     * \ref FieldTree_AddRootChild.

--- a/include/vanillapdf/semantics/c_field_tree.h
+++ b/include/vanillapdf/semantics/c_field_tree.h
@@ -186,10 +186,16 @@ extern "C"
     * as an indirect object within the document, for example through
     * \ref File_AllocateNewEntry.
     *
+    * The child may bring a subtree of its own - a group with its /Kids
+    * already in place. Every node of that subtree is held to the same
+    * rules as the child, under the fully qualified names the hierarchy
+    * will give them once the child is in place.
+    *
     * \returns \ref VANILLAPDF_ERROR_PARAMETER_VALUE when the child's
-    * dictionary is a direct object, the child already belongs to this
-    * hierarchy, or a field with the resulting fully qualified name already
-    * exists.
+    * dictionary is a direct object, the child or a node of its subtree
+    * already belongs to this hierarchy, or a fully qualified name the
+    * subtree would take already exists - in this hierarchy or twice within
+    * the subtree itself.
     */
     VANILLAPDF_API error_type CALLING_CONVENTION FieldTree_AddRootChild(FieldTreeHandle* handle, FieldHandle* child);
 

--- a/include/vanillapdf/semantics/c_field_tree.h
+++ b/include/vanillapdf/semantics/c_field_tree.h
@@ -55,6 +55,18 @@ extern "C"
     * empty one with \ref FieldTree_CreateFromDocument and
     * \ref InteractiveForm_SetFieldTree.
     *
+    * Thread safety: every FieldTree_* call on one tree handle is
+    * serialized on the tree's own lock, so the flat view, the top level
+    * and the mutators may be used concurrently on the same tree - a
+    * mutation is atomic and a concurrent enumeration observes it entirely
+    * or not at all. The Field_* calls are not part of that: a field is a
+    * plain view over its dictionary, so \ref Field_GetChild,
+    * \ref Field_GetParent and the field getters and setters run outside
+    * the tree's lock, as does any edit through the dictionary API. Walking
+    * the structure through Field_GetChild while another thread mutates the
+    * tree is a data race on the /Kids arrays, the same as any other
+    * unsynchronized dictionary access.
+    *
     * For more details please visit [section 12.7.3 - Field Dictionaries](PDF32000_2008.pdf#G11.2110737).
     */
 
@@ -188,10 +200,14 @@ extern "C"
     * The child's /Parent entry is set to the parent, and the parent's /Kids
     * array is created when the parent has none yet. Adding a child to a
     * field that is currently a terminal turns it into a group; the child's
-    * fully qualified name is then prefixed with the parent's. The parent
-    * of a nested field, as reported by \ref Field_GetParent, is always a
-    * valid argument here; a top-level field has no parent and is added
-    * next to with \ref FieldTree_AddRootChild.
+    * fully qualified name is then prefixed with the parent's. Any field of
+    * this hierarchy is a valid parent, whether it came from
+    * \ref FieldTree_GetRootChild, \ref Field_GetChild, \ref FieldTree_GetField
+    * or \ref Field_GetParent - with the caveat that Field_GetParent reports
+    * the /Parent entry as written, which a damaged file may point outside
+    * the hierarchy (refused here) or at the wrong node of it (accepted, and
+    * the child lands under that node). A top-level field has no parent and
+    * a sibling of it is added with \ref FieldTree_AddRootChild.
     *
     * \returns \ref VANILLAPDF_ERROR_PARAMETER_VALUE as for
     * \ref FieldTree_AddRootChild, and when the parent does not belong to
@@ -230,10 +246,14 @@ extern "C"
     * The widget annotations of the removed fields are not touched - they
     * stay in the page /Annots arrays. Remove them through
     * \ref PageAnnotations_Remove, otherwise the page keeps drawing widgets
-    * of fields that no longer exist.
+    * of fields that no longer exist. A container that lists the same node
+    * twice - which the enumeration reports once - loses the first entry
+    * only.
     *
     * \returns \ref VANILLAPDF_ERROR_PARAMETER_VALUE when the field does not
-    * belong to this hierarchy.
+    * belong to this hierarchy, or when its container no longer holds it
+    * because the hierarchy was edited underneath the tree without
+    * \ref FieldTree_Invalidate.
     */
     VANILLAPDF_API error_type CALLING_CONVENTION FieldTree_RemoveChild(FieldTreeHandle* handle, FieldHandle* field);
 

--- a/include/vanillapdf/semantics/c_field_tree.h
+++ b/include/vanillapdf/semantics/c_field_tree.h
@@ -97,6 +97,13 @@ extern "C"
     * A group without any child field yet is indistinguishable from a field
     * without widgets and is enumerated as a terminal field until it receives
     * a child.
+    *
+    * Both views classify the /Fields and /Kids entries the same way, so
+    * this is exactly the set of terminals the structural walk reaches. The
+    * arrays shall hold indirect references (Table 218, Table 220); an entry
+    * that is not one - a direct dictionary, say - does occur in existing
+    * files and is skipped with a warning rather than failing the
+    * enumeration, the same as a cyclic /Kids link.
     */
     VANILLAPDF_API error_type CALLING_CONVENTION FieldTree_GetFieldCount(FieldTreeHandle* handle, size_type* result);
 

--- a/include/vanillapdf/semantics/c_field_tree.h
+++ b/include/vanillapdf/semantics/c_field_tree.h
@@ -1,0 +1,275 @@
+#ifndef _C_FIELD_TREE_H
+#define _C_FIELD_TREE_H
+
+#include "vanillapdf/c_export.h"
+#include "vanillapdf/c_handles.h"
+#include "vanillapdf/c_values.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+    /**
+    * \file c_field_tree.h
+    * \brief This file contains class definitions for \ref FieldTreeHandle
+    */
+
+    /**
+    * \class FieldTreeHandle
+    * \extends IUnknownHandle
+    * \ingroup group_fields
+    * \brief
+    * The field hierarchy of an interactive form (PDF 1.2, section 12.7.3).
+    *
+    * The hierarchy is a tree whose top is the root /Fields array: its
+    * entries are the top-level fields, and a non-terminal field groups
+    * other fields through /Kids for naming and attribute inheritance. The
+    * tree is the view over that array, the same way \ref PageTreeHandle is
+    * the view over the page tree root.
+    *
+    * The tree offers two views over the hierarchy, told apart by their
+    * vocabulary - *Field* is the flat view, *Child* the structure:
+    *
+    * - The flat view - \ref FieldTree_GetFieldCount, \ref FieldTree_GetField
+    *   and \ref FieldTree_FindField - enumerates the resolved terminal
+    *   fields in document order. Terminal fields are the logical fields a
+    *   user interacts with; the grouping nodes are hidden, the same way the
+    *   page tree hides its interior nodes. This is the default path for
+    *   form filling.
+    * - The structural view starts at the top level with
+    *   \ref FieldTree_GetRootChildCount and \ref FieldTree_GetRootChild and
+    *   continues down through \ref Field_GetChildCount and
+    *   \ref Field_GetChild; \ref Field_GetParent walks back up and stops at
+    *   a top-level field, which has no /Parent.
+    *
+    * Every field mutation goes through the tree, because the tree owns the
+    * cache behind the flat view: \ref FieldTree_AddRootChild and
+    * \ref FieldTree_InsertRootChild at the top level, \ref FieldTree_AddChild
+    * and \ref FieldTree_InsertChild below it, \ref FieldTree_RemoveChild at
+    * either. Editing /Fields, /Kids or /Parent through the dictionary API
+    * underneath is possible; call \ref FieldTree_Invalidate afterwards.
+    *
+    * Obtain the tree of an existing form from
+    * \ref InteractiveForm_GetFieldTree; give a form that has none yet an
+    * empty one with \ref FieldTree_CreateFromDocument and
+    * \ref InteractiveForm_SetFieldTree.
+    *
+    * For more details please visit [section 12.7.3 - Field Dictionaries](PDF32000_2008.pdf#G11.2110737).
+    */
+
+    /**
+    * \memberof FieldTreeHandle
+    * @{
+    */
+
+    /**
+    * \brief
+    * Create an empty field hierarchy belonging to the document.
+    *
+    * The hierarchy is fully usable right away - fields can be added to it
+    * before it is attached - but it does not take effect until it is
+    * attached to a form with \ref InteractiveForm_SetFieldTree, which
+    * installs this very array as the form's /Fields entry. Creating and
+    * attaching are deliberately separate steps, so that reading a document
+    * never modifies it.
+    */
+    VANILLAPDF_API error_type CALLING_CONVENTION FieldTree_CreateFromDocument(DocumentHandle* handle, FieldTreeHandle** result);
+
+    /**
+    * \brief
+    * Get the number of resolved terminal fields in the hierarchy.
+    *
+    * A radio button group is a single terminal field with one value,
+    * regardless of how many widget annotations represent it on the page.
+    * A group without any child field yet is indistinguishable from a field
+    * without widgets and is enumerated as a terminal field until it receives
+    * a child.
+    */
+    VANILLAPDF_API error_type CALLING_CONVENTION FieldTree_GetFieldCount(FieldTreeHandle* handle, size_type* result);
+
+    /**
+    * \brief
+    * Get the resolved terminal field at the given zero-based index, in
+    * document order.
+    *
+    * Indices are stable until the hierarchy is mutated. This index space is
+    * the flat view's own - it is not a position for the structural
+    * mutators.
+    * \returns \ref VANILLAPDF_ERROR_OBJECT_MISSING when the index is out
+    * of range.
+    * \see \ref FieldTree_GetFieldCount
+    */
+    VANILLAPDF_API error_type CALLING_CONVENTION FieldTree_GetField(FieldTreeHandle* handle, size_type index, FieldHandle** result);
+
+    /**
+    * \brief
+    * Find a terminal field by its fully qualified name - the partial field
+    * names (/T entries) joined with '.', UTF-8 encoded - the same form
+    * \ref Field_GetQualifiedName produces, so its data can be passed back
+    * here unchanged. The name is given with an explicit size rather than
+    * as a NUL-terminated string because a partial name is a text string
+    * that may legitimately contain U+0000, which UTF-8 encodes as a NUL
+    * byte.
+    *
+    * Fully qualified names shall be unique (12.7.3.2), but existing documents
+    * do not always honor that. Duplicates are tolerated when reading - a
+    * warning is logged when the hierarchy is first enumerated, and the lookup
+    * resolves to the first terminal field in document order - and rejected
+    * when writing through the structural mutators.
+    *
+    * \returns \ref VANILLAPDF_ERROR_OBJECT_MISSING when no terminal field has
+    * that name.
+    */
+    VANILLAPDF_API error_type CALLING_CONVENTION FieldTree_FindField(FieldTreeHandle* handle, string_type qualified_name, size_type size, FieldHandle** result);
+
+    /**
+    * \brief
+    * Get the number of top-level fields - the entries of the root /Fields
+    * array, groups included.
+    *
+    * This is the first level of the structural view; \ref Field_GetChildCount
+    * continues below it.
+    */
+    VANILLAPDF_API error_type CALLING_CONVENTION FieldTree_GetRootChildCount(FieldTreeHandle* handle, size_type* result);
+
+    /**
+    * \brief
+    * Get the top-level field at the given zero-based index, in /Fields
+    * order.
+    *
+    * Together with \ref Field_GetChild this walks the whole hierarchy: the
+    * top-level fields from here, every level below through the field.
+    * \returns \ref VANILLAPDF_ERROR_OBJECT_MISSING when the index is out
+    * of range.
+    * \see \ref FieldTree_GetRootChildCount
+    */
+    VANILLAPDF_API error_type CALLING_CONVENTION FieldTree_GetRootChild(FieldTreeHandle* handle, size_type index, FieldHandle** result);
+
+    /**
+    * \brief
+    * Append a top-level field to the root /Fields array.
+    *
+    * Any /Parent entry the child carries is removed - Table 220 requires
+    * /Parent for /Kids entries only. The container arrays hold indirect
+    * references, so the child's underlying dictionary shall be registered
+    * as an indirect object within the document, for example through
+    * \ref File_AllocateNewEntry.
+    *
+    * \returns \ref VANILLAPDF_ERROR_PARAMETER_VALUE when the child's
+    * dictionary is a direct object, the child already belongs to this
+    * hierarchy, or a field with the resulting fully qualified name already
+    * exists.
+    */
+    VANILLAPDF_API error_type CALLING_CONVENTION FieldTree_AddRootChild(FieldTreeHandle* handle, FieldHandle* child);
+
+    /**
+    * \brief
+    * Insert a top-level field at the given zero-based position among the
+    * root /Fields entries.
+    *
+    * The index counts the /Fields entries - the same space as
+    * \ref FieldTree_GetRootChild, not the flat view - and an index equal to
+    * \ref FieldTree_GetRootChildCount appends. The order of the container
+    * arrays affects the enumeration order of the hierarchy only; the tab
+    * order of a page comes from its /Annots array. Otherwise identical to
+    * \ref FieldTree_AddRootChild.
+    *
+    * \returns \ref VANILLAPDF_ERROR_OBJECT_MISSING when the index is out of
+    * range, \ref VANILLAPDF_ERROR_PARAMETER_VALUE as for
+    * \ref FieldTree_AddRootChild.
+    */
+    VANILLAPDF_API error_type CALLING_CONVENTION FieldTree_InsertRootChild(FieldTreeHandle* handle, size_type index, FieldHandle* child);
+
+    /**
+    * \brief
+    * Append a child field to a parent field of this hierarchy.
+    *
+    * The child's /Parent entry is set to the parent, and the parent's /Kids
+    * array is created when the parent has none yet. Adding a child to a
+    * field that is currently a terminal turns it into a group; the child's
+    * fully qualified name is then prefixed with the parent's. The parent
+    * of a nested field, as reported by \ref Field_GetParent, is always a
+    * valid argument here; a top-level field has no parent and is added
+    * next to with \ref FieldTree_AddRootChild.
+    *
+    * \returns \ref VANILLAPDF_ERROR_PARAMETER_VALUE as for
+    * \ref FieldTree_AddRootChild, and when the parent does not belong to
+    * this hierarchy, is a terminal field carrying widget annotations, or is
+    * merged with its own widget annotation.
+    */
+    VANILLAPDF_API error_type CALLING_CONVENTION FieldTree_AddChild(FieldTreeHandle* handle, FieldHandle* parent, FieldHandle* child);
+
+    /**
+    * \brief
+    * Insert a child field at the given zero-based position among the
+    * parent's /Kids entries.
+    *
+    * The index counts the parent's /Kids entries and an index equal to
+    * \ref Field_GetChildCount appends. Otherwise identical to
+    * \ref FieldTree_AddChild.
+    *
+    * \returns \ref VANILLAPDF_ERROR_OBJECT_MISSING when the index is out of
+    * range, \ref VANILLAPDF_ERROR_PARAMETER_VALUE as for
+    * \ref FieldTree_AddChild.
+    */
+    VANILLAPDF_API error_type CALLING_CONVENTION FieldTree_InsertChild(FieldTreeHandle* handle, FieldHandle* parent, size_type index, FieldHandle* child);
+
+    /**
+    * \brief
+    * Remove a field - top-level or nested - from the hierarchy.
+    *
+    * The field's reference is removed from the container the hierarchy
+    * walk reached it through - the root /Fields array or its group's
+    * /Kids - and its /Parent entry is cleared. The walk is the authority,
+    * not the field's /Parent entry: a field whose /Parent is missing or
+    * points elsewhere is still removed from where it actually is. A group
+    * is removed together with its whole subtree. A group emptied by the
+    * removal stays in place; remove it explicitly if it is no longer wanted.
+    *
+    * The widget annotations of the removed fields are not touched - they
+    * stay in the page /Annots arrays. Remove them through
+    * \ref PageAnnotations_Remove, otherwise the page keeps drawing widgets
+    * of fields that no longer exist.
+    *
+    * \returns \ref VANILLAPDF_ERROR_PARAMETER_VALUE when the field does not
+    * belong to this hierarchy.
+    */
+    VANILLAPDF_API error_type CALLING_CONVENTION FieldTree_RemoveChild(FieldTreeHandle* handle, FieldHandle* field);
+
+    /**
+    * \brief
+    * Discard the cached flat view, so the next access rebuilds it from the
+    * dictionaries.
+    *
+    * The tree caches the resolved terminal fields and keeps that cache
+    * valid across its own mutators. It cannot observe edits made underneath
+    * it through the dictionary API - via \ref Field_GetBaseObject or any
+    * other path to the /Fields, /Kids and /Parent entries. Call this after
+    * such edits and before the next enumeration or lookup.
+    */
+    VANILLAPDF_API error_type CALLING_CONVENTION FieldTree_Invalidate(FieldTreeHandle* handle);
+
+    /**
+    * \brief Reinterpret current object as \ref IUnknownHandle
+    */
+    VANILLAPDF_API error_type CALLING_CONVENTION FieldTree_ToUnknown(FieldTreeHandle* handle, IUnknownHandle** result);
+
+    /**
+    * \brief Convert \ref IUnknownHandle to \ref FieldTreeHandle
+    */
+    VANILLAPDF_API error_type CALLING_CONVENTION FieldTree_FromUnknown(IUnknownHandle* handle, FieldTreeHandle** result);
+
+    /**
+    * \copydoc IUnknown_Release
+    * \see \ref IUnknown_Release
+    */
+    VANILLAPDF_API error_type CALLING_CONVENTION FieldTree_Release(FieldTreeHandle* handle);
+
+    /** @} */
+
+#ifdef __cplusplus
+};
+#endif
+
+#endif /* _C_FIELD_TREE_H */

--- a/include/vanillapdf/semantics/c_fields.h
+++ b/include/vanillapdf/semantics/c_fields.h
@@ -236,6 +236,15 @@ extern "C"
     * The /FT entry is inheritable and is resolved through the /Parent chain.
     * A non-terminal field without a resolvable type reports
     * \ref FieldType_NonTerminal.
+    *
+    * The type and the position in the hierarchy are independent: a group
+    * whose /FT is set, or inherited from an ancestor, reports that type
+    * and converts to the matching handle - \ref TextField_FromField on a
+    * text group succeeds, and \ref TextField_GetValue then returns the /V
+    * the group carries or inherits. This is what lets a field merged with
+    * its widget annotation, which usually carries /FT on the parent only,
+    * report its type. Ask \ref Field_IsTerminal whether a field is a
+    * logical field or a group; the type does not answer that.
     */
     VANILLAPDF_API error_type CALLING_CONVENTION Field_GetType(FieldHandle* handle, FieldType* result);
 
@@ -290,6 +299,10 @@ extern "C"
     * child field when it carries /T, /Kids or /FT, and a widget annotation
     * otherwise; a field merged with its widget annotation carries both /T
     * and /Subtype /Widget and is a child field.
+    *
+    * This is independent of \ref Field_GetType: a group can report a
+    * typed field type through its own or an inherited /FT, and a terminal
+    * field without any resolvable /FT reports \ref FieldType_NonTerminal.
     */
     VANILLAPDF_API error_type CALLING_CONVENTION Field_IsTerminal(FieldHandle* handle, boolean_type* result);
 

--- a/include/vanillapdf/semantics/c_fields.h
+++ b/include/vanillapdf/semantics/c_fields.h
@@ -22,16 +22,25 @@ extern "C"
     * \brief Collection of \ref FieldHandle
     * \deprecated
     * The raw /Fields array models dictionary nodes rather than logical
-    * fields. Enumerate the resolved terminal fields with
-    * \ref InteractiveForm_GetFieldCount and \ref InteractiveForm_GetField,
-    * and append new fields with \ref InteractiveForm_AddField.
+    * fields. Use the field hierarchy from \ref InteractiveForm_GetFieldTree
+    * instead - \ref FieldTree_GetFieldCount and \ref FieldTree_GetField
+    * for the resolved terminal fields, \ref FieldTree_GetRootChild with
+    * \ref Field_GetChild for the structure.
     */
 
     /**
     * \class FieldHandle
     * \extends IUnknownHandle
     * \ingroup group_fields
-    * \brief Base class for all fields
+    * \brief
+    * Base class for all fields.
+    *
+    * Fields form a hierarchy (12.7.3): the root /Fields array holds the
+    * top-level fields, non-terminal fields group other fields through /Kids
+    * for naming and attribute inheritance, and terminal fields are the
+    * logical fields a user interacts with. A field is a view over its own
+    * dictionary; the level above the top-level fields is the
+    * \ref FieldTreeHandle.
     */
 
     /**
@@ -183,26 +192,15 @@ extern "C"
     */
 
     /**
-    * \brief
-    * Create an empty field collection.
-    *
-    * Attach it to an interactive form with \ref InteractiveForm_SetFields.
-    * \deprecated
-    * Append fields directly with \ref InteractiveForm_AddField, which
-    * creates the /Fields array on demand.
-    */
-    VANILLAPDF_DEPRECATED VANILLAPDF_API error_type CALLING_CONVENTION FieldCollection_Create(FieldCollectionHandle** result);
-
-    /**
     * \brief Get size of field collection
-    * \deprecated Use \ref InteractiveForm_GetFieldCount instead
+    * \deprecated Use \ref FieldTree_GetFieldCount instead
     */
     VANILLAPDF_DEPRECATED VANILLAPDF_API error_type CALLING_CONVENTION FieldCollection_GetSize(FieldCollectionHandle* handle, size_type* result);
 
     /**
     * \brief
     * Get single field from array at specific position
-    * \deprecated Use \ref InteractiveForm_GetField instead
+    * \deprecated Use \ref FieldTree_GetField instead
     */
     VANILLAPDF_DEPRECATED VANILLAPDF_API error_type CALLING_CONVENTION FieldCollection_At(FieldCollectionHandle* handle, size_type at, FieldHandle** result);
 
@@ -225,7 +223,8 @@ extern "C"
     /**
     * \brief
     * Create a field from a dictionary object.
-    * The field type is determined by the /FT entry in the dictionary.
+    * The field type is determined by the /FT entry in the dictionary,
+    * resolved through the /Parent chain.
     */
     VANILLAPDF_API error_type CALLING_CONVENTION Field_CreateFromDictionary(DictionaryObjectHandle* dictionary, FieldHandle** result);
 
@@ -233,6 +232,10 @@ extern "C"
     * \brief
     * Return type of field.
     * Result can be used to convert to derived type.
+    *
+    * The /FT entry is inheritable and is resolved through the /Parent chain.
+    * A non-terminal field without a resolvable type reports
+    * \ref FieldType_NonTerminal.
     */
     VANILLAPDF_API error_type CALLING_CONVENTION Field_GetType(FieldHandle* handle, FieldType* result);
 
@@ -264,14 +267,15 @@ extern "C"
     VANILLAPDF_API error_type CALLING_CONVENTION Field_SetAlternateName(FieldHandle* handle, StringObjectHandle* value);
 
     /**
-    * \brief Get the field flags (/Ff entry).
-    * \returns \ref VANILLAPDF_ERROR_OBJECT_MISSING if the entry is not present.
+    * \brief Get the field flags (/Ff entry), resolved through the /Parent chain.
+    * \returns \ref VANILLAPDF_ERROR_OBJECT_MISSING if the entry is present on
+    * neither the field nor any ancestor.
     * \see FieldFlags
     */
     VANILLAPDF_API error_type CALLING_CONVENTION Field_GetFieldFlags(FieldHandle* handle, FieldFlags* result);
 
     /**
-    * \brief Set the field flags (/Ff entry).
+    * \brief Set the field flags (/Ff entry) in this field's own dictionary.
     * \see FieldFlags
     */
     VANILLAPDF_API error_type CALLING_CONVENTION Field_SetFieldFlags(FieldHandle* handle, FieldFlags value);
@@ -282,9 +286,45 @@ extern "C"
     *
     * A terminal field has no children other than widget annotations - it is
     * a logical field the user interacts with. A non-terminal field groups
-    * other fields for naming and attribute inheritance.
+    * other fields for naming and attribute inheritance. A /Kids entry is a
+    * child field when it carries /T, /Kids or /FT, and a widget annotation
+    * otherwise; a field merged with its widget annotation carries both /T
+    * and /Subtype /Widget and is a child field.
     */
     VANILLAPDF_API error_type CALLING_CONVENTION Field_IsTerminal(FieldHandle* handle, boolean_type* result);
+
+    /**
+    * \brief
+    * Get the number of child fields.
+    *
+    * Child fields are the /Kids entries that are fields - widget annotations
+    * are not children and are not counted. Zero for a terminal field. The
+    * top-level fields are enumerated by \ref FieldTree_GetRootChildCount.
+    */
+    VANILLAPDF_API error_type CALLING_CONVENTION Field_GetChildCount(FieldHandle* handle, size_type* result);
+
+    /**
+    * \brief
+    * Get the child field at the given zero-based index, in /Kids order.
+    *
+    * Together with \ref Field_GetChildCount this walks the hierarchy down
+    * from the top-level fields of \ref FieldTree_GetRootChild.
+    * \returns \ref VANILLAPDF_ERROR_OBJECT_MISSING when the index is out
+    * of range.
+    */
+    VANILLAPDF_API error_type CALLING_CONVENTION Field_GetChild(FieldHandle* handle, size_type index, FieldHandle** result);
+
+    /**
+    * \brief
+    * Get the parent field.
+    *
+    * A nested field reports its /Parent, which is a valid parent for
+    * \ref FieldTree_AddChild.
+    * \returns \ref VANILLAPDF_ERROR_OBJECT_MISSING for a top-level field,
+    * which has no /Parent (Table 220 requires it for /Kids entries only) -
+    * a sibling of it is added with \ref FieldTree_AddRootChild.
+    */
+    VANILLAPDF_API error_type CALLING_CONVENTION Field_GetParent(FieldHandle* handle, FieldHandle** result);
 
     /**
     * \brief
@@ -294,25 +334,55 @@ extern "C"
     * field hierarchy down to this field. Levels without a /T entry do not
     * contribute a segment. Each partial name is a text string and is
     * normalized to UTF-8, so the result is UTF-8 encoded regardless of how
-    * the names are stored in the document.
+    * the names are stored in the document. This is the form
+    * \ref FieldTree_FindField accepts.
     */
     VANILLAPDF_API error_type CALLING_CONVENTION Field_GetQualifiedName(FieldHandle* handle, BufferHandle** result);
+
+    /**
+    * \brief
+    * Get the field value (/V entry) as a raw object, resolved through the
+    * /Parent chain.
+    *
+    * The object type depends on the field type: a name for button fields,
+    * a text string for text fields, a text string or an array of text
+    * strings for choice fields, a signature dictionary for signature
+    * fields. The typed accessors such as \ref TextField_GetValue expose the
+    * same entry with its type.
+    * \returns \ref VANILLAPDF_ERROR_OBJECT_MISSING if the entry is present on
+    * neither the field nor any ancestor.
+    */
+    VANILLAPDF_API error_type CALLING_CONVENTION Field_GetValue(FieldHandle* handle, ObjectHandle** result);
+
+    /**
+    * \brief
+    * Get the default field value (/DV entry) as a raw object, resolved
+    * through the /Parent chain.
+    * \returns \ref VANILLAPDF_ERROR_OBJECT_MISSING if the entry is present on
+    * neither the field nor any ancestor.
+    * \see \ref Field_GetValue
+    */
+    VANILLAPDF_API error_type CALLING_CONVENTION Field_GetDefaultValue(FieldHandle* handle, ObjectHandle** result);
 
     /**
     * \brief
     * Get the default appearance string (/DA entry) for variable text fields,
     * resolved through the /Parent chain.
     *
-    * The document-wide default lives in the interactive form dictionary -
-    * when this function reports \ref VANILLAPDF_ERROR_OBJECT_MISSING, fall
-    * back to \ref InteractiveForm_GetDefaultAppearance.
+    * This is the field's own entry and its ancestors' only. The
+    * document-wide default lives in the interactive form dictionary;
+    * \ref InteractiveForm_ResolveDefaultAppearance performs the full lookup,
+    * form default included.
+    * \returns \ref VANILLAPDF_ERROR_OBJECT_MISSING if the entry is present on
+    * neither the field nor any ancestor.
     */
     VANILLAPDF_API error_type CALLING_CONVENTION Field_GetDefaultAppearance(FieldHandle* handle, StringObjectHandle** result);
 
     /**
     * \brief
     * Set the default appearance string (/DA entry) in this field's own
-    * dictionary, overriding any inherited value.
+    * dictionary, overriding any inherited value. The document default is
+    * set with \ref InteractiveForm_SetDefaultAppearance.
     */
     VANILLAPDF_API error_type CALLING_CONVENTION Field_SetDefaultAppearance(FieldHandle* handle, StringObjectHandle* value);
 
@@ -321,9 +391,12 @@ extern "C"
     * Get the quadding (/Q entry) - the text justification of variable text
     * fields - resolved through the /Parent chain.
     *
-    * The document-wide default lives in the interactive form dictionary -
-    * when this function reports \ref VANILLAPDF_ERROR_OBJECT_MISSING, fall
-    * back to \ref InteractiveForm_GetQuadding.
+    * This is the field's own entry and its ancestors' only. The
+    * document-wide default lives in the interactive form dictionary;
+    * \ref InteractiveForm_ResolveQuadding performs the full lookup, form
+    * default and specification default included.
+    * \returns \ref VANILLAPDF_ERROR_OBJECT_MISSING if the entry is present on
+    * neither the field nor any ancestor.
     * \see QuaddingType
     */
     VANILLAPDF_API error_type CALLING_CONVENTION Field_GetQuadding(FieldHandle* handle, QuaddingType* result);
@@ -331,7 +404,8 @@ extern "C"
     /**
     * \brief
     * Set the quadding (/Q entry) in this field's own dictionary, overriding
-    * any inherited value.
+    * any inherited value. The document default is set with
+    * \ref InteractiveForm_SetQuadding.
     * \see QuaddingType
     */
     VANILLAPDF_API error_type CALLING_CONVENTION Field_SetQuadding(FieldHandle* handle, QuaddingType value);
@@ -343,6 +417,10 @@ extern "C"
     * This is the escape hatch for anything the field API does not model -
     * the raw hierarchy is reachable through the dictionary's /Parent and
     * /Kids entries.
+    *
+    * The field hierarchy caches its flat view and cannot observe edits made
+    * through the dictionary - call \ref FieldTree_Invalidate after changing
+    * /Fields, /Kids or /Parent this way.
     */
     VANILLAPDF_API error_type CALLING_CONVENTION Field_GetBaseObject(FieldHandle* handle, DictionaryObjectHandle** result);
 

--- a/include/vanillapdf/semantics/c_fields.h
+++ b/include/vanillapdf/semantics/c_fields.h
@@ -20,6 +20,11 @@ extern "C"
     * \extends IUnknownHandle
     * \ingroup group_fields
     * \brief Collection of \ref FieldHandle
+    * \deprecated
+    * The raw /Fields array models dictionary nodes rather than logical
+    * fields. Enumerate the resolved terminal fields with
+    * \ref InteractiveForm_GetFieldCount and \ref InteractiveForm_GetField,
+    * and append new fields with \ref InteractiveForm_AddField.
     */
 
     /**
@@ -182,25 +187,33 @@ extern "C"
     * Create an empty field collection.
     *
     * Attach it to an interactive form with \ref InteractiveForm_SetFields.
+    * \deprecated
+    * Append fields directly with \ref InteractiveForm_AddField, which
+    * creates the /Fields array on demand.
     */
-    VANILLAPDF_API error_type CALLING_CONVENTION FieldCollection_Create(FieldCollectionHandle** result);
+    VANILLAPDF_DEPRECATED VANILLAPDF_API error_type CALLING_CONVENTION FieldCollection_Create(FieldCollectionHandle** result);
 
     /**
     * \brief Get size of field collection
+    * \deprecated Use \ref InteractiveForm_GetFieldCount instead
     */
-    VANILLAPDF_API error_type CALLING_CONVENTION FieldCollection_GetSize(FieldCollectionHandle* handle, size_type* result);
+    VANILLAPDF_DEPRECATED VANILLAPDF_API error_type CALLING_CONVENTION FieldCollection_GetSize(FieldCollectionHandle* handle, size_type* result);
 
     /**
     * \brief
     * Get single field from array at specific position
+    * \deprecated Use \ref InteractiveForm_GetField instead
     */
-    VANILLAPDF_API error_type CALLING_CONVENTION FieldCollection_At(FieldCollectionHandle* handle, size_type at, FieldHandle** result);
+    VANILLAPDF_DEPRECATED VANILLAPDF_API error_type CALLING_CONVENTION FieldCollection_At(FieldCollectionHandle* handle, size_type at, FieldHandle** result);
 
     /**
     * \copydoc IUnknown_Release
     * \see \ref IUnknown_Release
+    * \deprecated
+    * Retained for releasing collections obtained through the deprecated
+    * accessors - new code has no \ref FieldCollectionHandle to release.
     */
-    VANILLAPDF_API error_type CALLING_CONVENTION FieldCollection_Release(FieldCollectionHandle* handle);
+    VANILLAPDF_DEPRECATED VANILLAPDF_API error_type CALLING_CONVENTION FieldCollection_Release(FieldCollectionHandle* handle);
 
     /** @} */
 

--- a/include/vanillapdf/semantics/c_fields.h
+++ b/include/vanillapdf/semantics/c_fields.h
@@ -318,11 +318,15 @@ extern "C"
     * \brief
     * Get the parent field.
     *
-    * A nested field reports its /Parent, which is a valid parent for
-    * \ref FieldTree_AddChild.
-    * \returns \ref VANILLAPDF_ERROR_OBJECT_MISSING for a top-level field,
-    * which has no /Parent (Table 220 requires it for /Kids entries only) -
-    * a sibling of it is added with \ref FieldTree_AddRootChild.
+    * This reports the /Parent entry as written in the field dictionary. In
+    * a well-formed file that is the node whose /Kids holds the field; a
+    * damaged file may have it missing, pointing at another node of the
+    * hierarchy, or outside it. The tree walks /Kids and does not consult
+    * /Parent, so on such a file the parent reported here and the container
+    * the field is actually removed from can differ.
+    * \returns \ref VANILLAPDF_ERROR_OBJECT_MISSING when there is no /Parent
+    * entry - the case of a top-level field (Table 220 requires it for /Kids
+    * entries only), whose sibling is added with \ref FieldTree_AddRootChild.
     */
     VANILLAPDF_API error_type CALLING_CONVENTION Field_GetParent(FieldHandle* handle, FieldHandle** result);
 

--- a/include/vanillapdf/semantics/c_fields.h
+++ b/include/vanillapdf/semantics/c_fields.h
@@ -298,8 +298,11 @@ extern "C"
     * Get the number of child fields.
     *
     * Child fields are the /Kids entries that are fields - widget annotations
-    * are not children and are not counted. Zero for a terminal field. The
-    * top-level fields are enumerated by \ref FieldTree_GetRootChildCount.
+    * are not children and are not counted, and an entry that is not an
+    * indirect reference to a dictionary (Table 220) is skipped with a
+    * warning, as \ref FieldTree_GetFieldCount describes. Zero for a
+    * terminal field. The top-level fields are enumerated by
+    * \ref FieldTree_GetRootChildCount.
     */
     VANILLAPDF_API error_type CALLING_CONVENTION Field_GetChildCount(FieldHandle* handle, size_type* result);
 

--- a/include/vanillapdf/semantics/c_interactive_forms.h
+++ b/include/vanillapdf/semantics/c_interactive_forms.h
@@ -81,6 +81,10 @@ extern "C"
     * a form that does not have any fields yet. The attached instance
     * becomes the one \ref InteractiveForm_GetFieldTree returns, so the
     * caller's handle and the form share a single cache.
+    *
+    * \returns \ref VANILLAPDF_ERROR_PARAMETER_VALUE when the hierarchy was
+    * created for a different document than the form belongs to - its
+    * references would serialize as dangling object numbers here.
     */
     VANILLAPDF_API error_type CALLING_CONVENTION InteractiveForm_SetFieldTree(InteractiveFormHandle* handle, FieldTreeHandle* value);
 

--- a/include/vanillapdf/semantics/c_interactive_forms.h
+++ b/include/vanillapdf/semantics/c_interactive_forms.h
@@ -57,17 +57,34 @@ extern "C"
     /**
     * \brief
     * An array of references to the document's root fields.
+    * \deprecated
+    * Enumerate the resolved terminal fields with
+    * \ref InteractiveForm_GetFieldCount and \ref InteractiveForm_GetField
+    * instead.
     */
-    VANILLAPDF_API error_type CALLING_CONVENTION InteractiveForm_GetFields(InteractiveFormHandle* handle, FieldCollectionHandle** result);
+    VANILLAPDF_DEPRECATED VANILLAPDF_API error_type CALLING_CONVENTION InteractiveForm_GetFields(InteractiveFormHandle* handle, FieldCollectionHandle** result);
 
     /**
     * \brief
     * Set the array of references to the document's root fields.
-    *
-    * Obtain an empty collection from \ref FieldCollection_Create for a form
-    * that does not have any fields yet.
+    * \deprecated
+    * Append fields with \ref InteractiveForm_AddField, which creates the
+    * /Fields array on demand.
     */
-    VANILLAPDF_API error_type CALLING_CONVENTION InteractiveForm_SetFields(InteractiveFormHandle* handle, FieldCollectionHandle* value);
+    VANILLAPDF_DEPRECATED VANILLAPDF_API error_type CALLING_CONVENTION InteractiveForm_SetFields(InteractiveFormHandle* handle, FieldCollectionHandle* value);
+
+    /**
+    * \brief
+    * Append a field to the root /Fields array, creating the array when the
+    * form does not have one yet.
+    *
+    * The array holds indirect references, so the field's underlying
+    * dictionary shall be registered as an indirect object within the
+    * document, for example through \ref File_AllocateNewEntry.
+    * \returns \ref VANILLAPDF_ERROR_PARAMETER_VALUE when the field's
+    * dictionary is a direct object.
+    */
+    VANILLAPDF_API error_type CALLING_CONVENTION InteractiveForm_AddField(InteractiveFormHandle* handle, FieldHandle* value);
 
     /**
     * \brief

--- a/include/vanillapdf/semantics/c_interactive_forms.h
+++ b/include/vanillapdf/semantics/c_interactive_forms.h
@@ -5,6 +5,7 @@
 #include "vanillapdf/c_handles.h"
 #include "vanillapdf/c_values.h"
 #include "vanillapdf/semantics/c_fields.h"
+#include "vanillapdf/semantics/c_field_tree.h"
 
 #ifdef __cplusplus
 extern "C"
@@ -23,6 +24,10 @@ extern "C"
     * \brief
     * An interactive form (PDF 1.2) - sometimes referred to as an AcroForm - is
     * a collection of fields for gathering information interactively from the user.
+    *
+    * The form exposes its document-level attributes; the fields themselves
+    * live in the field hierarchy obtained from
+    * \ref InteractiveForm_GetFieldTree.
     *
     * For more details please visit [section 12.7 - Interactive Forms](PDF32000_2008.pdf#G11.2110737).
     */
@@ -56,35 +61,40 @@ extern "C"
 
     /**
     * \brief
+    * Get the field hierarchy of the form - its /Fields entry.
+    *
+    * Reading never creates the entry. The same hierarchy instance is
+    * returned for the lifetime of this form handle, so the flat view cache
+    * it owns is shared by everyone holding the form.
+    * \returns \ref VANILLAPDF_ERROR_OBJECT_MISSING when the form has no
+    * /Fields entry - attach one with \ref InteractiveForm_SetFieldTree.
+    * \see \ref FieldTreeHandle
+    */
+    VANILLAPDF_API error_type CALLING_CONVENTION InteractiveForm_GetFieldTree(InteractiveFormHandle* handle, FieldTreeHandle** result);
+
+    /**
+    * \brief
+    * Attach a field hierarchy to the form as its /Fields entry, replacing
+    * any existing one.
+    *
+    * Obtain an empty hierarchy from \ref FieldTree_CreateFromDocument for
+    * a form that does not have any fields yet. The attached instance
+    * becomes the one \ref InteractiveForm_GetFieldTree returns, so the
+    * caller's handle and the form share a single cache.
+    */
+    VANILLAPDF_API error_type CALLING_CONVENTION InteractiveForm_SetFieldTree(InteractiveFormHandle* handle, FieldTreeHandle* value);
+
+    /**
+    * \brief
     * An array of references to the document's root fields.
     * \deprecated
-    * Enumerate the resolved terminal fields with
-    * \ref InteractiveForm_GetFieldCount and \ref InteractiveForm_GetField
-    * instead.
+    * The raw /Fields array models dictionary nodes rather than logical
+    * fields. Use the field hierarchy from \ref InteractiveForm_GetFieldTree
+    * instead - \ref FieldTree_GetFieldCount and \ref FieldTree_GetField
+    * for the resolved terminal fields, \ref FieldTree_GetRootChild with
+    * \ref Field_GetChild for the structure.
     */
     VANILLAPDF_DEPRECATED VANILLAPDF_API error_type CALLING_CONVENTION InteractiveForm_GetFields(InteractiveFormHandle* handle, FieldCollectionHandle** result);
-
-    /**
-    * \brief
-    * Set the array of references to the document's root fields.
-    * \deprecated
-    * Append fields with \ref InteractiveForm_AddField, which creates the
-    * /Fields array on demand.
-    */
-    VANILLAPDF_DEPRECATED VANILLAPDF_API error_type CALLING_CONVENTION InteractiveForm_SetFields(InteractiveFormHandle* handle, FieldCollectionHandle* value);
-
-    /**
-    * \brief
-    * Append a field to the root /Fields array, creating the array when the
-    * form does not have one yet.
-    *
-    * The array holds indirect references, so the field's underlying
-    * dictionary shall be registered as an indirect object within the
-    * document, for example through \ref File_AllocateNewEntry.
-    * \returns \ref VANILLAPDF_ERROR_PARAMETER_VALUE when the field's
-    * dictionary is a direct object.
-    */
-    VANILLAPDF_API error_type CALLING_CONVENTION InteractiveForm_AddField(InteractiveFormHandle* handle, FieldHandle* value);
 
     /**
     * \brief
@@ -119,45 +129,12 @@ extern "C"
 
     /**
     * \brief
-    * Get the number of resolved terminal fields in the document.
-    *
-    * Terminal fields are the logical fields a user interacts with. The field
-    * hierarchy's grouping nodes exist only for naming and attribute
-    * inheritance and are not included - the same way the page tree hides its
-    * interior nodes. A radio button group is a single terminal field with one
-    * value, regardless of how many widget annotations represent it on the
-    * page.
-    */
-    VANILLAPDF_API error_type CALLING_CONVENTION InteractiveForm_GetFieldCount(InteractiveFormHandle* handle, size_type* result);
-
-    /**
-    * \brief
-    * Get the resolved terminal field at the given zero-based index, in
-    * document order.
-    *
-    * \see \ref InteractiveForm_GetFieldCount
-    */
-    VANILLAPDF_API error_type CALLING_CONVENTION InteractiveForm_GetField(InteractiveFormHandle* handle, size_type index, FieldHandle** result);
-
-    /**
-    * \brief
-    * Find a terminal field by its fully qualified name - the partial field
-    * names (/T entries) joined with '.', UTF-8 encoded.
-    *
-    * \returns \ref VANILLAPDF_ERROR_OBJECT_MISSING when no terminal field has
-    * that name.
-    * \see \ref Field_GetQualifiedName
-    */
-    VANILLAPDF_API error_type CALLING_CONVENTION InteractiveForm_FindField(InteractiveFormHandle* handle, string_type qualified_name, FieldHandle** result);
-
-    /**
-    * \brief
     * Get the document-wide default appearance string (/DA entry).
     *
-    * Fields resolve /DA through their /Parent chain only - when
-    * \ref Field_GetDefaultAppearance reports
-    * \ref VANILLAPDF_ERROR_OBJECT_MISSING, fall back to this document
-    * default.
+    * This is the form's own entry. Fields resolve /DA through their /Parent
+    * chain only; \ref InteractiveForm_ResolveDefaultAppearance performs the
+    * full lookup for a field, this default included.
+    * \returns \ref VANILLAPDF_ERROR_OBJECT_MISSING if the entry is not present.
     */
     VANILLAPDF_API error_type CALLING_CONVENTION InteractiveForm_GetDefaultAppearance(InteractiveFormHandle* handle, StringObjectHandle** result);
 
@@ -168,13 +145,28 @@ extern "C"
 
     /**
     * \brief
+    * Get the default appearance string (/DA entry) a field is rendered
+    * with: the field's own entry, then its ancestors through /Parent, then
+    * this form's document default (12.7.3.3).
+    *
+    * \ref Field_GetDefaultAppearance stops at the field hierarchy; the form
+    * owns the last step because it owns the entry. /DA is required for
+    * variable text fields but has no further default, so it can be missing
+    * everywhere.
+    * \returns \ref VANILLAPDF_ERROR_OBJECT_MISSING if the entry is present on
+    * neither the field, any of its ancestors, nor the form.
+    */
+    VANILLAPDF_API error_type CALLING_CONVENTION InteractiveForm_ResolveDefaultAppearance(InteractiveFormHandle* handle, FieldHandle* field, StringObjectHandle** result);
+
+    /**
+    * \brief
     * Get the document-wide default quadding (/Q entry) - the text
     * justification of variable text fields.
     *
-    * Fields resolve /Q through their /Parent chain only - when
-    * \ref Field_GetQuadding reports \ref VANILLAPDF_ERROR_OBJECT_MISSING,
-    * fall back to this document default. When this entry is missing as well,
-    * the specification default is \ref QuaddingType_LeftJustified.
+    * This is the form's own entry. Fields resolve /Q through their /Parent
+    * chain only; \ref InteractiveForm_ResolveQuadding performs the full
+    * lookup for a field, this default included.
+    * \returns \ref VANILLAPDF_ERROR_OBJECT_MISSING if the entry is not present.
     * \see QuaddingType
     */
     VANILLAPDF_API error_type CALLING_CONVENTION InteractiveForm_GetQuadding(InteractiveFormHandle* handle, QuaddingType* result);
@@ -184,6 +176,19 @@ extern "C"
     * \see QuaddingType
     */
     VANILLAPDF_API error_type CALLING_CONVENTION InteractiveForm_SetQuadding(InteractiveFormHandle* handle, QuaddingType value);
+
+    /**
+    * \brief
+    * Get the quadding (/Q entry) a field is rendered with: the field's own
+    * entry, then its ancestors through /Parent, then this form's document
+    * default, and finally the specification default
+    * \ref QuaddingType_LeftJustified (Table 222) - so it always resolves.
+    *
+    * \ref Field_GetQuadding stops at the field hierarchy; the form owns the
+    * last step because it owns the entry.
+    * \see QuaddingType
+    */
+    VANILLAPDF_API error_type CALLING_CONVENTION InteractiveForm_ResolveQuadding(InteractiveFormHandle* handle, FieldHandle* field, QuaddingType* result);
 
     /**
     * \brief Reinterpret current object as \ref IUnknownHandle

--- a/include/vanillapdf/semantics/c_interactive_forms.h
+++ b/include/vanillapdf/semantics/c_interactive_forms.h
@@ -156,7 +156,8 @@ extern "C"
     * \ref Field_GetDefaultAppearance stops at the field hierarchy; the form
     * owns the last step because it owns the entry. /DA is required for
     * variable text fields but has no further default, so it can be missing
-    * everywhere.
+    * everywhere. The field is taken as given - it is not checked to belong
+    * to this form's hierarchy.
     * \returns \ref VANILLAPDF_ERROR_OBJECT_MISSING if the entry is present on
     * neither the field, any of its ancestors, nor the form.
     */
@@ -189,7 +190,8 @@ extern "C"
     * \ref QuaddingType_LeftJustified (Table 222) - so it always resolves.
     *
     * \ref Field_GetQuadding stops at the field hierarchy; the form owns the
-    * last step because it owns the entry.
+    * last step because it owns the entry. The field is taken as given - it
+    * is not checked to belong to this form's hierarchy.
     * \see QuaddingType
     */
     VANILLAPDF_API error_type CALLING_CONVENTION InteractiveForm_ResolveQuadding(InteractiveFormHandle* handle, FieldHandle* field, QuaddingType* result);

--- a/src/vanillapdf.benchmark/CMakeLists.txt
+++ b/src/vanillapdf.benchmark/CMakeLists.txt
@@ -13,6 +13,7 @@ set(VANILLAPDF_BENCHMARK_SOURCES
     buffer_hash.cpp
     character_map.cpp
     content_stream.cpp
+    field_tree.cpp
     filters.cpp
     io_strategy.cpp
     objects.cpp

--- a/src/vanillapdf.benchmark/field_tree.cpp
+++ b/src/vanillapdf.benchmark/field_tree.cpp
@@ -1,0 +1,145 @@
+// Benchmark: FieldTree bulk authoring
+//
+// Covers the path a form author takes: attach an empty hierarchy, append
+// N root-level fields through FieldTree_AddRootChild, then read the flat
+// view once. Every mutator drops the cache, and the validation of the
+// next insert (membership, name uniqueness) forces a full rebuild before
+// it, so appending N fields walks O(1+2+...+N) = O(N²) nodes.
+//
+// Environment: Windows 11 x64, MSVC 18, Release, L3 16 MiB,
+// Google Benchmark, 3 repetitions, mean reported
+//
+// Baseline (Invalidate on every mutator, this branch before the change):
+//
+// | Benchmark                           | Time      | CPU       |
+// |-------------------------------------|-----------|-----------|
+// | AppendRootChildren/100_mean         |   51.9 ms |   53.0 ms |
+// | AppendRootChildren/1000_mean        |   5192 ms |   5188 ms |
+// | AppendRootChildren/5000_mean        | 148490 ms | 147734 ms |
+//
+// 100→1000 fields (10×): time grows 100× (O(N²) confirmed).
+// 1000→5000 fields (5×): time grows 28.6× (also O(N²)).
+
+#include "benchmark.h"
+#include "handle_guard.h"
+
+#include <string>
+#include <vector>
+
+// ---------------------------------------------------------------------------
+// Fixture helpers
+// ---------------------------------------------------------------------------
+
+struct FieldTreeFixture {
+    HandleGuard<InputOutputStreamHandle, InputOutputStream_Release> io_stream;
+    HandleGuard<FileHandle, File_Release> file;
+    HandleGuard<DocumentHandle, Document_Release> document;
+    HandleGuard<InteractiveFormHandle, InteractiveForm_Release> form;
+    HandleGuard<FieldTreeHandle, FieldTree_Release> tree;
+    std::vector<FieldHandle*> fields;
+
+    ~FieldTreeFixture() {
+        for (auto* field : fields) {
+            Field_Release(field);
+        }
+    }
+
+    bool Create(size_type field_count) {
+        if (InputOutputStream_CreateFromMemory(io_stream.out()) != VANILLAPDF_ERROR_SUCCESS) return false;
+        if (File_CreateStream(io_stream, "field_tree_benchmark", file.out()) != VANILLAPDF_ERROR_SUCCESS) return false;
+        if (Document_CreateFile(file, document.out()) != VANILLAPDF_ERROR_SUCCESS) return false;
+        if (InteractiveForm_CreateFromDocument(document, form.out()) != VANILLAPDF_ERROR_SUCCESS) return false;
+        if (FieldTree_CreateFromDocument(document, tree.out()) != VANILLAPDF_ERROR_SUCCESS) return false;
+        if (InteractiveForm_SetFieldTree(form, tree) != VANILLAPDF_ERROR_SUCCESS) return false;
+
+        // Registering the dictionaries allocates cross-reference entries,
+        // which is not the subject - every field is prepared up front, so
+        // the timed loop is AddRootChild alone. Each needs a distinct name,
+        // since duplicates are rejected on write.
+        fields.reserve(field_count);
+        for (size_type i = 0; i < field_count; i += 1) {
+            FieldHandle* field = nullptr;
+            if (!CreateTextField("field" + std::to_string(i), &field)) return false;
+            fields.push_back(field);
+        }
+
+        return true;
+    }
+
+private:
+    bool CreateTextField(const std::string& partial_name, FieldHandle** result) {
+        HandleGuard<DictionaryObjectHandle, DictionaryObject_Release> dictionary;
+        if (DictionaryObject_Create(dictionary.out()) != VANILLAPDF_ERROR_SUCCESS) return false;
+
+        HandleGuard<NameObjectHandle, NameObject_Release> name_key;
+        HandleGuard<LiteralStringObjectHandle, LiteralStringObject_Release> name_literal;
+        HandleGuard<StringObjectHandle, StringObject_Release> name_string;
+        HandleGuard<ObjectHandle, Object_Release> name_object;
+        if (NameObject_CreateFromDecodedString("T", name_key.out()) != VANILLAPDF_ERROR_SUCCESS) return false;
+        if (LiteralStringObject_CreateFromDecodedString(partial_name.c_str(), name_literal.out()) != VANILLAPDF_ERROR_SUCCESS) return false;
+        if (LiteralStringObject_ToStringObject(name_literal, name_string.out()) != VANILLAPDF_ERROR_SUCCESS) return false;
+        if (StringObject_ToObject(name_string, name_object.out()) != VANILLAPDF_ERROR_SUCCESS) return false;
+        if (DictionaryObject_Insert(dictionary, name_key, name_object, VANILLAPDF_RV_TRUE) != VANILLAPDF_ERROR_SUCCESS) return false;
+
+        HandleGuard<NameObjectHandle, NameObject_Release> type_key;
+        HandleGuard<NameObjectHandle, NameObject_Release> type_value;
+        HandleGuard<ObjectHandle, Object_Release> type_object;
+        if (NameObject_CreateFromDecodedString("FT", type_key.out()) != VANILLAPDF_ERROR_SUCCESS) return false;
+        if (NameObject_CreateFromDecodedString("Tx", type_value.out()) != VANILLAPDF_ERROR_SUCCESS) return false;
+        if (NameObject_ToObject(type_value, type_object.out()) != VANILLAPDF_ERROR_SUCCESS) return false;
+        if (DictionaryObject_Insert(dictionary, type_key, type_object, VANILLAPDF_RV_TRUE) != VANILLAPDF_ERROR_SUCCESS) return false;
+
+        HandleGuard<ObjectHandle, Object_Release> dictionary_object;
+        HandleGuard<XrefUsedEntryHandle, XrefUsedEntry_Release> entry;
+        if (DictionaryObject_ToObject(dictionary, dictionary_object.out()) != VANILLAPDF_ERROR_SUCCESS) return false;
+        if (File_AllocateNewEntry(file, entry.out()) != VANILLAPDF_ERROR_SUCCESS) return false;
+        if (XrefUsedEntry_SetReference(entry, dictionary_object) != VANILLAPDF_ERROR_SUCCESS) return false;
+
+        return Field_CreateFromDictionary(dictionary, result) == VANILLAPDF_ERROR_SUCCESS;
+    }
+};
+
+// ---------------------------------------------------------------------------
+// BM_FieldTreeAppendRootChildren
+//
+// Appends `field_count` prepared fields to an empty hierarchy, then reads
+// the flat view once - the cost an author pays for a form of that size.
+// The fixture is rebuilt each iteration with the timer paused, so every
+// iteration starts from an empty tree.
+// ---------------------------------------------------------------------------
+
+static void BM_FieldTreeAppendRootChildren(benchmark::State& state) {
+    auto field_count = static_cast<size_type>(state.range(0));
+
+    for (auto _ : state) {
+        state.PauseTiming();
+        FieldTreeFixture fixture;
+        if (!fixture.Create(field_count)) {
+            state.SkipWithError("Could not prepare the field tree fixture");
+            return;
+        }
+
+        state.ResumeTiming();
+        for (auto* field : fixture.fields) {
+            if (FieldTree_AddRootChild(fixture.tree, field) != VANILLAPDF_ERROR_SUCCESS) {
+                state.SkipWithError("FieldTree_AddRootChild failed");
+                return;
+            }
+        }
+
+        size_type count = 0;
+        FieldTree_GetFieldCount(fixture.tree, &count);
+        benchmark::DoNotOptimize(count);
+
+        state.PauseTiming();
+        // fixture destructor runs here with timer paused
+    }
+
+    state.SetItemsProcessed(static_cast<int64_t>(state.iterations()) * static_cast<int64_t>(field_count));
+}
+
+BENCHMARK(BM_FieldTreeAppendRootChildren)
+    ->Arg(100)
+    ->Arg(1000)
+    ->Arg(5000)
+    ->Unit(benchmark::kMillisecond);

--- a/src/vanillapdf.benchmark/field_tree.cpp
+++ b/src/vanillapdf.benchmark/field_tree.cpp
@@ -2,9 +2,10 @@
 //
 // Covers the path a form author takes: attach an empty hierarchy, append
 // N root-level fields through FieldTree_AddRootChild, then read the flat
-// view once. Every mutator drops the cache, and the validation of the
-// next insert (membership, name uniqueness) forces a full rebuild before
-// it, so appending N fields walks O(1+2+...+N) = O(N²) nodes.
+// view once. Originally every mutator dropped the cache, and the
+// validation of the next insert (membership, name uniqueness) forced a
+// full rebuild before it, so appending N fields walked O(1+2+...+N) =
+// O(N²) nodes.
 //
 // Environment: Windows 11 x64, MSVC 18, Release, L3 16 MiB,
 // Google Benchmark, 3 repetitions, mean reported
@@ -19,6 +20,21 @@
 //
 // 100→1000 fields (10×): time grows 100× (O(N²) confirmed).
 // 1000→5000 fields (5×): time grows 28.6× (also O(N²)).
+//
+// After the two-tier cache (this branch - the insert mutators extend the
+// membership and name index with the subtree they validated and only mark
+// the ordered views stale; the read at the end rebuilds them once):
+//
+// | Benchmark                           | Time      | CPU       |
+// |-------------------------------------|-----------|-----------|
+// | AppendRootChildren/100_mean         |   1.64 ms |   1.73 ms |
+// | AppendRootChildren/1000_mean        |   16.3 ms |   16.7 ms |
+// | AppendRootChildren/5000_mean        |   93.2 ms |   94.6 ms |
+//
+// 100→1000 fields (10×): time grows 9.9× (linear).
+// 1000→5000 fields (5×): time grows 5.7× (linear).
+// Improvement: 1000 fields 5192 ms → 16.3 ms (~320×),
+// 5000 fields 148490 ms → 93.2 ms (~1600×).
 
 #include "benchmark.h"
 #include "handle_guard.h"

--- a/src/vanillapdf.test/documents.c
+++ b/src/vanillapdf.test/documents.c
@@ -1793,8 +1793,7 @@ error_type process_interactive_form(InteractiveFormHandle* obj, int nested) {
     boolean_type need_appearances = VANILLAPDF_RV_FALSE;
     StringObjectHandle* default_appearance = NULL;
     QuaddingType quadding = QuaddingType_LeftJustified;
-    size_type field_count = 0;
-    size_type i = 0;
+    FieldTreeHandle* field_tree = NULL;
 
     print_spaces(nested);
     print_text("Interactive form begin\n");
@@ -1819,8 +1818,27 @@ error_type process_interactive_form(InteractiveFormHandle* obj, int nested) {
         process_signature_flags(signature_flags, nested + 1),
         SignatureFlags_Release(signature_flags));
 
+    // The field hierarchy - a form without a /Fields entry has none
+    RETURN_ERROR_IF_NOT_SUCCESS_OPTIONAL_RELEASE(InteractiveForm_GetFieldTree(obj, &field_tree),
+        process_field_tree(field_tree, nested + 1),
+        FieldTree_Release(field_tree));
+
+    print_spaces(nested);
+    print_text("Interactive form end\n");
+
+    return VANILLAPDF_TEST_ERROR_SUCCESS;
+}
+
+error_type process_field_tree(FieldTreeHandle* obj, int nested) {
+    size_type field_count = 0;
+    size_type root_child_count = 0;
+    size_type i = 0;
+
+    print_spaces(nested);
+    print_text("Field tree begin\n");
+
     // Flat enumeration of resolved terminal fields
-    RETURN_ERROR_IF_NOT_SUCCESS(InteractiveForm_GetFieldCount(obj, &field_count));
+    RETURN_ERROR_IF_NOT_SUCCESS(FieldTree_GetFieldCount(obj, &field_count));
 
     print_spaces(nested + 1);
 
@@ -1830,13 +1848,68 @@ error_type process_interactive_form(InteractiveFormHandle* obj, int nested) {
     for (i = 0; i < field_count; ++i) {
         FieldHandle* terminal_field = NULL;
 
-        RETURN_ERROR_IF_NOT_SUCCESS(InteractiveForm_GetField(obj, i, &terminal_field));
+        RETURN_ERROR_IF_NOT_SUCCESS(FieldTree_GetField(obj, i, &terminal_field));
         RETURN_ERROR_IF_NOT_SUCCESS(process_field(terminal_field, nested + 1));
         RETURN_ERROR_IF_NOT_SUCCESS(Field_Release(terminal_field));
     }
 
+    // Structural walk from the top level down, exercising the same code
+    // path over every node of the hierarchy - groups included
+    RETURN_ERROR_IF_NOT_SUCCESS(FieldTree_GetRootChildCount(obj, &root_child_count));
+
+    print_spaces(nested + 1);
+
+    unsigned long long converted_root_child_count = root_child_count;
+    print_text("Root child count: %llu\n", converted_root_child_count);
+
+    for (i = 0; i < root_child_count; ++i) {
+        FieldHandle* root_child = NULL;
+        FieldHandle* parent = NULL;
+
+        RETURN_ERROR_IF_NOT_SUCCESS(FieldTree_GetRootChild(obj, i, &root_child));
+
+        // A top-level field has no /Parent - one that carries a stale entry
+        // anyway is a dirty file the tree tolerates, so it is only released
+        RETURN_ERROR_IF_NOT_SUCCESS_OPTIONAL_RELEASE(Field_GetParent(root_child, &parent),
+            VANILLAPDF_TEST_ERROR_SUCCESS,
+            Field_Release(parent));
+
+        RETURN_ERROR_IF_NOT_SUCCESS(process_field(root_child, nested + 1));
+        RETURN_ERROR_IF_NOT_SUCCESS(process_field_subtree(root_child, nested + 1));
+        RETURN_ERROR_IF_NOT_SUCCESS(Field_Release(root_child));
+    }
+
     print_spaces(nested);
-    print_text("Interactive form end\n");
+    print_text("Field tree end\n");
+
+    return VANILLAPDF_TEST_ERROR_SUCCESS;
+}
+
+error_type process_field_subtree(FieldHandle* obj, int nested) {
+    size_type child_count = 0;
+    size_type i = 0;
+
+    RETURN_ERROR_IF_NOT_SUCCESS(Field_GetChildCount(obj, &child_count));
+
+    print_spaces(nested);
+
+    unsigned long long converted_child_count = child_count;
+    print_text("Child field count: %llu\n", converted_child_count);
+
+    for (i = 0; i < child_count; ++i) {
+        FieldHandle* child = NULL;
+        FieldHandle* parent = NULL;
+
+        RETURN_ERROR_IF_NOT_SUCCESS(Field_GetChild(obj, i, &child));
+
+        // Every child reached from a node reports that node as its parent
+        RETURN_ERROR_IF_NOT_SUCCESS(Field_GetParent(child, &parent));
+        RETURN_ERROR_IF_NOT_SUCCESS(Field_Release(parent));
+
+        RETURN_ERROR_IF_NOT_SUCCESS(process_field(child, nested + 1));
+        RETURN_ERROR_IF_NOT_SUCCESS(process_field_subtree(child, nested + 1));
+        RETURN_ERROR_IF_NOT_SUCCESS(Field_Release(child));
+    }
 
     return VANILLAPDF_TEST_ERROR_SUCCESS;
 }
@@ -1892,9 +1965,9 @@ error_type process_field(FieldHandle* obj, int nested) {
     RETURN_ERROR_IF_NOT_SUCCESS_OPTIONAL(Field_GetFieldFlags(obj, &flags),
         VANILLAPDF_TEST_ERROR_SUCCESS);
 
-    RETURN_ERROR_IF_NOT_SUCCESS(Field_GetQualifiedName(obj, &qualified_name));
-    RETURN_ERROR_IF_NOT_SUCCESS(process_buffer(qualified_name, nested + 1));
-    RETURN_ERROR_IF_NOT_SUCCESS(Buffer_Release(qualified_name));
+    RETURN_ERROR_IF_NOT_SUCCESS_OPTIONAL_RELEASE(Field_GetQualifiedName(obj, &qualified_name),
+        process_buffer(qualified_name, nested + 1),
+        Buffer_Release(qualified_name));
 
     RETURN_ERROR_IF_NOT_SUCCESS(Field_IsTerminal(obj, &is_terminal));
 

--- a/src/vanillapdf.test/documents.c
+++ b/src/vanillapdf.test/documents.c
@@ -1789,7 +1789,6 @@ error_type process_document_edit(
 }
 
 error_type process_interactive_form(InteractiveFormHandle* obj, int nested) {
-    FieldCollectionHandle* fields = NULL;
     SignatureFlagsHandle* signature_flags = NULL;
     boolean_type need_appearances = VANILLAPDF_RV_FALSE;
     StringObjectHandle* default_appearance = NULL;
@@ -1819,10 +1818,6 @@ error_type process_interactive_form(InteractiveFormHandle* obj, int nested) {
     RETURN_ERROR_IF_NOT_SUCCESS_OPTIONAL_RELEASE(InteractiveForm_GetSignatureFlags(obj, &signature_flags),
         process_signature_flags(signature_flags, nested + 1),
         SignatureFlags_Release(signature_flags));
-
-    RETURN_ERROR_IF_NOT_SUCCESS_OPTIONAL_RELEASE(InteractiveForm_GetFields(obj, &fields),
-        process_field_collection(fields, nested + 1),
-        FieldCollection_Release(fields));
 
     // Flat enumeration of resolved terminal fields
     RETURN_ERROR_IF_NOT_SUCCESS(InteractiveForm_GetFieldCount(obj, &field_count));
@@ -1864,34 +1859,6 @@ error_type process_signature_flags(SignatureFlagsHandle* obj, int nested) {
 
     print_spaces(nested);
     print_text("Signature flags end\n");
-
-    return VANILLAPDF_TEST_ERROR_SUCCESS;
-}
-
-error_type process_field_collection(FieldCollectionHandle* obj, int nested) {
-    size_type i = 0;
-    size_type size = 0;
-
-    print_spaces(nested);
-    print_text("Field collection begin\n");
-
-    RETURN_ERROR_IF_NOT_SUCCESS(FieldCollection_GetSize(obj, &size));
-
-    print_spaces(nested);
-
-    unsigned long long converted_size = size;
-    print_text("Size: %llu\n", converted_size);
-
-    for (i = 0; i < size; ++i) {
-        FieldHandle* field = NULL;
-
-        RETURN_ERROR_IF_NOT_SUCCESS(FieldCollection_At(obj, i, &field));
-        RETURN_ERROR_IF_NOT_SUCCESS(process_field(field, nested + 1));
-        RETURN_ERROR_IF_NOT_SUCCESS(Field_Release(field));
-    }
-
-    print_spaces(nested);
-    print_text("Field collection end\n");
 
     return VANILLAPDF_TEST_ERROR_SUCCESS;
 }

--- a/src/vanillapdf.test/test.h
+++ b/src/vanillapdf.test/test.h
@@ -104,6 +104,8 @@ error_type process_link_annotation(LinkAnnotationHandle* obj, int nested);
 error_type process_resource_dictionary(ResourceDictionaryHandle* obj, int nested);
 error_type process_font_map(FontMapHandle* obj, int nested);
 error_type process_interactive_form(InteractiveFormHandle* obj, int nested);
+error_type process_field_tree(FieldTreeHandle* obj, int nested);
+error_type process_field_subtree(FieldHandle* obj, int nested);
 error_type process_signature_flags(SignatureFlagsHandle* obj, int nested);
 error_type process_field(FieldHandle* obj, int nested);
 error_type process_button_field(ButtonFieldHandle* obj, int nested);

--- a/src/vanillapdf.test/test.h
+++ b/src/vanillapdf.test/test.h
@@ -105,7 +105,6 @@ error_type process_resource_dictionary(ResourceDictionaryHandle* obj, int nested
 error_type process_font_map(FontMapHandle* obj, int nested);
 error_type process_interactive_form(InteractiveFormHandle* obj, int nested);
 error_type process_signature_flags(SignatureFlagsHandle* obj, int nested);
-error_type process_field_collection(FieldCollectionHandle* obj, int nested);
 error_type process_field(FieldHandle* obj, int nested);
 error_type process_button_field(ButtonFieldHandle* obj, int nested);
 error_type process_text_field(TextFieldHandle* obj, int nested);

--- a/src/vanillapdf.tools/verify.c
+++ b/src/vanillapdf.tools/verify.c
@@ -31,6 +31,7 @@ int process_verify(int argc, char *argv[]) {
     FileHandle* file = NULL;
     CatalogHandle* catalog = NULL;
     InteractiveFormHandle* acro_form = NULL;
+    FieldTreeHandle* field_tree = NULL;
     FieldHandle* field = NULL;
     SignatureFieldHandle* sig_field = NULL;
     DigitalSignatureHandle* digital_signature = NULL;
@@ -112,12 +113,19 @@ int process_verify(int argc, char *argv[]) {
         return VANILLAPDF_TOOLS_ERROR_FAILURE;
     }
 
-    // Enumerate the resolved terminal fields
+    // Enumerate the resolved terminal fields of the field hierarchy
     size_type field_count = 0;
-    RETURN_ERROR_IF_NOT_SUCCESS(InteractiveForm_GetFieldCount(acro_form, &field_count));
+    error_type field_tree_result = InteractiveForm_GetFieldTree(acro_form, &field_tree);
+    if (field_tree_result == VANILLAPDF_ERROR_SUCCESS) {
+        RETURN_ERROR_IF_NOT_SUCCESS(FieldTree_GetFieldCount(field_tree, &field_count));
+    } else if (field_tree_result != VANILLAPDF_ERROR_OBJECT_MISSING) {
+        printf("Error: Failed to get the field hierarchy\n");
+        return VANILLAPDF_TOOLS_ERROR_FAILURE;
+    }
 
     if (field_count == 0) {
         printf("Error: No form fields found in PDF\n");
+        if (field_tree) FieldTree_Release(field_tree);
         InteractiveForm_Release(acro_form);
         Catalog_Release(catalog);
         Document_Release(document);
@@ -178,7 +186,7 @@ int process_verify(int argc, char *argv[]) {
         result = NULL;
 
         // Get field at index
-        error_type field_result = InteractiveForm_GetField(acro_form, i, &field);
+        error_type field_result = FieldTree_GetField(field_tree, i, &field);
         if (field_result != VANILLAPDF_ERROR_SUCCESS) {
             printf("Warning: Failed to get field at index %llu\n", (unsigned long long) i);
             continue;
@@ -308,6 +316,7 @@ int process_verify(int argc, char *argv[]) {
     // Cleanup (iteration resources already cleaned up in loop)
     if (settings) SignatureVerificationSettings_Release(settings);
     if (trust_store) TrustedCertificateStore_Release(trust_store);
+    if (field_tree) FieldTree_Release(field_tree);
     if (acro_form) InteractiveForm_Release(acro_form);
     if (catalog) Catalog_Release(catalog);
     if (document) Document_Release(document);

--- a/src/vanillapdf.tools/verify.c
+++ b/src/vanillapdf.tools/verify.c
@@ -31,7 +31,6 @@ int process_verify(int argc, char *argv[]) {
     FileHandle* file = NULL;
     CatalogHandle* catalog = NULL;
     InteractiveFormHandle* acro_form = NULL;
-    FieldCollectionHandle* fields = NULL;
     FieldHandle* field = NULL;
     SignatureFieldHandle* sig_field = NULL;
     DigitalSignatureHandle* digital_signature = NULL;
@@ -113,23 +112,12 @@ int process_verify(int argc, char *argv[]) {
         return VANILLAPDF_TOOLS_ERROR_FAILURE;
     }
 
-    // Get fields
-    error_type fields_result = InteractiveForm_GetFields(acro_form, &fields);
-    if (fields_result != VANILLAPDF_ERROR_SUCCESS) {
-        printf("Error: Failed to get form fields\n");
-        InteractiveForm_Release(acro_form);
-        Catalog_Release(catalog);
-        Document_Release(document);
-        File_Release(file);
-        return VANILLAPDF_TOOLS_ERROR_FAILURE;
-    }
-
+    // Enumerate the resolved terminal fields
     size_type field_count = 0;
-    RETURN_ERROR_IF_NOT_SUCCESS(FieldCollection_GetSize(fields, &field_count));
+    RETURN_ERROR_IF_NOT_SUCCESS(InteractiveForm_GetFieldCount(acro_form, &field_count));
 
     if (field_count == 0) {
         printf("Error: No form fields found in PDF\n");
-        FieldCollection_Release(fields);
         InteractiveForm_Release(acro_form);
         Catalog_Release(catalog);
         Document_Release(document);
@@ -190,7 +178,7 @@ int process_verify(int argc, char *argv[]) {
         result = NULL;
 
         // Get field at index
-        error_type field_result = FieldCollection_At(fields, i, &field);
+        error_type field_result = InteractiveForm_GetField(acro_form, i, &field);
         if (field_result != VANILLAPDF_ERROR_SUCCESS) {
             printf("Warning: Failed to get field at index %llu\n", (unsigned long long) i);
             continue;
@@ -320,7 +308,6 @@ int process_verify(int argc, char *argv[]) {
     // Cleanup (iteration resources already cleaned up in loop)
     if (settings) SignatureVerificationSettings_Release(settings);
     if (trust_store) TrustedCertificateStore_Release(trust_store);
-    if (fields) FieldCollection_Release(fields);
     if (acro_form) InteractiveForm_Release(acro_form);
     if (catalog) Catalog_Release(catalog);
     if (document) Document_Release(document);

--- a/src/vanillapdf.unittest/CMakeLists.txt
+++ b/src/vanillapdf.unittest/CMakeLists.txt
@@ -34,6 +34,7 @@ set(VANILLAPDF_UNITTEST_SOURCES
     destinations_test.cpp
     fields_test.cpp
     interactive_forms_test.cpp
+    field_tree_test.cpp
     filter_test.cpp
     text_string_encoding_test.cpp
     file_structure_validator_test.cpp

--- a/src/vanillapdf.unittest/field_tree_test.cpp
+++ b/src/vanillapdf.unittest/field_tree_test.cpp
@@ -337,6 +337,43 @@ TEST(FieldTree, NamelessIntermediateNodeIsWalked) {
     EXPECT_EQ(FindFieldByName(tree, "group.leaf", found.out()), VANILLAPDF_ERROR_SUCCESS);
 }
 
+// The root array holds fields only - a stray dictionary in it is skipped
+// by both views, the same way a widget among /Kids is
+TEST(FieldTree, StrayRootEntryIsSkipped) {
+    SampleHierarchy sample;
+    BuildSampleHierarchy(sample);
+
+    HandleGuard<DictionaryObjectHandle, DictionaryObject_Release> widget;
+    ASSERT_EQ(DictionaryObject_Create(widget.out()), VANILLAPDF_ERROR_SUCCESS);
+    InsertNameEntry(widget, "Subtype", "Widget");
+    RegisterIndirectObject(sample.file, widget);
+
+    // Slip it between the two fields of the array the tree is a view over
+    HandleGuard<NameObjectHandle, NameObject_Release> fields_key;
+    ASSERT_EQ(NameObject_CreateFromDecodedString("Fields", fields_key.out()), VANILLAPDF_ERROR_SUCCESS);
+
+    HandleGuard<ObjectHandle, Object_Release> fields_object;
+    ASSERT_EQ(DictionaryObject_Find(sample.form_dictionary, fields_key, fields_object.out()), VANILLAPDF_ERROR_SUCCESS);
+
+    HandleGuard<ArrayObjectHandle, ArrayObject_Release> fields_array;
+    ASSERT_EQ(ArrayObject_FromObject(fields_object, fields_array.out()), VANILLAPDF_ERROR_SUCCESS);
+
+    HandleGuard<IndirectReferenceObjectHandle, IndirectReferenceObject_Release> widget_reference;
+    CreateReferenceTo(widget, widget_reference);
+
+    HandleGuard<ObjectHandle, Object_Release> widget_reference_object;
+    ASSERT_EQ(IndirectReferenceObject_ToObject(widget_reference, widget_reference_object.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(ArrayObject_Insert(fields_array, 1, widget_reference_object), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(FieldTree_Invalidate(sample.tree), VANILLAPDF_ERROR_SUCCESS);
+
+    ASSERT_EQ(GetRootChildCount(sample.tree), 2u);
+    EXPECT_EQ(GetRootChildQualifiedName(sample.tree, 0), "address");
+    EXPECT_EQ(GetRootChildQualifiedName(sample.tree, 1), "email");
+
+    ASSERT_EQ(GetFieldCount(sample.tree), 3u);
+    EXPECT_EQ(GetFieldQualifiedName(sample.tree, 2), "email");
+}
+
 // --- Walking up ---
 
 // A nested field reports its group, a top-level field has no /Parent and

--- a/src/vanillapdf.unittest/field_tree_test.cpp
+++ b/src/vanillapdf.unittest/field_tree_test.cpp
@@ -814,6 +814,9 @@ TEST(FieldTree, InvalidateAfterRawEdit) {
 
     ASSERT_EQ(GetFieldCount(sample.tree), 3u);
 
+    HandleGuard<FieldHandle, Field_Release> email;
+    ASSERT_EQ(FindFieldByName(sample.tree, "email", email.out()), VANILLAPDF_ERROR_SUCCESS);
+
     // Drop the /Fields entry for the email field behind the tree's back,
     // through the form dictionary itself
     HandleGuard<NameObjectHandle, NameObject_Release> fields_key;
@@ -826,12 +829,17 @@ TEST(FieldTree, InvalidateAfterRawEdit) {
     ASSERT_EQ(ArrayObject_FromObject(fields_object, fields_array.out()), VANILLAPDF_ERROR_SUCCESS);
     ASSERT_EQ(ArrayObject_Remove(fields_array, 1), VANILLAPDF_ERROR_SUCCESS);
 
-    // Stale until told otherwise
+    // Stale until told otherwise - the flat view still lists the field, and
+    // a removal finds the container no longer holding it
     EXPECT_EQ(GetFieldCount(sample.tree), 3u);
+    EXPECT_EQ(FieldTree_RemoveChild(sample.tree, email), VANILLAPDF_ERROR_PARAMETER_VALUE);
 
     ASSERT_EQ(FieldTree_Invalidate(sample.tree), VANILLAPDF_ERROR_SUCCESS);
     ASSERT_EQ(GetFieldCount(sample.tree), 2u);
     EXPECT_EQ(GetFieldQualifiedName(sample.tree, 1), "address.city");
+
+    // Rebuilt, the field is simply not a member
+    EXPECT_EQ(FieldTree_RemoveChild(sample.tree, email), VANILLAPDF_ERROR_PARAMETER_VALUE);
 }
 
 // --- Attachment ---

--- a/src/vanillapdf.unittest/field_tree_test.cpp
+++ b/src/vanillapdf.unittest/field_tree_test.cpp
@@ -1208,18 +1208,18 @@ TEST(FieldTree, SignSkipsNameTakenByGroup) {
     HandleGuard<DocumentHandle, Document_Release> document;
     CreateMemoryDocument(io_stream, file, document);
 
-    HandleGuard<InteractiveFormHandle, InteractiveForm_Release> created_form;
-    ASSERT_EQ(InteractiveForm_CreateFromDocument(document, created_form.out()), VANILLAPDF_ERROR_SUCCESS);
+    HandleGuard<InteractiveFormHandle, InteractiveForm_Release> form;
+    ASSERT_EQ(InteractiveForm_CreateFromDocument(document, form.out()), VANILLAPDF_ERROR_SUCCESS);
 
     HandleGuard<CatalogHandle, Catalog_Release> catalog;
     ASSERT_EQ(Document_GetCatalog(document, catalog.out()), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(Catalog_SetAcroForm(catalog, created_form), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Catalog_SetAcroForm(catalog, form), VANILLAPDF_ERROR_SUCCESS);
 
-    // The catalog resolves the form once and hands out that instance to
-    // everyone, the signer included - so the hierarchy is attached to the
-    // instance the catalog hands out, not to the one that was installed
-    HandleGuard<InteractiveFormHandle, InteractiveForm_Release> form;
-    ASSERT_EQ(Catalog_GetAcroForm(catalog, form.out()), VANILLAPDF_ERROR_SUCCESS);
+    // The attached instance is the one the catalog hands out to everyone,
+    // the signer included
+    HandleGuard<InteractiveFormHandle, InteractiveForm_Release> catalog_form;
+    ASSERT_EQ(Catalog_GetAcroForm(catalog, catalog_form.out()), VANILLAPDF_ERROR_SUCCESS);
+    EXPECT_EQ(catalog_form.get(), form.get());
 
     HandleGuard<FieldTreeHandle, FieldTree_Release> tree;
     ASSERT_EQ(FieldTree_CreateFromDocument(document, tree.out()), VANILLAPDF_ERROR_SUCCESS);
@@ -1267,8 +1267,8 @@ TEST(FieldTree, SignSkipsNameTakenByGroup) {
 
     // The signature went in next to the group, under the next free name,
     // and the tree held here shows it right away: the signer reached the
-    // form through the catalog, which hands out the very form instance
-    // attached above, and that form hands out this very tree
+    // form through the catalog, which hands out the very instance attached
+    // above, and that form hands out this very tree
     ASSERT_EQ(GetRootChildCount(tree), 2u);
     EXPECT_EQ(GetRootChildQualifiedName(tree, 1), "Signature2");
 

--- a/src/vanillapdf.unittest/field_tree_test.cpp
+++ b/src/vanillapdf.unittest/field_tree_test.cpp
@@ -75,6 +75,21 @@ static void InsertParentEntry(DictionaryObjectHandle* child, DictionaryObjectHan
     ASSERT_EQ(DictionaryObject_Insert(child, key, reference_object, VANILLAPDF_RV_TRUE), VANILLAPDF_ERROR_SUCCESS);
 }
 
+// The array a dictionary entry holds, for editing it in place behind the
+// tree's back
+static void FindArrayEntry(
+    DictionaryObjectHandle* dict,
+    const char* key_name,
+    HandleGuard<ArrayObjectHandle, ArrayObject_Release>& array
+) {
+    HandleGuard<NameObjectHandle, NameObject_Release> key;
+    ASSERT_EQ(NameObject_CreateFromDecodedString(key_name, key.out()), VANILLAPDF_ERROR_SUCCESS);
+
+    HandleGuard<ObjectHandle, Object_Release> array_object;
+    ASSERT_EQ(DictionaryObject_Find(dict, key, array_object.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(ArrayObject_FromObject(array_object, array.out()), VANILLAPDF_ERROR_SUCCESS);
+}
+
 static void RemoveEntry(DictionaryObjectHandle* dict, const char* key_name) {
     HandleGuard<NameObjectHandle, NameObject_Release> key;
     ASSERT_EQ(NameObject_CreateFromDecodedString(key_name, key.out()), VANILLAPDF_ERROR_SUCCESS);
@@ -372,6 +387,47 @@ TEST(FieldTree, StrayRootEntryIsSkipped) {
 
     ASSERT_EQ(GetFieldCount(sample.tree), 3u);
     EXPECT_EQ(GetFieldQualifiedName(sample.tree, 2), "email");
+}
+
+// Both arrays shall hold indirect references - a direct dictionary in
+// either is malformed but occurs, and both views skip it the same way
+// instead of the flat view failing where the child walk works
+TEST(FieldTree, DirectDictionaryEntriesAreSkippedByBothViews) {
+    SampleHierarchy sample;
+    BuildSampleHierarchy(sample);
+
+    // A field-looking dictionary embedded directly, once in the root array
+    // and once among the group's kids
+    HandleGuard<DictionaryObjectHandle, DictionaryObject_Release> embedded;
+    ASSERT_EQ(DictionaryObject_Create(embedded.out()), VANILLAPDF_ERROR_SUCCESS);
+    InsertStringEntry(embedded, "T", "embedded");
+    InsertNameEntry(embedded, "FT", "Tx");
+
+    HandleGuard<ObjectHandle, Object_Release> embedded_object;
+    ASSERT_EQ(DictionaryObject_ToObject(embedded, embedded_object.out()), VANILLAPDF_ERROR_SUCCESS);
+
+    HandleGuard<ArrayObjectHandle, ArrayObject_Release> fields_array;
+    FindArrayEntry(sample.form_dictionary, "Fields", fields_array);
+    ASSERT_EQ(ArrayObject_Insert(fields_array, 0, embedded_object), VANILLAPDF_ERROR_SUCCESS);
+
+    HandleGuard<ArrayObjectHandle, ArrayObject_Release> kids_array;
+    FindArrayEntry(sample.address, "Kids", kids_array);
+    ASSERT_EQ(ArrayObject_Insert(kids_array, 1, embedded_object), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(FieldTree_Invalidate(sample.tree), VANILLAPDF_ERROR_SUCCESS);
+
+    ASSERT_EQ(GetRootChildCount(sample.tree), 2u);
+    EXPECT_EQ(GetRootChildQualifiedName(sample.tree, 0), "address");
+
+    HandleGuard<FieldHandle, Field_Release> address;
+    ASSERT_EQ(FieldTree_GetRootChild(sample.tree, 0, address.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(GetChildCount(address), 2u);
+    EXPECT_EQ(GetChildQualifiedName(address, 1), "address.city");
+
+    ASSERT_EQ(GetFieldCount(sample.tree), 3u);
+    EXPECT_EQ(GetFieldQualifiedName(sample.tree, 1), "address.city");
+
+    HandleGuard<FieldHandle, Field_Release> not_found;
+    EXPECT_EQ(FindFieldByName(sample.tree, "embedded", not_found.out()), VANILLAPDF_ERROR_OBJECT_MISSING);
 }
 
 // --- Walking up ---

--- a/src/vanillapdf.unittest/field_tree_test.cpp
+++ b/src/vanillapdf.unittest/field_tree_test.cpp
@@ -1,5 +1,6 @@
 #include "unittest.h"
 #include "handle_guard.h"
+#include "test_data.h"
 
 #include <cstring>
 
@@ -1193,6 +1194,106 @@ TEST(FieldTree, AuthoredHierarchyPersistsAcrossSave) {
     HandleGuard<FieldHandle, Field_Release> reloaded_street_parent;
     ASSERT_EQ(Field_GetParent(reloaded_street, reloaded_street_parent.out()), VANILLAPDF_ERROR_SUCCESS);
     EXPECT_EQ(GetQualifiedName(reloaded_street_parent), "address");
+}
+
+// --- Signing ---
+
+// Document_Sign adds its signature field through the tree and picks a
+// name the tree accepts: a group named Signature1 takes that name just as
+// a terminal would, so the signature lands at Signature2 - it must not
+// probe with the terminal lookup and then be refused by the group
+TEST(FieldTree, SignSkipsNameTakenByGroup) {
+    HandleGuard<InputOutputStreamHandle, InputOutputStream_Release> io_stream;
+    HandleGuard<FileHandle, File_Release> file;
+    HandleGuard<DocumentHandle, Document_Release> document;
+    CreateMemoryDocument(io_stream, file, document);
+
+    HandleGuard<InteractiveFormHandle, InteractiveForm_Release> created_form;
+    ASSERT_EQ(InteractiveForm_CreateFromDocument(document, created_form.out()), VANILLAPDF_ERROR_SUCCESS);
+
+    HandleGuard<CatalogHandle, Catalog_Release> catalog;
+    ASSERT_EQ(Document_GetCatalog(document, catalog.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Catalog_SetAcroForm(catalog, created_form), VANILLAPDF_ERROR_SUCCESS);
+
+    // The catalog resolves the form once and hands out that instance to
+    // everyone, the signer included - so the hierarchy is attached to the
+    // instance the catalog hands out, not to the one that was installed
+    HandleGuard<InteractiveFormHandle, InteractiveForm_Release> form;
+    ASSERT_EQ(Catalog_GetAcroForm(catalog, form.out()), VANILLAPDF_ERROR_SUCCESS);
+
+    HandleGuard<FieldTreeHandle, FieldTree_Release> tree;
+    ASSERT_EQ(FieldTree_CreateFromDocument(document, tree.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(InteractiveForm_SetFieldTree(form, tree), VANILLAPDF_ERROR_SUCCESS);
+
+    // A group carrying the name the signer would pick first
+    HandleGuard<DictionaryObjectHandle, DictionaryObject_Release> group_dictionary;
+    ASSERT_EQ(DictionaryObject_Create(group_dictionary.out()), VANILLAPDF_ERROR_SUCCESS);
+    InsertStringEntry(group_dictionary, "T", "Signature1");
+    RegisterIndirectObject(file, group_dictionary);
+
+    HandleGuard<FieldHandle, Field_Release> group;
+    ASSERT_EQ(Field_CreateFromDictionary(group_dictionary, group.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(FieldTree_AddRootChild(tree, group), VANILLAPDF_ERROR_SUCCESS);
+
+    HandleGuard<DictionaryObjectHandle, DictionaryObject_Release> child_dictionary;
+    HandleGuard<FieldHandle, Field_Release> child;
+    CreateTextFieldDictionary(file, "child", child_dictionary, child);
+    ASSERT_EQ(FieldTree_AddChild(tree, group, child), VANILLAPDF_ERROR_SUCCESS);
+
+    // The terminal lookup does not see the group; the signer must not
+    // rely on it
+    HandleGuard<FieldHandle, Field_Release> not_a_terminal;
+    ASSERT_EQ(FindFieldByName(tree, "Signature1", not_a_terminal.out()), VANILLAPDF_ERROR_OBJECT_MISSING);
+
+    HandleGuard<BufferHandle, Buffer_Release> signing_key_data;
+    HandleGuard<PKCS12KeyHandle, PKCS12Key_Release> pkcs12_key;
+    HandleGuard<SigningKeyHandle, SigningKey_Release> signing_key;
+    HandleGuard<DateHandle, Date_Release> signing_time;
+    HandleGuard<DocumentSignatureSettingsHandle, DocumentSignatureSettings_Release> signature_settings;
+    ASSERT_EQ(Buffer_CreateFromData(reinterpret_cast<string_type>(SIGNING_CERTIFICATE), sizeof(SIGNING_CERTIFICATE), signing_key_data.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(PKCS12Key_CreateFromBuffer(signing_key_data, nullptr, pkcs12_key.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(PKCS12Key_ToSigningKey(pkcs12_key, signing_key.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Date_CreateCurrent(signing_time.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(DocumentSignatureSettings_Create(signature_settings.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(DocumentSignatureSettings_SetSigningKey(signature_settings, signing_key), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(DocumentSignatureSettings_SetDigest(signature_settings, MessageDigestAlgorithmType_SHA256), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(DocumentSignatureSettings_SetSigningTime(signature_settings, signing_time), VANILLAPDF_ERROR_SUCCESS);
+
+    HandleGuard<InputOutputStreamHandle, InputOutputStream_Release> signed_stream;
+    HandleGuard<FileHandle, File_Release> signed_file;
+    ASSERT_EQ(InputOutputStream_CreateFromMemory(signed_stream.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(File_CreateStream(signed_stream, "temp_signed", signed_file.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Document_Sign(document, signed_file, signature_settings), VANILLAPDF_ERROR_SUCCESS);
+
+    // The signature went in next to the group, under the next free name,
+    // and the tree held here shows it right away: the signer reached the
+    // form through the catalog, which hands out the very form instance
+    // attached above, and that form hands out this very tree
+    ASSERT_EQ(GetRootChildCount(tree), 2u);
+    EXPECT_EQ(GetRootChildQualifiedName(tree, 1), "Signature2");
+
+    HandleGuard<FileHandle, File_Release> reloaded_file;
+    HandleGuard<DocumentHandle, Document_Release> reloaded_document;
+    HandleGuard<CatalogHandle, Catalog_Release> reloaded_catalog;
+    HandleGuard<InteractiveFormHandle, InteractiveForm_Release> reloaded_form;
+    HandleGuard<FieldTreeHandle, FieldTree_Release> reloaded_tree;
+    ASSERT_EQ(File_OpenStream(signed_stream, "temp_signed", reloaded_file.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(File_Initialize(reloaded_file), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Document_OpenFile(reloaded_file, reloaded_document.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Document_GetCatalog(reloaded_document, reloaded_catalog.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Catalog_GetAcroForm(reloaded_catalog, reloaded_form.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(InteractiveForm_GetFieldTree(reloaded_form, reloaded_tree.out()), VANILLAPDF_ERROR_SUCCESS);
+
+    ASSERT_EQ(GetFieldCount(reloaded_tree), 2u);
+    EXPECT_EQ(GetFieldQualifiedName(reloaded_tree, 0), "Signature1.child");
+    EXPECT_EQ(GetFieldQualifiedName(reloaded_tree, 1), "Signature2");
+
+    HandleGuard<FieldHandle, Field_Release> signature;
+    ASSERT_EQ(FindFieldByName(reloaded_tree, "Signature2", signature.out()), VANILLAPDF_ERROR_SUCCESS);
+
+    FieldType type = FieldType_Undefined;
+    ASSERT_EQ(Field_GetType(signature, &type), VANILLAPDF_ERROR_SUCCESS);
+    EXPECT_EQ(type, FieldType_Signature);
 }
 
 } // namespace field_tree

--- a/src/vanillapdf.unittest/field_tree_test.cpp
+++ b/src/vanillapdf.unittest/field_tree_test.cpp
@@ -867,6 +867,36 @@ TEST(FieldTree, CreatedTreeIsUsableBeforeAttachment) {
     EXPECT_EQ(GetFieldCount(form_tree), 1u);
 }
 
+// A hierarchy holds references into the document it was created for -
+// attached to a form of another document, they would serialize as dangling
+// object numbers, so the attachment is refused and the form is left as it was
+TEST(FieldTree, AttachingTreeOfAnotherDocumentIsRefused) {
+    HandleGuard<InputOutputStreamHandle, InputOutputStream_Release> io_stream;
+    HandleGuard<FileHandle, File_Release> file;
+    HandleGuard<DocumentHandle, Document_Release> document;
+    CreateMemoryDocument(io_stream, file, document);
+
+    HandleGuard<InputOutputStreamHandle, InputOutputStream_Release> other_io_stream;
+    HandleGuard<FileHandle, File_Release> other_file;
+    HandleGuard<DocumentHandle, Document_Release> other_document;
+    CreateMemoryDocument(other_io_stream, other_file, other_document);
+
+    HandleGuard<InteractiveFormHandle, InteractiveForm_Release> form;
+    ASSERT_EQ(InteractiveForm_CreateFromDocument(document, form.out()), VANILLAPDF_ERROR_SUCCESS);
+
+    HandleGuard<FieldTreeHandle, FieldTree_Release> other_tree;
+    ASSERT_EQ(FieldTree_CreateFromDocument(other_document, other_tree.out()), VANILLAPDF_ERROR_SUCCESS);
+    EXPECT_EQ(InteractiveForm_SetFieldTree(form, other_tree), VANILLAPDF_ERROR_PARAMETER_VALUE);
+
+    HandleGuard<FieldTreeHandle, FieldTree_Release> missing_tree;
+    EXPECT_EQ(InteractiveForm_GetFieldTree(form, missing_tree.out()), VANILLAPDF_ERROR_OBJECT_MISSING);
+
+    // The document's own hierarchy is accepted as before
+    HandleGuard<FieldTreeHandle, FieldTree_Release> own_tree;
+    ASSERT_EQ(FieldTree_CreateFromDocument(document, own_tree.out()), VANILLAPDF_ERROR_SUCCESS);
+    EXPECT_EQ(InteractiveForm_SetFieldTree(form, own_tree), VANILLAPDF_ERROR_SUCCESS);
+}
+
 // --- Persistence ---
 
 // A hierarchy authored through the tree survives a save and reopen cycle

--- a/src/vanillapdf.unittest/field_tree_test.cpp
+++ b/src/vanillapdf.unittest/field_tree_test.cpp
@@ -897,6 +897,59 @@ TEST(FieldTree, RemoveChildNavigatesByTheWalkNotByParent) {
     EXPECT_EQ(Field_GetParent(city, city_parent.out()), VANILLAPDF_ERROR_OBJECT_MISSING);
 }
 
+// The names the tree indexes follow the walk, not /Parent - on a file
+// whose /Parent entries are missing or wrong, the lookup still finds a
+// field at the path the structure shows, and the write path judges a new
+// name against the same names
+TEST(FieldTree, NamesFollowTheWalkNotParent) {
+    SampleHierarchy sample;
+    BuildSampleHierarchy(sample);
+
+    // street loses its /Parent, city's /Parent points at the wrong node
+    RemoveEntry(sample.street, "Parent");
+    RemoveEntry(sample.city, "Parent");
+    InsertParentEntry(sample.city, sample.email);
+    ASSERT_EQ(FieldTree_Invalidate(sample.tree), VANILLAPDF_ERROR_SUCCESS);
+
+    HandleGuard<FieldHandle, Field_Release> street;
+    EXPECT_EQ(FindFieldByName(sample.tree, "address.street", street.out()), VANILLAPDF_ERROR_SUCCESS);
+
+    HandleGuard<FieldHandle, Field_Release> city;
+    EXPECT_EQ(FindFieldByName(sample.tree, "address.city", city.out()), VANILLAPDF_ERROR_SUCCESS);
+
+    HandleGuard<FieldHandle, Field_Release> not_found;
+    EXPECT_EQ(FindFieldByName(sample.tree, "street", not_found.out()), VANILLAPDF_ERROR_OBJECT_MISSING);
+    EXPECT_EQ(FindFieldByName(sample.tree, "email.city", not_found.out()), VANILLAPDF_ERROR_OBJECT_MISSING);
+
+    // The field itself can only follow its /Parent, and reports the
+    // damaged file's view
+    EXPECT_EQ(GetQualifiedName(street), "street");
+    EXPECT_EQ(GetQualifiedName(city), "email.city");
+
+    // Uniqueness is judged against the walk's names: "address.city" is
+    // taken, "email.city" and "street" are free
+    HandleGuard<FieldHandle, Field_Release> address;
+    ASSERT_EQ(FieldTree_GetRootChild(sample.tree, 0, address.out()), VANILLAPDF_ERROR_SUCCESS);
+
+    HandleGuard<DictionaryObjectHandle, DictionaryObject_Release> duplicate_city_dictionary;
+    HandleGuard<FieldHandle, Field_Release> duplicate_city;
+    CreateTextFieldDictionary(sample.file, "city", duplicate_city_dictionary, duplicate_city);
+    EXPECT_EQ(FieldTree_AddChild(sample.tree, address, duplicate_city), VANILLAPDF_ERROR_PARAMETER_VALUE);
+
+    HandleGuard<FieldHandle, Field_Release> email;
+    ASSERT_EQ(FieldTree_GetRootChild(sample.tree, 1, email.out()), VANILLAPDF_ERROR_SUCCESS);
+    EXPECT_EQ(FieldTree_AddChild(sample.tree, email, duplicate_city), VANILLAPDF_ERROR_SUCCESS);
+
+    HandleGuard<DictionaryObjectHandle, DictionaryObject_Release> root_street_dictionary;
+    HandleGuard<FieldHandle, Field_Release> root_street;
+    CreateTextFieldDictionary(sample.file, "street", root_street_dictionary, root_street);
+    EXPECT_EQ(FieldTree_AddRootChild(sample.tree, root_street), VANILLAPDF_ERROR_SUCCESS);
+
+    HandleGuard<FieldHandle, Field_Release> found;
+    EXPECT_EQ(FindFieldByName(sample.tree, "email.city", found.out()), VANILLAPDF_ERROR_SUCCESS);
+    EXPECT_EQ(FindFieldByName(sample.tree, "street", found.out()), VANILLAPDF_ERROR_SUCCESS);
+}
+
 // --- Invalidate ---
 
 // The tree cannot observe edits made underneath it through the dictionary

--- a/src/vanillapdf.unittest/field_tree_test.cpp
+++ b/src/vanillapdf.unittest/field_tree_test.cpp
@@ -1,0 +1,947 @@
+#include "unittest.h"
+#include "handle_guard.h"
+
+#include <cstring>
+
+// Structural view of the interactive form field hierarchy - the top level,
+// the child walk, the parent round trip and the mutators of FieldTreeHandle.
+// The flat view is covered next to the form in interactive_forms_test.cpp.
+namespace field_tree {
+
+static void CreateMemoryDocument(
+    HandleGuard<InputOutputStreamHandle, InputOutputStream_Release>& io_stream,
+    HandleGuard<FileHandle, File_Release>& file,
+    HandleGuard<DocumentHandle, Document_Release>& document
+) {
+    ASSERT_EQ(InputOutputStream_CreateFromMemory(io_stream.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(File_CreateStream(io_stream, "temp", file.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Document_CreateFile(file, document.out()), VANILLAPDF_ERROR_SUCCESS);
+}
+
+static void RegisterIndirectObject(FileHandle* file, DictionaryObjectHandle* dict) {
+    HandleGuard<ObjectHandle, Object_Release> dict_object;
+    ASSERT_EQ(DictionaryObject_ToObject(dict, dict_object.out()), VANILLAPDF_ERROR_SUCCESS);
+
+    HandleGuard<XrefUsedEntryHandle, XrefUsedEntry_Release> entry;
+    ASSERT_EQ(File_AllocateNewEntry(file, entry.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(XrefUsedEntry_SetReference(entry, dict_object), VANILLAPDF_ERROR_SUCCESS);
+}
+
+static void CreateReferenceTo(
+    DictionaryObjectHandle* dict,
+    HandleGuard<IndirectReferenceObjectHandle, IndirectReferenceObject_Release>& reference
+) {
+    HandleGuard<ObjectHandle, Object_Release> dict_object;
+    ASSERT_EQ(DictionaryObject_ToObject(dict, dict_object.out()), VANILLAPDF_ERROR_SUCCESS);
+
+    ASSERT_EQ(IndirectReferenceObject_Create(reference.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(IndirectReferenceObject_SetReferencedObject(reference, dict_object), VANILLAPDF_ERROR_SUCCESS);
+}
+
+static void InsertReferenceArrayEntry(
+    DictionaryObjectHandle* dict,
+    const char* key_name,
+    std::initializer_list<DictionaryObjectHandle*> targets
+) {
+    HandleGuard<ArrayObjectHandle, ArrayObject_Release> array;
+    ASSERT_EQ(ArrayObject_Create(array.out()), VANILLAPDF_ERROR_SUCCESS);
+
+    for (DictionaryObjectHandle* target : targets) {
+        HandleGuard<IndirectReferenceObjectHandle, IndirectReferenceObject_Release> reference;
+        CreateReferenceTo(target, reference);
+
+        HandleGuard<ObjectHandle, Object_Release> reference_object;
+        ASSERT_EQ(IndirectReferenceObject_ToObject(reference, reference_object.out()), VANILLAPDF_ERROR_SUCCESS);
+        ASSERT_EQ(ArrayObject_Append(array, reference_object), VANILLAPDF_ERROR_SUCCESS);
+    }
+
+    HandleGuard<ObjectHandle, Object_Release> array_object;
+    ASSERT_EQ(ArrayObject_ToObject(array, array_object.out()), VANILLAPDF_ERROR_SUCCESS);
+
+    HandleGuard<NameObjectHandle, NameObject_Release> key;
+    ASSERT_EQ(NameObject_CreateFromDecodedString(key_name, key.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(DictionaryObject_Insert(dict, key, array_object, VANILLAPDF_RV_TRUE), VANILLAPDF_ERROR_SUCCESS);
+}
+
+static void InsertParentEntry(DictionaryObjectHandle* child, DictionaryObjectHandle* parent) {
+    HandleGuard<IndirectReferenceObjectHandle, IndirectReferenceObject_Release> reference;
+    CreateReferenceTo(parent, reference);
+
+    HandleGuard<ObjectHandle, Object_Release> reference_object;
+    ASSERT_EQ(IndirectReferenceObject_ToObject(reference, reference_object.out()), VANILLAPDF_ERROR_SUCCESS);
+
+    HandleGuard<NameObjectHandle, NameObject_Release> key;
+    ASSERT_EQ(NameObject_CreateFromDecodedString("Parent", key.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(DictionaryObject_Insert(child, key, reference_object, VANILLAPDF_RV_TRUE), VANILLAPDF_ERROR_SUCCESS);
+}
+
+static void RemoveEntry(DictionaryObjectHandle* dict, const char* key_name) {
+    HandleGuard<NameObjectHandle, NameObject_Release> key;
+    ASSERT_EQ(NameObject_CreateFromDecodedString(key_name, key.out()), VANILLAPDF_ERROR_SUCCESS);
+
+    boolean_type removed = VANILLAPDF_RV_FALSE;
+    ASSERT_EQ(DictionaryObject_Remove(dict, key, &removed), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(removed, VANILLAPDF_RV_TRUE);
+}
+
+static void InsertNameEntry(DictionaryObjectHandle* dict, const char* key_name, const char* value) {
+    HandleGuard<NameObjectHandle, NameObject_Release> key;
+    HandleGuard<NameObjectHandle, NameObject_Release> name_value;
+    ASSERT_EQ(NameObject_CreateFromDecodedString(key_name, key.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(NameObject_CreateFromDecodedString(value, name_value.out()), VANILLAPDF_ERROR_SUCCESS);
+
+    HandleGuard<ObjectHandle, Object_Release> value_object;
+    ASSERT_EQ(NameObject_ToObject(name_value, value_object.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(DictionaryObject_Insert(dict, key, value_object, VANILLAPDF_RV_TRUE), VANILLAPDF_ERROR_SUCCESS);
+}
+
+static void InsertStringEntry(DictionaryObjectHandle* dict, const char* key_name, const char* value) {
+    HandleGuard<NameObjectHandle, NameObject_Release> key;
+    HandleGuard<LiteralStringObjectHandle, LiteralStringObject_Release> literal_value;
+    ASSERT_EQ(NameObject_CreateFromDecodedString(key_name, key.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(LiteralStringObject_CreateFromDecodedString(value, literal_value.out()), VANILLAPDF_ERROR_SUCCESS);
+
+    HandleGuard<StringObjectHandle, StringObject_Release> string_value;
+    ASSERT_EQ(LiteralStringObject_ToStringObject(literal_value, string_value.out()), VANILLAPDF_ERROR_SUCCESS);
+
+    HandleGuard<ObjectHandle, Object_Release> value_object;
+    ASSERT_EQ(StringObject_ToObject(string_value, value_object.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(DictionaryObject_Insert(dict, key, value_object, VANILLAPDF_RV_TRUE), VANILLAPDF_ERROR_SUCCESS);
+}
+
+static void InsertIntegerEntry(DictionaryObjectHandle* dict, const char* key_name, bigint_type value) {
+    HandleGuard<NameObjectHandle, NameObject_Release> key;
+    HandleGuard<IntegerObjectHandle, IntegerObject_Release> integer_value;
+    ASSERT_EQ(NameObject_CreateFromDecodedString(key_name, key.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(IntegerObject_CreateFromIntegerValue(value, integer_value.out()), VANILLAPDF_ERROR_SUCCESS);
+
+    HandleGuard<ObjectHandle, Object_Release> value_object;
+    ASSERT_EQ(IntegerObject_ToObject(integer_value, value_object.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(DictionaryObject_Insert(dict, key, value_object, VANILLAPDF_RV_TRUE), VANILLAPDF_ERROR_SUCCESS);
+}
+
+static std::string BufferToString(BufferHandle* buffer) {
+    string_type data = nullptr;
+    size_type size = 0;
+    EXPECT_EQ(Buffer_GetData(buffer, &data, &size), VANILLAPDF_ERROR_SUCCESS);
+    return std::string(data, size);
+}
+
+static std::string StringObjectToString(StringObjectHandle* string_object) {
+    HandleGuard<BufferHandle, Buffer_Release> value;
+    EXPECT_EQ(StringObject_GetValue(string_object, value.out()), VANILLAPDF_ERROR_SUCCESS);
+    return BufferToString(value);
+}
+
+// Looks a terminal field up by its fully qualified name given as a literal
+static error_type FindFieldByName(FieldTreeHandle* tree, const char* qualified_name, FieldHandle** result) {
+    return FieldTree_FindField(tree, qualified_name, static_cast<size_type>(strlen(qualified_name)), result);
+}
+
+static std::string GetQualifiedName(FieldHandle* field) {
+    HandleGuard<BufferHandle, Buffer_Release> qualified_name;
+    EXPECT_EQ(Field_GetQualifiedName(field, qualified_name.out()), VANILLAPDF_ERROR_SUCCESS);
+    return BufferToString(qualified_name);
+}
+
+static std::string GetFieldQualifiedName(FieldTreeHandle* tree, size_type index) {
+    HandleGuard<FieldHandle, Field_Release> field;
+    EXPECT_EQ(FieldTree_GetField(tree, index, field.out()), VANILLAPDF_ERROR_SUCCESS);
+    return GetQualifiedName(field);
+}
+
+static std::string GetRootChildQualifiedName(FieldTreeHandle* tree, size_type index) {
+    HandleGuard<FieldHandle, Field_Release> child;
+    EXPECT_EQ(FieldTree_GetRootChild(tree, index, child.out()), VANILLAPDF_ERROR_SUCCESS);
+    return GetQualifiedName(child);
+}
+
+static std::string GetChildQualifiedName(FieldHandle* parent, size_type index) {
+    HandleGuard<FieldHandle, Field_Release> child;
+    EXPECT_EQ(Field_GetChild(parent, index, child.out()), VANILLAPDF_ERROR_SUCCESS);
+    return GetQualifiedName(child);
+}
+
+static size_type GetFieldCount(FieldTreeHandle* tree) {
+    size_type count = 0;
+    EXPECT_EQ(FieldTree_GetFieldCount(tree, &count), VANILLAPDF_ERROR_SUCCESS);
+    return count;
+}
+
+static size_type GetRootChildCount(FieldTreeHandle* tree) {
+    size_type count = 0;
+    EXPECT_EQ(FieldTree_GetRootChildCount(tree, &count), VANILLAPDF_ERROR_SUCCESS);
+    return count;
+}
+
+static size_type GetChildCount(FieldHandle* field) {
+    size_type count = 0;
+    EXPECT_EQ(Field_GetChildCount(field, &count), VANILLAPDF_ERROR_SUCCESS);
+    return count;
+}
+
+static void CreateTextFieldDictionary(
+    FileHandle* file,
+    const char* partial_name,
+    HandleGuard<DictionaryObjectHandle, DictionaryObject_Release>& dictionary,
+    HandleGuard<FieldHandle, Field_Release>& field
+) {
+    ASSERT_EQ(DictionaryObject_Create(dictionary.out()), VANILLAPDF_ERROR_SUCCESS);
+    InsertStringEntry(dictionary, "T", partial_name);
+    InsertNameEntry(dictionary, "FT", "Tx");
+    RegisterIndirectObject(file, dictionary);
+    ASSERT_EQ(Field_CreateFromDictionary(dictionary, field.out()), VANILLAPDF_ERROR_SUCCESS);
+}
+
+// A small hierarchy shared by most tests:
+//
+//   /Fields [ address, email ]
+//   address (group, /FT /Tx) /Kids [ street, city ]
+//   email   (terminal)
+//
+// The form dictionary carries the document defaults /DA and /Q.
+struct SampleHierarchy {
+    HandleGuard<InputOutputStreamHandle, InputOutputStream_Release> io_stream;
+    HandleGuard<FileHandle, File_Release> file;
+    HandleGuard<DocumentHandle, Document_Release> document;
+
+    HandleGuard<DictionaryObjectHandle, DictionaryObject_Release> address;
+    HandleGuard<DictionaryObjectHandle, DictionaryObject_Release> street;
+    HandleGuard<DictionaryObjectHandle, DictionaryObject_Release> city;
+    HandleGuard<DictionaryObjectHandle, DictionaryObject_Release> email;
+    HandleGuard<DictionaryObjectHandle, DictionaryObject_Release> form_dictionary;
+
+    HandleGuard<InteractiveFormHandle, InteractiveForm_Release> form;
+    HandleGuard<FieldTreeHandle, FieldTree_Release> tree;
+};
+
+static void BuildSampleHierarchy(SampleHierarchy& sample) {
+    CreateMemoryDocument(sample.io_stream, sample.file, sample.document);
+
+    ASSERT_EQ(DictionaryObject_Create(sample.address.out()), VANILLAPDF_ERROR_SUCCESS);
+    InsertStringEntry(sample.address, "T", "address");
+    InsertNameEntry(sample.address, "FT", "Tx");
+    RegisterIndirectObject(sample.file, sample.address);
+
+    ASSERT_EQ(DictionaryObject_Create(sample.street.out()), VANILLAPDF_ERROR_SUCCESS);
+    InsertStringEntry(sample.street, "T", "street");
+    InsertStringEntry(sample.street, "V", "Main St");
+    RegisterIndirectObject(sample.file, sample.street);
+    InsertParentEntry(sample.street, sample.address);
+
+    ASSERT_EQ(DictionaryObject_Create(sample.city.out()), VANILLAPDF_ERROR_SUCCESS);
+    InsertStringEntry(sample.city, "T", "city");
+    RegisterIndirectObject(sample.file, sample.city);
+    InsertParentEntry(sample.city, sample.address);
+
+    InsertReferenceArrayEntry(sample.address, "Kids", { sample.street.get(), sample.city.get() });
+
+    ASSERT_EQ(DictionaryObject_Create(sample.email.out()), VANILLAPDF_ERROR_SUCCESS);
+    InsertStringEntry(sample.email, "T", "email");
+    InsertNameEntry(sample.email, "FT", "Tx");
+    RegisterIndirectObject(sample.file, sample.email);
+
+    ASSERT_EQ(DictionaryObject_Create(sample.form_dictionary.out()), VANILLAPDF_ERROR_SUCCESS);
+    InsertStringEntry(sample.form_dictionary, "DA", "/Helv 0 Tf 0 g");
+    InsertIntegerEntry(sample.form_dictionary, "Q", 1);
+    InsertReferenceArrayEntry(sample.form_dictionary, "Fields", { sample.address.get(), sample.email.get() });
+
+    ASSERT_EQ(InteractiveForm_CreateFromDictionary(sample.form_dictionary, sample.form.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(InteractiveForm_GetFieldTree(sample.form, sample.tree.out()), VANILLAPDF_ERROR_SUCCESS);
+}
+
+// --- Walking down ---
+
+// The top level is the root /Fields entries - groups included - and a
+// group's children are its /Kids fields, in array order
+TEST(FieldTree, ChildrenWalkFromTheTopLevel) {
+    SampleHierarchy sample;
+    BuildSampleHierarchy(sample);
+
+    ASSERT_EQ(GetRootChildCount(sample.tree), 2u);
+    EXPECT_EQ(GetRootChildQualifiedName(sample.tree, 0), "address");
+    EXPECT_EQ(GetRootChildQualifiedName(sample.tree, 1), "email");
+
+    HandleGuard<FieldHandle, Field_Release> out_of_range;
+    EXPECT_EQ(FieldTree_GetRootChild(sample.tree, 2, out_of_range.out()), VANILLAPDF_ERROR_OBJECT_MISSING);
+
+    HandleGuard<FieldHandle, Field_Release> address;
+    ASSERT_EQ(FieldTree_GetRootChild(sample.tree, 0, address.out()), VANILLAPDF_ERROR_SUCCESS);
+
+    boolean_type terminal = VANILLAPDF_RV_TRUE;
+    ASSERT_EQ(Field_IsTerminal(address, &terminal), VANILLAPDF_ERROR_SUCCESS);
+    EXPECT_EQ(terminal, VANILLAPDF_RV_FALSE);
+
+    FieldType type = FieldType_Undefined;
+    ASSERT_EQ(Field_GetType(address, &type), VANILLAPDF_ERROR_SUCCESS);
+    EXPECT_EQ(type, FieldType_Text);
+
+    ASSERT_EQ(GetChildCount(address), 2u);
+    EXPECT_EQ(GetChildQualifiedName(address, 0), "address.street");
+    EXPECT_EQ(GetChildQualifiedName(address, 1), "address.city");
+
+    HandleGuard<FieldHandle, Field_Release> street;
+    ASSERT_EQ(Field_GetChild(address, 0, street.out()), VANILLAPDF_ERROR_SUCCESS);
+    EXPECT_EQ(GetChildCount(street), 0u);
+    EXPECT_EQ(Field_GetChild(street, 0, out_of_range.out()), VANILLAPDF_ERROR_OBJECT_MISSING);
+
+    // The flat view is the same tree, terminals only, in the same order
+    ASSERT_EQ(GetFieldCount(sample.tree), 3u);
+    EXPECT_EQ(GetFieldQualifiedName(sample.tree, 0), "address.street");
+    EXPECT_EQ(GetFieldQualifiedName(sample.tree, 1), "address.city");
+    EXPECT_EQ(GetFieldQualifiedName(sample.tree, 2), "email");
+}
+
+// A /Kids entry is a child field when it carries /T, /Kids or /FT - a
+// nameless intermediate node is legal and its subtree is not lost
+TEST(FieldTree, NamelessIntermediateNodeIsWalked) {
+    HandleGuard<InputOutputStreamHandle, InputOutputStream_Release> io_stream;
+    HandleGuard<FileHandle, File_Release> file;
+    HandleGuard<DocumentHandle, Document_Release> document;
+    CreateMemoryDocument(io_stream, file, document);
+
+    HandleGuard<DictionaryObjectHandle, DictionaryObject_Release> group;
+    ASSERT_EQ(DictionaryObject_Create(group.out()), VANILLAPDF_ERROR_SUCCESS);
+    InsertStringEntry(group, "T", "group");
+    RegisterIndirectObject(file, group);
+
+    // No /T of its own - contributes no name segment
+    HandleGuard<DictionaryObjectHandle, DictionaryObject_Release> nameless;
+    ASSERT_EQ(DictionaryObject_Create(nameless.out()), VANILLAPDF_ERROR_SUCCESS);
+    RegisterIndirectObject(file, nameless);
+    InsertParentEntry(nameless, group);
+
+    HandleGuard<DictionaryObjectHandle, DictionaryObject_Release> leaf;
+    ASSERT_EQ(DictionaryObject_Create(leaf.out()), VANILLAPDF_ERROR_SUCCESS);
+    InsertStringEntry(leaf, "T", "leaf");
+    InsertNameEntry(leaf, "FT", "Tx");
+    RegisterIndirectObject(file, leaf);
+    InsertParentEntry(leaf, nameless);
+
+    InsertReferenceArrayEntry(nameless, "Kids", { leaf.get() });
+    InsertReferenceArrayEntry(group, "Kids", { nameless.get() });
+
+    HandleGuard<DictionaryObjectHandle, DictionaryObject_Release> form_dictionary;
+    ASSERT_EQ(DictionaryObject_Create(form_dictionary.out()), VANILLAPDF_ERROR_SUCCESS);
+    InsertReferenceArrayEntry(form_dictionary, "Fields", { group.get() });
+
+    HandleGuard<InteractiveFormHandle, InteractiveForm_Release> form;
+    HandleGuard<FieldTreeHandle, FieldTree_Release> tree;
+    ASSERT_EQ(InteractiveForm_CreateFromDictionary(form_dictionary, form.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(InteractiveForm_GetFieldTree(form, tree.out()), VANILLAPDF_ERROR_SUCCESS);
+
+    ASSERT_EQ(GetFieldCount(tree), 1u);
+    EXPECT_EQ(GetFieldQualifiedName(tree, 0), "group.leaf");
+
+    HandleGuard<FieldHandle, Field_Release> found;
+    EXPECT_EQ(FindFieldByName(tree, "group.leaf", found.out()), VANILLAPDF_ERROR_SUCCESS);
+}
+
+// --- Walking up ---
+
+// A nested field reports its group, a top-level field has no /Parent and
+// reports nothing - whether the handle came from the tree or was created
+// straight from the dictionary
+TEST(FieldTree, GetParentRoundTrips) {
+    SampleHierarchy sample;
+    BuildSampleHierarchy(sample);
+
+    HandleGuard<FieldHandle, Field_Release> street;
+    ASSERT_EQ(FindFieldByName(sample.tree, "address.street", street.out()), VANILLAPDF_ERROR_SUCCESS);
+
+    HandleGuard<FieldHandle, Field_Release> street_parent;
+    ASSERT_EQ(Field_GetParent(street, street_parent.out()), VANILLAPDF_ERROR_SUCCESS);
+    EXPECT_EQ(GetQualifiedName(street_parent), "address");
+
+    boolean_type terminal = VANILLAPDF_RV_TRUE;
+    ASSERT_EQ(Field_IsTerminal(street_parent, &terminal), VANILLAPDF_ERROR_SUCCESS);
+    EXPECT_EQ(terminal, VANILLAPDF_RV_FALSE);
+    EXPECT_EQ(GetChildCount(street_parent), 2u);
+
+    HandleGuard<FieldHandle, Field_Release> beyond_top;
+    EXPECT_EQ(Field_GetParent(street_parent, beyond_top.out()), VANILLAPDF_ERROR_OBJECT_MISSING);
+
+    // The parent handed back is a valid parent for the mutators
+    HandleGuard<DictionaryObjectHandle, DictionaryObject_Release> zip_dictionary;
+    HandleGuard<FieldHandle, Field_Release> zip;
+    CreateTextFieldDictionary(sample.file, "zip", zip_dictionary, zip);
+    ASSERT_EQ(FieldTree_AddChild(sample.tree, street_parent, zip), VANILLAPDF_ERROR_SUCCESS);
+    EXPECT_EQ(GetFieldQualifiedName(sample.tree, 2), "address.zip");
+
+    // A field is a view over its dictionary - a wrapper created straight
+    // from the dictionary behaves exactly like one handed out by the tree
+    HandleGuard<FieldHandle, Field_Release> detached_street;
+    ASSERT_EQ(Field_CreateFromDictionary(sample.street, detached_street.out()), VANILLAPDF_ERROR_SUCCESS);
+
+    HandleGuard<FieldHandle, Field_Release> detached_street_parent;
+    ASSERT_EQ(Field_GetParent(detached_street, detached_street_parent.out()), VANILLAPDF_ERROR_SUCCESS);
+    EXPECT_EQ(GetQualifiedName(detached_street_parent), "address");
+
+    HandleGuard<FieldHandle, Field_Release> detached_email;
+    ASSERT_EQ(Field_CreateFromDictionary(sample.email, detached_email.out()), VANILLAPDF_ERROR_SUCCESS);
+
+    HandleGuard<FieldHandle, Field_Release> detached_email_parent;
+    EXPECT_EQ(Field_GetParent(detached_email, detached_email_parent.out()), VANILLAPDF_ERROR_OBJECT_MISSING);
+}
+
+// --- Values ---
+
+// /V and /DV are exposed as raw objects, resolved through /Parent
+TEST(FieldTree, ValueObjectsResolveThroughParent) {
+    SampleHierarchy sample;
+    BuildSampleHierarchy(sample);
+
+    InsertStringEntry(sample.address, "DV", "unknown");
+
+    HandleGuard<FieldHandle, Field_Release> city;
+    ASSERT_EQ(FindFieldByName(sample.tree, "address.city", city.out()), VANILLAPDF_ERROR_SUCCESS);
+
+    HandleGuard<ObjectHandle, Object_Release> missing_value;
+    EXPECT_EQ(Field_GetValue(city, missing_value.out()), VANILLAPDF_ERROR_OBJECT_MISSING);
+
+    HandleGuard<ObjectHandle, Object_Release> inherited_default;
+    ASSERT_EQ(Field_GetDefaultValue(city, inherited_default.out()), VANILLAPDF_ERROR_SUCCESS);
+
+    ObjectType default_type = ObjectType_Undefined;
+    ASSERT_EQ(Object_GetObjectType(inherited_default, &default_type), VANILLAPDF_ERROR_SUCCESS);
+    EXPECT_EQ(default_type, ObjectType_String);
+
+    HandleGuard<FieldHandle, Field_Release> street;
+    ASSERT_EQ(FindFieldByName(sample.tree, "address.street", street.out()), VANILLAPDF_ERROR_SUCCESS);
+
+    HandleGuard<ObjectHandle, Object_Release> own_value;
+    ASSERT_EQ(Field_GetValue(street, own_value.out()), VANILLAPDF_ERROR_SUCCESS);
+
+    HandleGuard<StringObjectHandle, StringObject_Release> own_value_string;
+    ASSERT_EQ(StringObject_FromObject(own_value, own_value_string.out()), VANILLAPDF_ERROR_SUCCESS);
+    EXPECT_EQ(StringObjectToString(own_value_string), "Main St");
+}
+
+// --- Appearance defaults ---
+
+// /DA and /Q resolve field, then ancestors, then the form's document
+// default - the field getters stop at the hierarchy, the form finishes
+TEST(FieldTree, ResolveDefaultAppearanceAndQuaddingThroughTheForm) {
+    SampleHierarchy sample;
+    BuildSampleHierarchy(sample);
+
+    HandleGuard<FieldHandle, Field_Release> city;
+    ASSERT_EQ(FindFieldByName(sample.tree, "address.city", city.out()), VANILLAPDF_ERROR_SUCCESS);
+
+    // Nothing on the field or its group - the form default applies
+    HandleGuard<StringObjectHandle, StringObject_Release> field_appearance;
+    EXPECT_EQ(Field_GetDefaultAppearance(city, field_appearance.out()), VANILLAPDF_ERROR_OBJECT_MISSING);
+
+    HandleGuard<StringObjectHandle, StringObject_Release> form_appearance;
+    ASSERT_EQ(InteractiveForm_ResolveDefaultAppearance(sample.form, city, form_appearance.out()), VANILLAPDF_ERROR_SUCCESS);
+    EXPECT_EQ(StringObjectToString(form_appearance), "/Helv 0 Tf 0 g");
+
+    QuaddingType quadding = QuaddingType_LeftJustified;
+    ASSERT_EQ(InteractiveForm_ResolveQuadding(sample.form, city, &quadding), VANILLAPDF_ERROR_SUCCESS);
+    EXPECT_EQ(quadding, QuaddingType_Centered);
+
+    // The group's entries are inherited before the form is consulted
+    InsertStringEntry(sample.address, "DA", "/TiRo 10 Tf 0 g");
+    InsertIntegerEntry(sample.address, "Q", 2);
+
+    HandleGuard<StringObjectHandle, StringObject_Release> group_appearance;
+    ASSERT_EQ(InteractiveForm_ResolveDefaultAppearance(sample.form, city, group_appearance.out()), VANILLAPDF_ERROR_SUCCESS);
+    EXPECT_EQ(StringObjectToString(group_appearance), "/TiRo 10 Tf 0 g");
+
+    ASSERT_EQ(InteractiveForm_ResolveQuadding(sample.form, city, &quadding), VANILLAPDF_ERROR_SUCCESS);
+    EXPECT_EQ(quadding, QuaddingType_RightJustified);
+
+    // The field's own entries win over everything
+    InsertStringEntry(sample.city, "DA", "/Cour 8 Tf 0 g");
+    InsertIntegerEntry(sample.city, "Q", 0);
+
+    HandleGuard<StringObjectHandle, StringObject_Release> own_appearance;
+    ASSERT_EQ(InteractiveForm_ResolveDefaultAppearance(sample.form, city, own_appearance.out()), VANILLAPDF_ERROR_SUCCESS);
+    EXPECT_EQ(StringObjectToString(own_appearance), "/Cour 8 Tf 0 g");
+
+    ASSERT_EQ(InteractiveForm_ResolveQuadding(sample.form, city, &quadding), VANILLAPDF_ERROR_SUCCESS);
+    EXPECT_EQ(quadding, QuaddingType_LeftJustified);
+}
+
+// --- AddChild ---
+
+// Adding under a group sets /Parent and prefixes the name
+TEST(FieldTree, AddChildUnderGroup) {
+    SampleHierarchy sample;
+    BuildSampleHierarchy(sample);
+
+    HandleGuard<FieldHandle, Field_Release> address;
+    ASSERT_EQ(FieldTree_GetRootChild(sample.tree, 0, address.out()), VANILLAPDF_ERROR_SUCCESS);
+
+    HandleGuard<DictionaryObjectHandle, DictionaryObject_Release> zip_dictionary;
+    HandleGuard<FieldHandle, Field_Release> zip;
+    CreateTextFieldDictionary(sample.file, "zip", zip_dictionary, zip);
+    ASSERT_EQ(FieldTree_AddChild(sample.tree, address, zip), VANILLAPDF_ERROR_SUCCESS);
+
+    EXPECT_EQ(GetChildCount(address), 3u);
+    EXPECT_EQ(GetChildQualifiedName(address, 2), "address.zip");
+
+    ASSERT_EQ(GetFieldCount(sample.tree), 4u);
+    EXPECT_EQ(GetFieldQualifiedName(sample.tree, 2), "address.zip");
+    EXPECT_EQ(GetFieldQualifiedName(sample.tree, 3), "email");
+
+    // /Parent was written - the new child walks back up to the group
+    HandleGuard<FieldHandle, Field_Release> found_zip;
+    ASSERT_EQ(FindFieldByName(sample.tree, "address.zip", found_zip.out()), VANILLAPDF_ERROR_SUCCESS);
+
+    HandleGuard<FieldHandle, Field_Release> zip_parent;
+    ASSERT_EQ(Field_GetParent(found_zip, zip_parent.out()), VANILLAPDF_ERROR_SUCCESS);
+    EXPECT_EQ(GetQualifiedName(zip_parent), "address");
+}
+
+// Adding a child to a terminal field turns it into a group - it leaves the
+// flat view and its child takes its place
+TEST(FieldTree, AddChildTurnsTerminalIntoGroup) {
+    SampleHierarchy sample;
+    BuildSampleHierarchy(sample);
+
+    HandleGuard<FieldHandle, Field_Release> email;
+    ASSERT_EQ(FindFieldByName(sample.tree, "email", email.out()), VANILLAPDF_ERROR_SUCCESS);
+
+    HandleGuard<DictionaryObjectHandle, DictionaryObject_Release> work_dictionary;
+    HandleGuard<FieldHandle, Field_Release> work;
+    CreateTextFieldDictionary(sample.file, "work", work_dictionary, work);
+    ASSERT_EQ(FieldTree_AddChild(sample.tree, email, work), VANILLAPDF_ERROR_SUCCESS);
+
+    boolean_type terminal = VANILLAPDF_RV_TRUE;
+    ASSERT_EQ(Field_IsTerminal(email, &terminal), VANILLAPDF_ERROR_SUCCESS);
+    EXPECT_EQ(terminal, VANILLAPDF_RV_FALSE);
+
+    ASSERT_EQ(GetFieldCount(sample.tree), 3u);
+    EXPECT_EQ(GetFieldQualifiedName(sample.tree, 2), "email.work");
+
+    HandleGuard<FieldHandle, Field_Release> group_lookup;
+    EXPECT_EQ(FindFieldByName(sample.tree, "email", group_lookup.out()), VANILLAPDF_ERROR_OBJECT_MISSING);
+}
+
+// A top-level field carrying a stale /Parent has it removed on the way in
+TEST(FieldTree, AddRootChildClearsParent) {
+    SampleHierarchy sample;
+    BuildSampleHierarchy(sample);
+
+    HandleGuard<DictionaryObjectHandle, DictionaryObject_Release> phone_dictionary;
+    HandleGuard<FieldHandle, Field_Release> phone;
+    CreateTextFieldDictionary(sample.file, "phone", phone_dictionary, phone);
+    InsertParentEntry(phone_dictionary, sample.address);
+
+    ASSERT_EQ(FieldTree_AddRootChild(sample.tree, phone), VANILLAPDF_ERROR_SUCCESS);
+
+    ASSERT_EQ(GetRootChildCount(sample.tree), 3u);
+    EXPECT_EQ(GetRootChildQualifiedName(sample.tree, 2), "phone");
+
+    HandleGuard<FieldHandle, Field_Release> phone_parent;
+    EXPECT_EQ(Field_GetParent(phone, phone_parent.out()), VANILLAPDF_ERROR_OBJECT_MISSING);
+    EXPECT_EQ(GetQualifiedName(phone), "phone");
+}
+
+// Every refusal leaves the hierarchy untouched
+TEST(FieldTree, AddChildRefusals) {
+    SampleHierarchy sample;
+    BuildSampleHierarchy(sample);
+
+    HandleGuard<FieldHandle, Field_Release> address;
+    ASSERT_EQ(FieldTree_GetRootChild(sample.tree, 0, address.out()), VANILLAPDF_ERROR_SUCCESS);
+
+    // Duplicate fully qualified names, at the top level and under a group
+    HandleGuard<DictionaryObjectHandle, DictionaryObject_Release> duplicate_email_dictionary;
+    HandleGuard<FieldHandle, Field_Release> duplicate_email;
+    CreateTextFieldDictionary(sample.file, "email", duplicate_email_dictionary, duplicate_email);
+    EXPECT_EQ(FieldTree_AddRootChild(sample.tree, duplicate_email), VANILLAPDF_ERROR_PARAMETER_VALUE);
+
+    HandleGuard<DictionaryObjectHandle, DictionaryObject_Release> duplicate_city_dictionary;
+    HandleGuard<FieldHandle, Field_Release> duplicate_city;
+    CreateTextFieldDictionary(sample.file, "city", duplicate_city_dictionary, duplicate_city);
+    EXPECT_EQ(FieldTree_AddChild(sample.tree, address, duplicate_city), VANILLAPDF_ERROR_PARAMETER_VALUE);
+
+    // The same partial name under a different parent is a different field
+    EXPECT_EQ(FieldTree_AddRootChild(sample.tree, duplicate_city), VANILLAPDF_ERROR_SUCCESS);
+
+    // A field already in the hierarchy cannot be added again
+    HandleGuard<FieldHandle, Field_Release> street;
+    ASSERT_EQ(FindFieldByName(sample.tree, "address.street", street.out()), VANILLAPDF_ERROR_SUCCESS);
+    EXPECT_EQ(FieldTree_AddRootChild(sample.tree, street), VANILLAPDF_ERROR_PARAMETER_VALUE);
+    EXPECT_EQ(FieldTree_AddChild(sample.tree, address, street), VANILLAPDF_ERROR_PARAMETER_VALUE);
+
+    // A parent from another hierarchy is refused - nothing but the tree's
+    // own index tells it apart from a field of this document
+    SampleHierarchy other;
+    BuildSampleHierarchy(other);
+
+    HandleGuard<FieldHandle, Field_Release> other_address;
+    ASSERT_EQ(FieldTree_GetRootChild(other.tree, 0, other_address.out()), VANILLAPDF_ERROR_SUCCESS);
+
+    HandleGuard<DictionaryObjectHandle, DictionaryObject_Release> stray_dictionary;
+    HandleGuard<FieldHandle, Field_Release> stray;
+    CreateTextFieldDictionary(sample.file, "stray", stray_dictionary, stray);
+    EXPECT_EQ(FieldTree_AddChild(sample.tree, other_address, stray), VANILLAPDF_ERROR_PARAMETER_VALUE);
+
+    // A terminal field carrying widget annotations cannot take child fields
+    HandleGuard<DictionaryObjectHandle, DictionaryObject_Release> radio_group;
+    ASSERT_EQ(DictionaryObject_Create(radio_group.out()), VANILLAPDF_ERROR_SUCCESS);
+    InsertStringEntry(radio_group, "T", "gender");
+    InsertNameEntry(radio_group, "FT", "Btn");
+    RegisterIndirectObject(sample.file, radio_group);
+
+    HandleGuard<DictionaryObjectHandle, DictionaryObject_Release> widget;
+    ASSERT_EQ(DictionaryObject_Create(widget.out()), VANILLAPDF_ERROR_SUCCESS);
+    InsertNameEntry(widget, "Subtype", "Widget");
+    RegisterIndirectObject(sample.file, widget);
+    InsertReferenceArrayEntry(radio_group, "Kids", { widget.get() });
+
+    HandleGuard<FieldHandle, Field_Release> radio_field;
+    ASSERT_EQ(Field_CreateFromDictionary(radio_group, radio_field.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(FieldTree_AddRootChild(sample.tree, radio_field), VANILLAPDF_ERROR_SUCCESS);
+    EXPECT_EQ(FieldTree_AddChild(sample.tree, radio_field, stray), VANILLAPDF_ERROR_PARAMETER_VALUE);
+
+    // A field merged with its widget annotation cannot take child fields
+    HandleGuard<DictionaryObjectHandle, DictionaryObject_Release> merged;
+    ASSERT_EQ(DictionaryObject_Create(merged.out()), VANILLAPDF_ERROR_SUCCESS);
+    InsertStringEntry(merged, "T", "merged");
+    InsertNameEntry(merged, "FT", "Tx");
+    InsertNameEntry(merged, "Subtype", "Widget");
+    RegisterIndirectObject(sample.file, merged);
+
+    HandleGuard<FieldHandle, Field_Release> merged_field;
+    ASSERT_EQ(Field_CreateFromDictionary(merged, merged_field.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(FieldTree_AddRootChild(sample.tree, merged_field), VANILLAPDF_ERROR_SUCCESS);
+    EXPECT_EQ(FieldTree_AddChild(sample.tree, merged_field, stray), VANILLAPDF_ERROR_PARAMETER_VALUE);
+
+    // Nothing but the accepted additions made it in
+    ASSERT_EQ(GetRootChildCount(sample.tree), 5u);
+    ASSERT_EQ(GetFieldCount(sample.tree), 6u);
+    EXPECT_EQ(GetFieldQualifiedName(sample.tree, 3), "city");
+    EXPECT_EQ(GetFieldQualifiedName(sample.tree, 4), "gender");
+    EXPECT_EQ(GetFieldQualifiedName(sample.tree, 5), "merged");
+}
+
+// --- InsertChild ---
+
+// The index is a position among the container's entries; the end appends
+TEST(FieldTree, InsertChildAtPosition) {
+    SampleHierarchy sample;
+    BuildSampleHierarchy(sample);
+
+    HandleGuard<DictionaryObjectHandle, DictionaryObject_Release> first_dictionary;
+    HandleGuard<FieldHandle, Field_Release> first;
+    CreateTextFieldDictionary(sample.file, "first", first_dictionary, first);
+    ASSERT_EQ(FieldTree_InsertRootChild(sample.tree, 0, first), VANILLAPDF_ERROR_SUCCESS);
+
+    HandleGuard<DictionaryObjectHandle, DictionaryObject_Release> middle_dictionary;
+    HandleGuard<FieldHandle, Field_Release> middle;
+    CreateTextFieldDictionary(sample.file, "middle", middle_dictionary, middle);
+    ASSERT_EQ(FieldTree_InsertRootChild(sample.tree, 2, middle), VANILLAPDF_ERROR_SUCCESS);
+
+    HandleGuard<DictionaryObjectHandle, DictionaryObject_Release> last_dictionary;
+    HandleGuard<FieldHandle, Field_Release> last;
+    CreateTextFieldDictionary(sample.file, "last", last_dictionary, last);
+    ASSERT_EQ(FieldTree_InsertRootChild(sample.tree, 4, last), VANILLAPDF_ERROR_SUCCESS);
+
+    ASSERT_EQ(GetRootChildCount(sample.tree), 5u);
+    EXPECT_EQ(GetRootChildQualifiedName(sample.tree, 0), "first");
+    EXPECT_EQ(GetRootChildQualifiedName(sample.tree, 1), "address");
+    EXPECT_EQ(GetRootChildQualifiedName(sample.tree, 2), "middle");
+    EXPECT_EQ(GetRootChildQualifiedName(sample.tree, 3), "email");
+    EXPECT_EQ(GetRootChildQualifiedName(sample.tree, 4), "last");
+
+    // The flat view follows the same order
+    ASSERT_EQ(GetFieldCount(sample.tree), 6u);
+    EXPECT_EQ(GetFieldQualifiedName(sample.tree, 0), "first");
+    EXPECT_EQ(GetFieldQualifiedName(sample.tree, 1), "address.street");
+    EXPECT_EQ(GetFieldQualifiedName(sample.tree, 3), "middle");
+    EXPECT_EQ(GetFieldQualifiedName(sample.tree, 5), "last");
+
+    // Past the end is out of range, and nothing changes
+    HandleGuard<DictionaryObjectHandle, DictionaryObject_Release> beyond_dictionary;
+    HandleGuard<FieldHandle, Field_Release> beyond;
+    CreateTextFieldDictionary(sample.file, "beyond", beyond_dictionary, beyond);
+    EXPECT_EQ(FieldTree_InsertRootChild(sample.tree, 6, beyond), VANILLAPDF_ERROR_OBJECT_MISSING);
+    EXPECT_EQ(GetRootChildCount(sample.tree), 5u);
+
+    // Under a group, the index counts the group's /Kids
+    HandleGuard<FieldHandle, Field_Release> address;
+    ASSERT_EQ(FieldTree_GetRootChild(sample.tree, 1, address.out()), VANILLAPDF_ERROR_SUCCESS);
+
+    HandleGuard<DictionaryObjectHandle, DictionaryObject_Release> country_dictionary;
+    HandleGuard<FieldHandle, Field_Release> country;
+    CreateTextFieldDictionary(sample.file, "country", country_dictionary, country);
+    ASSERT_EQ(FieldTree_InsertChild(sample.tree, address, 1, country), VANILLAPDF_ERROR_SUCCESS);
+
+    ASSERT_EQ(GetChildCount(address), 3u);
+    EXPECT_EQ(GetChildQualifiedName(address, 0), "address.street");
+    EXPECT_EQ(GetChildQualifiedName(address, 1), "address.country");
+    EXPECT_EQ(GetChildQualifiedName(address, 2), "address.city");
+
+    EXPECT_EQ(FieldTree_InsertChild(sample.tree, address, 4, beyond), VANILLAPDF_ERROR_OBJECT_MISSING);
+    EXPECT_EQ(GetChildCount(address), 3u);
+}
+
+// --- RemoveChild ---
+
+// Removing a nested field takes it out of its group's /Kids and clears
+// /Parent; removing a top-level field takes it out of /Fields
+TEST(FieldTree, RemoveChildAtEitherLevel) {
+    SampleHierarchy sample;
+    BuildSampleHierarchy(sample);
+
+    HandleGuard<FieldHandle, Field_Release> street;
+    ASSERT_EQ(FindFieldByName(sample.tree, "address.street", street.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(FieldTree_RemoveChild(sample.tree, street), VANILLAPDF_ERROR_SUCCESS);
+
+    HandleGuard<FieldHandle, Field_Release> address;
+    ASSERT_EQ(FieldTree_GetRootChild(sample.tree, 0, address.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(GetChildCount(address), 1u);
+    EXPECT_EQ(GetChildQualifiedName(address, 0), "address.city");
+
+    // /Parent is gone - the removed field neither walks up nor keeps the
+    // group's name prefix
+    HandleGuard<FieldHandle, Field_Release> street_parent;
+    EXPECT_EQ(Field_GetParent(street, street_parent.out()), VANILLAPDF_ERROR_OBJECT_MISSING);
+    EXPECT_EQ(GetQualifiedName(street), "street");
+
+    ASSERT_EQ(GetFieldCount(sample.tree), 2u);
+    EXPECT_EQ(GetFieldQualifiedName(sample.tree, 0), "address.city");
+    EXPECT_EQ(GetFieldQualifiedName(sample.tree, 1), "email");
+
+    HandleGuard<FieldHandle, Field_Release> email;
+    ASSERT_EQ(FindFieldByName(sample.tree, "email", email.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(FieldTree_RemoveChild(sample.tree, email), VANILLAPDF_ERROR_SUCCESS);
+
+    ASSERT_EQ(GetRootChildCount(sample.tree), 1u);
+    ASSERT_EQ(GetFieldCount(sample.tree), 1u);
+    EXPECT_EQ(GetFieldQualifiedName(sample.tree, 0), "address.city");
+
+    // Removing twice, or a field that never belonged, is refused
+    EXPECT_EQ(FieldTree_RemoveChild(sample.tree, email), VANILLAPDF_ERROR_PARAMETER_VALUE);
+
+    HandleGuard<DictionaryObjectHandle, DictionaryObject_Release> stranger_dictionary;
+    HandleGuard<FieldHandle, Field_Release> stranger;
+    CreateTextFieldDictionary(sample.file, "stranger", stranger_dictionary, stranger);
+    EXPECT_EQ(FieldTree_RemoveChild(sample.tree, stranger), VANILLAPDF_ERROR_PARAMETER_VALUE);
+}
+
+// A group goes with its whole subtree; a group emptied by removals stays
+TEST(FieldTree, RemoveGroupTakesSubtreeAndEmptiedGroupStays) {
+    SampleHierarchy sample;
+    BuildSampleHierarchy(sample);
+
+    HandleGuard<FieldHandle, Field_Release> address;
+    ASSERT_EQ(FieldTree_GetRootChild(sample.tree, 0, address.out()), VANILLAPDF_ERROR_SUCCESS);
+
+    HandleGuard<FieldHandle, Field_Release> city;
+    ASSERT_EQ(Field_GetChild(address, 1, city.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(FieldTree_RemoveChild(sample.tree, city), VANILLAPDF_ERROR_SUCCESS);
+
+    HandleGuard<FieldHandle, Field_Release> street;
+    ASSERT_EQ(Field_GetChild(address, 0, street.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(FieldTree_RemoveChild(sample.tree, street), VANILLAPDF_ERROR_SUCCESS);
+
+    // The emptied group is still a top-level field, now enumerated as a
+    // widget-less terminal until it receives a child again
+    ASSERT_EQ(GetRootChildCount(sample.tree), 2u);
+    EXPECT_EQ(GetRootChildQualifiedName(sample.tree, 0), "address");
+    EXPECT_EQ(GetChildCount(address), 0u);
+    ASSERT_EQ(GetFieldCount(sample.tree), 2u);
+    EXPECT_EQ(GetFieldQualifiedName(sample.tree, 0), "address");
+
+    // Rebuild the group and remove it as a whole
+    HandleGuard<DictionaryObjectHandle, DictionaryObject_Release> zip_dictionary;
+    HandleGuard<FieldHandle, Field_Release> zip;
+    CreateTextFieldDictionary(sample.file, "zip", zip_dictionary, zip);
+    ASSERT_EQ(FieldTree_AddChild(sample.tree, address, zip), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(GetFieldQualifiedName(sample.tree, 0), "address.zip");
+
+    ASSERT_EQ(FieldTree_RemoveChild(sample.tree, address), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(GetRootChildCount(sample.tree), 1u);
+    ASSERT_EQ(GetFieldCount(sample.tree), 1u);
+    EXPECT_EQ(GetFieldQualifiedName(sample.tree, 0), "email");
+
+    HandleGuard<FieldHandle, Field_Release> gone;
+    EXPECT_EQ(FindFieldByName(sample.tree, "address.zip", gone.out()), VANILLAPDF_ERROR_OBJECT_MISSING);
+}
+
+// The walk is the authority for where a field lives, not its /Parent entry
+// - a missing or mismatched one is the common way a file is already dirty,
+// and navigating by it would remove from the wrong array or none at all
+TEST(FieldTree, RemoveChildNavigatesByTheWalkNotByParent) {
+    SampleHierarchy sample;
+    BuildSampleHierarchy(sample);
+
+    // street loses its /Parent, city's /Parent points at the wrong node
+    RemoveEntry(sample.street, "Parent");
+    RemoveEntry(sample.city, "Parent");
+    InsertParentEntry(sample.city, sample.email);
+    ASSERT_EQ(FieldTree_Invalidate(sample.tree), VANILLAPDF_ERROR_SUCCESS);
+
+    HandleGuard<FieldHandle, Field_Release> address;
+    ASSERT_EQ(FieldTree_GetRootChild(sample.tree, 0, address.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(GetChildCount(address), 2u);
+
+    HandleGuard<FieldHandle, Field_Release> street;
+    ASSERT_EQ(Field_GetChild(address, 0, street.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(FieldTree_RemoveChild(sample.tree, street), VANILLAPDF_ERROR_SUCCESS);
+
+    ASSERT_EQ(GetChildCount(address), 1u);
+    EXPECT_EQ(GetRootChildCount(sample.tree), 2u);
+
+    HandleGuard<FieldHandle, Field_Release> city;
+    ASSERT_EQ(Field_GetChild(address, 0, city.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(FieldTree_RemoveChild(sample.tree, city), VANILLAPDF_ERROR_SUCCESS);
+
+    // Both left the group's /Kids; the wrong /Parent target was not touched
+    EXPECT_EQ(GetChildCount(address), 0u);
+    EXPECT_EQ(GetRootChildCount(sample.tree), 2u);
+
+    HandleGuard<FieldHandle, Field_Release> email;
+    ASSERT_EQ(FieldTree_GetRootChild(sample.tree, 1, email.out()), VANILLAPDF_ERROR_SUCCESS);
+    EXPECT_EQ(GetChildCount(email), 0u);
+
+    HandleGuard<FieldHandle, Field_Release> city_parent;
+    EXPECT_EQ(Field_GetParent(city, city_parent.out()), VANILLAPDF_ERROR_OBJECT_MISSING);
+}
+
+// --- Invalidate ---
+
+// The tree cannot observe edits made underneath it through the dictionary
+// API; Invalidate is the contract for that path
+TEST(FieldTree, InvalidateAfterRawEdit) {
+    SampleHierarchy sample;
+    BuildSampleHierarchy(sample);
+
+    ASSERT_EQ(GetFieldCount(sample.tree), 3u);
+
+    // Drop the /Fields entry for the email field behind the tree's back,
+    // through the form dictionary itself
+    HandleGuard<NameObjectHandle, NameObject_Release> fields_key;
+    ASSERT_EQ(NameObject_CreateFromDecodedString("Fields", fields_key.out()), VANILLAPDF_ERROR_SUCCESS);
+
+    HandleGuard<ObjectHandle, Object_Release> fields_object;
+    ASSERT_EQ(DictionaryObject_Find(sample.form_dictionary, fields_key, fields_object.out()), VANILLAPDF_ERROR_SUCCESS);
+
+    HandleGuard<ArrayObjectHandle, ArrayObject_Release> fields_array;
+    ASSERT_EQ(ArrayObject_FromObject(fields_object, fields_array.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(ArrayObject_Remove(fields_array, 1), VANILLAPDF_ERROR_SUCCESS);
+
+    // Stale until told otherwise
+    EXPECT_EQ(GetFieldCount(sample.tree), 3u);
+
+    ASSERT_EQ(FieldTree_Invalidate(sample.tree), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(GetFieldCount(sample.tree), 2u);
+    EXPECT_EQ(GetFieldQualifiedName(sample.tree, 1), "address.city");
+}
+
+// --- Attachment ---
+
+// A hierarchy created for a document is usable right away and can be
+// populated before a form adopts it; once attached, the caller's handle is
+// the form's hierarchy
+TEST(FieldTree, CreatedTreeIsUsableBeforeAttachment) {
+    HandleGuard<InputOutputStreamHandle, InputOutputStream_Release> io_stream;
+    HandleGuard<FileHandle, File_Release> file;
+    HandleGuard<DocumentHandle, Document_Release> document;
+    CreateMemoryDocument(io_stream, file, document);
+
+    HandleGuard<FieldTreeHandle, FieldTree_Release> tree;
+    ASSERT_EQ(FieldTree_CreateFromDocument(document, tree.out()), VANILLAPDF_ERROR_SUCCESS);
+    EXPECT_EQ(GetFieldCount(tree), 0u);
+    EXPECT_EQ(GetRootChildCount(tree), 0u);
+
+    HandleGuard<DictionaryObjectHandle, DictionaryObject_Release> field_dictionary;
+    HandleGuard<FieldHandle, Field_Release> field;
+    CreateTextFieldDictionary(file, "email", field_dictionary, field);
+    ASSERT_EQ(FieldTree_AddRootChild(tree, field), VANILLAPDF_ERROR_SUCCESS);
+    EXPECT_EQ(GetFieldCount(tree), 1u);
+    EXPECT_EQ(GetRootChildCount(tree), 1u);
+
+    HandleGuard<InteractiveFormHandle, InteractiveForm_Release> form;
+    ASSERT_EQ(InteractiveForm_CreateFromDocument(document, form.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(InteractiveForm_SetFieldTree(form, tree), VANILLAPDF_ERROR_SUCCESS);
+
+    HandleGuard<FieldTreeHandle, FieldTree_Release> form_tree;
+    ASSERT_EQ(InteractiveForm_GetFieldTree(form, form_tree.out()), VANILLAPDF_ERROR_SUCCESS);
+    EXPECT_EQ(form_tree.get(), tree.get());
+    EXPECT_EQ(GetFieldCount(form_tree), 1u);
+}
+
+// --- Persistence ---
+
+// A hierarchy authored through the tree survives a save and reopen cycle
+// with its structure, names and /Parent links intact
+TEST(FieldTree, AuthoredHierarchyPersistsAcrossSave) {
+    HandleGuard<InputOutputStreamHandle, InputOutputStream_Release> io_stream;
+    HandleGuard<FileHandle, File_Release> file;
+    HandleGuard<DocumentHandle, Document_Release> document;
+    CreateMemoryDocument(io_stream, file, document);
+
+    HandleGuard<InteractiveFormHandle, InteractiveForm_Release> form;
+    ASSERT_EQ(InteractiveForm_CreateFromDocument(document, form.out()), VANILLAPDF_ERROR_SUCCESS);
+
+    HandleGuard<CatalogHandle, Catalog_Release> catalog;
+    ASSERT_EQ(Document_GetCatalog(document, catalog.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Catalog_SetAcroForm(catalog, form), VANILLAPDF_ERROR_SUCCESS);
+
+    HandleGuard<FieldTreeHandle, FieldTree_Release> tree;
+    ASSERT_EQ(FieldTree_CreateFromDocument(document, tree.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(InteractiveForm_SetFieldTree(form, tree), VANILLAPDF_ERROR_SUCCESS);
+
+    // A group is a field with a name and no type of its own
+    HandleGuard<DictionaryObjectHandle, DictionaryObject_Release> address_dictionary;
+    ASSERT_EQ(DictionaryObject_Create(address_dictionary.out()), VANILLAPDF_ERROR_SUCCESS);
+    InsertStringEntry(address_dictionary, "T", "address");
+    RegisterIndirectObject(file, address_dictionary);
+
+    HandleGuard<FieldHandle, Field_Release> address;
+    ASSERT_EQ(Field_CreateFromDictionary(address_dictionary, address.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(FieldTree_AddRootChild(tree, address), VANILLAPDF_ERROR_SUCCESS);
+
+    HandleGuard<DictionaryObjectHandle, DictionaryObject_Release> street_dictionary;
+    HandleGuard<FieldHandle, Field_Release> street;
+    CreateTextFieldDictionary(file, "street", street_dictionary, street);
+    ASSERT_EQ(FieldTree_AddChild(tree, address, street), VANILLAPDF_ERROR_SUCCESS);
+
+    HandleGuard<DictionaryObjectHandle, DictionaryObject_Release> email_dictionary;
+    HandleGuard<FieldHandle, Field_Release> email;
+    CreateTextFieldDictionary(file, "email", email_dictionary, email);
+    ASSERT_EQ(FieldTree_AddRootChild(tree, email), VANILLAPDF_ERROR_SUCCESS);
+
+    HandleGuard<InputOutputStreamHandle, InputOutputStream_Release> destination_stream;
+    HandleGuard<FileHandle, File_Release> destination_file;
+    ASSERT_EQ(InputOutputStream_CreateFromMemory(destination_stream.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(File_CreateStream(destination_stream, "temp_destination", destination_file.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Document_SaveFile(document, destination_file), VANILLAPDF_ERROR_SUCCESS);
+
+    HandleGuard<FileHandle, File_Release> reloaded_file;
+    HandleGuard<DocumentHandle, Document_Release> reloaded_document;
+    HandleGuard<CatalogHandle, Catalog_Release> reloaded_catalog;
+    ASSERT_EQ(File_OpenStream(destination_stream, "temp_destination", reloaded_file.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(File_Initialize(reloaded_file), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Document_OpenFile(reloaded_file, reloaded_document.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Document_GetCatalog(reloaded_document, reloaded_catalog.out()), VANILLAPDF_ERROR_SUCCESS);
+
+    HandleGuard<InteractiveFormHandle, InteractiveForm_Release> reloaded_form;
+    ASSERT_EQ(Catalog_GetAcroForm(reloaded_catalog, reloaded_form.out()), VANILLAPDF_ERROR_SUCCESS);
+
+    HandleGuard<FieldTreeHandle, FieldTree_Release> reloaded_tree;
+    ASSERT_EQ(InteractiveForm_GetFieldTree(reloaded_form, reloaded_tree.out()), VANILLAPDF_ERROR_SUCCESS);
+
+    ASSERT_EQ(GetFieldCount(reloaded_tree), 2u);
+    EXPECT_EQ(GetFieldQualifiedName(reloaded_tree, 0), "address.street");
+    EXPECT_EQ(GetFieldQualifiedName(reloaded_tree, 1), "email");
+
+    ASSERT_EQ(GetRootChildCount(reloaded_tree), 2u);
+    EXPECT_EQ(GetRootChildQualifiedName(reloaded_tree, 0), "address");
+    EXPECT_EQ(GetRootChildQualifiedName(reloaded_tree, 1), "email");
+
+    HandleGuard<FieldHandle, Field_Release> reloaded_street;
+    ASSERT_EQ(FindFieldByName(reloaded_tree, "address.street", reloaded_street.out()), VANILLAPDF_ERROR_SUCCESS);
+
+    HandleGuard<FieldHandle, Field_Release> reloaded_street_parent;
+    ASSERT_EQ(Field_GetParent(reloaded_street, reloaded_street_parent.out()), VANILLAPDF_ERROR_SUCCESS);
+    EXPECT_EQ(GetQualifiedName(reloaded_street_parent), "address");
+}
+
+} // namespace field_tree

--- a/src/vanillapdf.unittest/field_tree_test.cpp
+++ b/src/vanillapdf.unittest/field_tree_test.cpp
@@ -712,6 +712,73 @@ TEST(FieldTree, AddChildRefusals) {
     EXPECT_EQ(GetFieldQualifiedName(sample.tree, 5), "merged");
 }
 
+// A child that brings a subtree is judged as a whole - the names its
+// nodes will take and their membership - not by its own /T alone
+TEST(FieldTree, AddChildValidatesTheWholeSubtree) {
+    SampleHierarchy sample;
+    BuildSampleHierarchy(sample);
+
+    // A nameless group whose kid would be named "email" at the root level
+    HandleGuard<DictionaryObjectHandle, DictionaryObject_Release> nameless;
+    ASSERT_EQ(DictionaryObject_Create(nameless.out()), VANILLAPDF_ERROR_SUCCESS);
+    RegisterIndirectObject(sample.file, nameless);
+
+    HandleGuard<DictionaryObjectHandle, DictionaryObject_Release> nested_email_dictionary;
+    HandleGuard<FieldHandle, Field_Release> nested_email;
+    CreateTextFieldDictionary(sample.file, "email", nested_email_dictionary, nested_email);
+    InsertParentEntry(nested_email_dictionary, nameless);
+    InsertReferenceArrayEntry(nameless, "Kids", { nested_email_dictionary.get() });
+
+    HandleGuard<FieldHandle, Field_Release> nameless_field;
+    ASSERT_EQ(Field_CreateFromDictionary(nameless, nameless_field.out()), VANILLAPDF_ERROR_SUCCESS);
+    EXPECT_EQ(FieldTree_AddRootChild(sample.tree, nameless_field), VANILLAPDF_ERROR_PARAMETER_VALUE);
+
+    // Under a group the same subtree is named "address.email" and is free
+    HandleGuard<FieldHandle, Field_Release> address;
+    ASSERT_EQ(FieldTree_GetRootChild(sample.tree, 0, address.out()), VANILLAPDF_ERROR_SUCCESS);
+    EXPECT_EQ(FieldTree_AddChild(sample.tree, address, nameless_field), VANILLAPDF_ERROR_SUCCESS);
+
+    HandleGuard<FieldHandle, Field_Release> found;
+    EXPECT_EQ(FindFieldByName(sample.tree, "address.email", found.out()), VANILLAPDF_ERROR_SUCCESS);
+
+    // A group whose kid is already a member of the hierarchy
+    HandleGuard<DictionaryObjectHandle, DictionaryObject_Release> thief;
+    ASSERT_EQ(DictionaryObject_Create(thief.out()), VANILLAPDF_ERROR_SUCCESS);
+    InsertStringEntry(thief, "T", "thief");
+    RegisterIndirectObject(sample.file, thief);
+    InsertReferenceArrayEntry(thief, "Kids", { sample.street.get() });
+
+    HandleGuard<FieldHandle, Field_Release> thief_field;
+    ASSERT_EQ(Field_CreateFromDictionary(thief, thief_field.out()), VANILLAPDF_ERROR_SUCCESS);
+    EXPECT_EQ(FieldTree_AddRootChild(sample.tree, thief_field), VANILLAPDF_ERROR_PARAMETER_VALUE);
+
+    // A group whose two kids would take the same name
+    HandleGuard<DictionaryObjectHandle, DictionaryObject_Release> twins;
+    ASSERT_EQ(DictionaryObject_Create(twins.out()), VANILLAPDF_ERROR_SUCCESS);
+    InsertStringEntry(twins, "T", "twins");
+    RegisterIndirectObject(sample.file, twins);
+
+    HandleGuard<DictionaryObjectHandle, DictionaryObject_Release> first_twin_dictionary;
+    HandleGuard<FieldHandle, Field_Release> first_twin;
+    CreateTextFieldDictionary(sample.file, "twin", first_twin_dictionary, first_twin);
+    InsertParentEntry(first_twin_dictionary, twins);
+
+    HandleGuard<DictionaryObjectHandle, DictionaryObject_Release> second_twin_dictionary;
+    HandleGuard<FieldHandle, Field_Release> second_twin;
+    CreateTextFieldDictionary(sample.file, "twin", second_twin_dictionary, second_twin);
+    InsertParentEntry(second_twin_dictionary, twins);
+    InsertReferenceArrayEntry(twins, "Kids", { first_twin_dictionary.get(), second_twin_dictionary.get() });
+
+    HandleGuard<FieldHandle, Field_Release> twins_field;
+    ASSERT_EQ(Field_CreateFromDictionary(twins, twins_field.out()), VANILLAPDF_ERROR_SUCCESS);
+    EXPECT_EQ(FieldTree_AddRootChild(sample.tree, twins_field), VANILLAPDF_ERROR_PARAMETER_VALUE);
+
+    // Nothing but the accepted addition made it in
+    ASSERT_EQ(GetRootChildCount(sample.tree), 2u);
+    ASSERT_EQ(GetFieldCount(sample.tree), 4u);
+    EXPECT_EQ(GetFieldQualifiedName(sample.tree, 2), "address.email");
+}
+
 // --- InsertChild ---
 
 // The index is a position among the container's entries; the end appends

--- a/src/vanillapdf.unittest/interactive_forms_test.cpp
+++ b/src/vanillapdf.unittest/interactive_forms_test.cpp
@@ -107,65 +107,6 @@ TEST(InteractiveForm, CreateRejectsNullParameters) {
     EXPECT_EQ(InteractiveForm_CreateFromDictionary(nullptr, nullptr), VANILLAPDF_ERROR_PARAMETER_VALUE);
 }
 
-// A blank form has no /Fields entry at all
-TEST(InteractiveForm, GetFieldsMissing) {
-    HandleGuard<InputOutputStreamHandle, InputOutputStream_Release> io_stream;
-    HandleGuard<FileHandle, File_Release> file;
-    HandleGuard<DocumentHandle, Document_Release> document;
-    HandleGuard<InteractiveFormHandle, InteractiveForm_Release> form;
-    CreateMemoryDocumentWithForm(io_stream, file, document, form);
-
-    FieldCollectionHandle* fields = nullptr;
-    EXPECT_EQ(InteractiveForm_GetFields(form, &fields), VANILLAPDF_ERROR_OBJECT_MISSING);
-    EXPECT_EQ(fields, nullptr);
-}
-
-// SetFields inserts the /Fields array, which GetFields then finds
-TEST(InteractiveForm, SetFieldsThenGetFields) {
-    HandleGuard<InputOutputStreamHandle, InputOutputStream_Release> io_stream;
-    HandleGuard<FileHandle, File_Release> file;
-    HandleGuard<DocumentHandle, Document_Release> document;
-    HandleGuard<InteractiveFormHandle, InteractiveForm_Release> form;
-    CreateMemoryDocumentWithForm(io_stream, file, document, form);
-
-    HandleGuard<FieldCollectionHandle, FieldCollection_Release> created_fields;
-    ASSERT_EQ(FieldCollection_Create(created_fields.out()), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(InteractiveForm_SetFields(form, created_fields), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_NE(created_fields.get(), nullptr);
-
-    size_type size = 1;
-    ASSERT_EQ(FieldCollection_GetSize(created_fields, &size), VANILLAPDF_ERROR_SUCCESS);
-    EXPECT_EQ(size, 0u);
-
-    HandleGuard<FieldCollectionHandle, FieldCollection_Release> found_fields;
-    ASSERT_EQ(InteractiveForm_GetFields(form, found_fields.out()), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_NE(found_fields.get(), nullptr);
-}
-
-// Setting fields twice must replace the previous array rather than throw
-TEST(InteractiveForm, SetFieldsOverwrite) {
-    HandleGuard<InputOutputStreamHandle, InputOutputStream_Release> io_stream;
-    HandleGuard<FileHandle, File_Release> file;
-    HandleGuard<DocumentHandle, Document_Release> document;
-    HandleGuard<InteractiveFormHandle, InteractiveForm_Release> form;
-    CreateMemoryDocumentWithForm(io_stream, file, document, form);
-
-    HandleGuard<FieldCollectionHandle, FieldCollection_Release> first;
-    HandleGuard<FieldCollectionHandle, FieldCollection_Release> second;
-    ASSERT_EQ(FieldCollection_Create(first.out()), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(FieldCollection_Create(second.out()), VANILLAPDF_ERROR_SUCCESS);
-
-    ASSERT_EQ(InteractiveForm_SetFields(form, first), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(InteractiveForm_SetFields(form, second), VANILLAPDF_ERROR_SUCCESS);
-
-    HandleGuard<FieldCollectionHandle, FieldCollection_Release> found;
-    ASSERT_EQ(InteractiveForm_GetFields(form, found.out()), VANILLAPDF_ERROR_SUCCESS);
-
-    size_type size = 1;
-    ASSERT_EQ(FieldCollection_GetSize(found, &size), VANILLAPDF_ERROR_SUCCESS);
-    EXPECT_EQ(size, 0u);
-}
-
 TEST(InteractiveForm, NeedAppearancesMissingOnBlankForm) {
     HandleGuard<InputOutputStreamHandle, InputOutputStream_Release> io_stream;
     HandleGuard<FileHandle, File_Release> file;
@@ -706,9 +647,9 @@ TEST(InteractiveForm, FindFieldByQualifiedName) {
     EXPECT_EQ(InteractiveForm_FindField(form, "group.missing", missing.out()), VANILLAPDF_ERROR_OBJECT_MISSING);
 }
 
-// Replacing the /Fields array through SetFields must be reflected by the
-// enumeration built before the change
-TEST(InteractiveForm, FieldCacheInvalidatedOnSetFields) {
+// Appending a field through AddField must be reflected by the enumeration
+// built before the change
+TEST(InteractiveForm, FieldCacheInvalidatedOnAddField) {
     HandleGuard<InputOutputStreamHandle, InputOutputStream_Release> io_stream;
     HandleGuard<FileHandle, File_Release> file;
     HandleGuard<DocumentHandle, Document_Release> document;
@@ -731,12 +672,127 @@ TEST(InteractiveForm, FieldCacheInvalidatedOnSetFields) {
     ASSERT_EQ(InteractiveForm_GetFieldCount(form, &count), VANILLAPDF_ERROR_SUCCESS);
     ASSERT_EQ(count, 1u);
 
-    HandleGuard<FieldCollectionHandle, FieldCollection_Release> empty_fields;
-    ASSERT_EQ(FieldCollection_Create(empty_fields.out()), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(InteractiveForm_SetFields(form, empty_fields), VANILLAPDF_ERROR_SUCCESS);
+    HandleGuard<DictionaryObjectHandle, DictionaryObject_Release> appended;
+    ASSERT_EQ(DictionaryObject_Create(appended.out()), VANILLAPDF_ERROR_SUCCESS);
+    InsertStringEntry(appended, "T", "phone");
+    InsertNameEntry(appended, "FT", "Tx");
+    RegisterIndirectObject(file, appended);
+
+    HandleGuard<FieldHandle, Field_Release> appended_field;
+    ASSERT_EQ(Field_CreateFromDictionary(appended, appended_field.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(InteractiveForm_AddField(form, appended_field), VANILLAPDF_ERROR_SUCCESS);
 
     ASSERT_EQ(InteractiveForm_GetFieldCount(form, &count), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(count, 2u);
+
+    // Appending preserves document order
+    EXPECT_EQ(GetFieldQualifiedName(form, 0), "email");
+    EXPECT_EQ(GetFieldQualifiedName(form, 1), "phone");
+}
+
+// AddField creates the /Fields array on a form that does not have one yet
+TEST(InteractiveForm, AddFieldCreatesFieldsArray) {
+    HandleGuard<InputOutputStreamHandle, InputOutputStream_Release> io_stream;
+    HandleGuard<FileHandle, File_Release> file;
+    HandleGuard<DocumentHandle, Document_Release> document;
+    HandleGuard<InteractiveFormHandle, InteractiveForm_Release> form;
+    CreateMemoryDocumentWithForm(io_stream, file, document, form);
+
+    size_type count = 1;
+    ASSERT_EQ(InteractiveForm_GetFieldCount(form, &count), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(count, 0u);
+
+    HandleGuard<DictionaryObjectHandle, DictionaryObject_Release> field_dictionary;
+    ASSERT_EQ(DictionaryObject_Create(field_dictionary.out()), VANILLAPDF_ERROR_SUCCESS);
+    InsertStringEntry(field_dictionary, "T", "email");
+    InsertNameEntry(field_dictionary, "FT", "Tx");
+    RegisterIndirectObject(file, field_dictionary);
+
+    HandleGuard<FieldHandle, Field_Release> field;
+    ASSERT_EQ(Field_CreateFromDictionary(field_dictionary, field.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(InteractiveForm_AddField(form, field), VANILLAPDF_ERROR_SUCCESS);
+
+    ASSERT_EQ(InteractiveForm_GetFieldCount(form, &count), VANILLAPDF_ERROR_SUCCESS);
+    EXPECT_EQ(count, 1u);
+
+    HandleGuard<FieldHandle, Field_Release> found;
+    EXPECT_EQ(InteractiveForm_FindField(form, "email", found.out()), VANILLAPDF_ERROR_SUCCESS);
+}
+
+// The /Fields array holds indirect references, so a field backed by a direct
+// dictionary is refused instead of serializing a dangling reference
+TEST(InteractiveForm, AddFieldRejectsDirectDictionary) {
+    HandleGuard<InputOutputStreamHandle, InputOutputStream_Release> io_stream;
+    HandleGuard<FileHandle, File_Release> file;
+    HandleGuard<DocumentHandle, Document_Release> document;
+    HandleGuard<InteractiveFormHandle, InteractiveForm_Release> form;
+    CreateMemoryDocumentWithForm(io_stream, file, document, form);
+
+    HandleGuard<DictionaryObjectHandle, DictionaryObject_Release> field_dictionary;
+    ASSERT_EQ(DictionaryObject_Create(field_dictionary.out()), VANILLAPDF_ERROR_SUCCESS);
+    InsertStringEntry(field_dictionary, "T", "email");
+    InsertNameEntry(field_dictionary, "FT", "Tx");
+
+    HandleGuard<FieldHandle, Field_Release> field;
+    ASSERT_EQ(Field_CreateFromDictionary(field_dictionary, field.out()), VANILLAPDF_ERROR_SUCCESS);
+    EXPECT_EQ(InteractiveForm_AddField(form, field), VANILLAPDF_ERROR_PARAMETER_VALUE);
+
+    // The refused append must not leave a half-created /Fields array behind
+    size_type count = 1;
+    ASSERT_EQ(InteractiveForm_GetFieldCount(form, &count), VANILLAPDF_ERROR_SUCCESS);
     EXPECT_EQ(count, 0u);
+}
+
+TEST(InteractiveForm, AddFieldRejectsNullParameters) {
+    HandleGuard<InputOutputStreamHandle, InputOutputStream_Release> io_stream;
+    HandleGuard<FileHandle, File_Release> file;
+    HandleGuard<DocumentHandle, Document_Release> document;
+    HandleGuard<InteractiveFormHandle, InteractiveForm_Release> form;
+    CreateMemoryDocumentWithForm(io_stream, file, document, form);
+
+    EXPECT_EQ(InteractiveForm_AddField(nullptr, nullptr), VANILLAPDF_ERROR_PARAMETER_VALUE);
+    EXPECT_EQ(InteractiveForm_AddField(form, nullptr), VANILLAPDF_ERROR_PARAMETER_VALUE);
+}
+
+// The appended reference has to survive a save and reopen cycle
+TEST(InteractiveForm, AddedFieldPersistsAcrossSave) {
+    HandleGuard<InputOutputStreamHandle, InputOutputStream_Release> io_stream;
+    HandleGuard<FileHandle, File_Release> file;
+    HandleGuard<DocumentHandle, Document_Release> document;
+    HandleGuard<InteractiveFormHandle, InteractiveForm_Release> form;
+    CreateMemoryDocumentWithForm(io_stream, file, document, form);
+
+    HandleGuard<DictionaryObjectHandle, DictionaryObject_Release> field_dictionary;
+    ASSERT_EQ(DictionaryObject_Create(field_dictionary.out()), VANILLAPDF_ERROR_SUCCESS);
+    InsertStringEntry(field_dictionary, "T", "email");
+    InsertNameEntry(field_dictionary, "FT", "Tx");
+    RegisterIndirectObject(file, field_dictionary);
+
+    HandleGuard<FieldHandle, Field_Release> field;
+    ASSERT_EQ(Field_CreateFromDictionary(field_dictionary, field.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(InteractiveForm_AddField(form, field), VANILLAPDF_ERROR_SUCCESS);
+
+    HandleGuard<InputOutputStreamHandle, InputOutputStream_Release> destination_stream;
+    HandleGuard<FileHandle, File_Release> destination_file;
+    ASSERT_EQ(InputOutputStream_CreateFromMemory(destination_stream.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(File_CreateStream(destination_stream, "temp_destination", destination_file.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Document_SaveFile(document, destination_file), VANILLAPDF_ERROR_SUCCESS);
+
+    HandleGuard<FileHandle, File_Release> reloaded_file;
+    HandleGuard<DocumentHandle, Document_Release> reloaded_document;
+    HandleGuard<CatalogHandle, Catalog_Release> reloaded_catalog;
+    ASSERT_EQ(File_OpenStream(destination_stream, "temp_destination", reloaded_file.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(File_Initialize(reloaded_file), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Document_OpenFile(reloaded_file, reloaded_document.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Document_GetCatalog(reloaded_document, reloaded_catalog.out()), VANILLAPDF_ERROR_SUCCESS);
+
+    HandleGuard<InteractiveFormHandle, InteractiveForm_Release> reloaded_form;
+    ASSERT_EQ(Catalog_GetAcroForm(reloaded_catalog, reloaded_form.out()), VANILLAPDF_ERROR_SUCCESS);
+
+    size_type count = 0;
+    ASSERT_EQ(InteractiveForm_GetFieldCount(reloaded_form, &count), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(count, 1u);
+    EXPECT_EQ(GetFieldQualifiedName(reloaded_form, 0), "email");
 }
 
 // Malformed documents can link /Kids in a cycle; the enumeration has to

--- a/src/vanillapdf.unittest/interactive_forms_test.cpp
+++ b/src/vanillapdf.unittest/interactive_forms_test.cpp
@@ -1,6 +1,8 @@
 #include "unittest.h"
 #include "handle_guard.h"
 
+#include <cstring>
+
 namespace interactive_forms {
 
 // Creates an in-memory document together with an attached interactive form.
@@ -425,10 +427,15 @@ static std::string BufferToString(BufferHandle* buffer) {
     return std::string(data, size);
 }
 
-// Reads the qualified name of the terminal field at the given index
-static std::string GetFieldQualifiedName(InteractiveFormHandle* form, size_type index) {
+// Looks a terminal field up by its fully qualified name given as a literal
+static error_type FindFieldByName(FieldTreeHandle* tree, const char* qualified_name, FieldHandle** result) {
+    return FieldTree_FindField(tree, qualified_name, static_cast<size_type>(strlen(qualified_name)), result);
+}
+
+// Reads the fully qualified name of the terminal field at the given index
+static std::string GetFieldQualifiedName(FieldTreeHandle* tree, size_type index) {
     HandleGuard<FieldHandle, Field_Release> field;
-    EXPECT_EQ(InteractiveForm_GetField(form, index, field.out()), VANILLAPDF_ERROR_SUCCESS);
+    EXPECT_EQ(FieldTree_GetField(tree, index, field.out()), VANILLAPDF_ERROR_SUCCESS);
 
     HandleGuard<BufferHandle, Buffer_Release> qualified_name;
     EXPECT_EQ(Field_GetQualifiedName(field, qualified_name.out()), VANILLAPDF_ERROR_SUCCESS);
@@ -444,6 +451,40 @@ static void CreateStringObject(
     HandleGuard<LiteralStringObjectHandle, LiteralStringObject_Release> literal;
     ASSERT_EQ(LiteralStringObject_CreateFromDecodedString(value, literal.out()), VANILLAPDF_ERROR_SUCCESS);
     ASSERT_EQ(LiteralStringObject_ToStringObject(literal, result.out()), VANILLAPDF_ERROR_SUCCESS);
+}
+
+// Wraps a form dictionary and obtains its field hierarchy
+static void CreateFormWithTree(
+    DictionaryObjectHandle* form_dictionary,
+    HandleGuard<InteractiveFormHandle, InteractiveForm_Release>& form,
+    HandleGuard<FieldTreeHandle, FieldTree_Release>& tree
+) {
+    ASSERT_EQ(InteractiveForm_CreateFromDictionary(form_dictionary, form.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(InteractiveForm_GetFieldTree(form, tree.out()), VANILLAPDF_ERROR_SUCCESS);
+}
+
+// Gives a blank form an empty hierarchy, the way a document author starts
+static void AttachEmptyTree(
+    DocumentHandle* document,
+    InteractiveFormHandle* form,
+    HandleGuard<FieldTreeHandle, FieldTree_Release>& tree
+) {
+    ASSERT_EQ(FieldTree_CreateFromDocument(document, tree.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(InteractiveForm_SetFieldTree(form, tree), VANILLAPDF_ERROR_SUCCESS);
+}
+
+// Creates a registered terminal text field dictionary with the given name
+static void CreateTextFieldDictionary(
+    FileHandle* file,
+    const char* partial_name,
+    HandleGuard<DictionaryObjectHandle, DictionaryObject_Release>& dictionary,
+    HandleGuard<FieldHandle, Field_Release>& field
+) {
+    ASSERT_EQ(DictionaryObject_Create(dictionary.out()), VANILLAPDF_ERROR_SUCCESS);
+    InsertStringEntry(dictionary, "T", partial_name);
+    InsertNameEntry(dictionary, "FT", "Tx");
+    RegisterIndirectObject(file, dictionary);
+    ASSERT_EQ(Field_CreateFromDictionary(dictionary, field.out()), VANILLAPDF_ERROR_SUCCESS);
 }
 
 // Document-wide defaults for /DA and /Q roundtrip through the form setters
@@ -471,21 +512,38 @@ TEST(InteractiveForm, SetAndGetDocumentDefaults) {
     EXPECT_EQ(quadding, QuaddingType_Centered);
 }
 
-// A blank form has no fields to enumerate
-TEST(InteractiveForm, FieldCountZeroWithoutFields) {
+// A blank form has no /Fields entry - reading it never creates one, so
+// there is no hierarchy to hand out until one is attached
+TEST(InteractiveForm, FieldTreeMissingOnBlankForm) {
     HandleGuard<InputOutputStreamHandle, InputOutputStream_Release> io_stream;
     HandleGuard<FileHandle, File_Release> file;
     HandleGuard<DocumentHandle, Document_Release> document;
     HandleGuard<InteractiveFormHandle, InteractiveForm_Release> form;
     CreateMemoryDocumentWithForm(io_stream, file, document, form);
 
+    FieldTreeHandle* missing_tree = nullptr;
+    EXPECT_EQ(InteractiveForm_GetFieldTree(form, &missing_tree), VANILLAPDF_ERROR_OBJECT_MISSING);
+    EXPECT_EQ(missing_tree, nullptr);
+
+    HandleGuard<FieldTreeHandle, FieldTree_Release> tree;
+    AttachEmptyTree(document, form, tree);
+
     size_type count = 1;
-    ASSERT_EQ(InteractiveForm_GetFieldCount(form, &count), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(FieldTree_GetFieldCount(tree, &count), VANILLAPDF_ERROR_SUCCESS);
+    EXPECT_EQ(count, 0u);
+
+    ASSERT_EQ(FieldTree_GetRootChildCount(tree, &count), VANILLAPDF_ERROR_SUCCESS);
     EXPECT_EQ(count, 0u);
 
     HandleGuard<FieldHandle, Field_Release> field;
-    EXPECT_EQ(InteractiveForm_GetField(form, 0, field.out()), VANILLAPDF_ERROR_OBJECT_MISSING);
-    EXPECT_EQ(InteractiveForm_FindField(form, "missing", field.out()), VANILLAPDF_ERROR_OBJECT_MISSING);
+    EXPECT_EQ(FieldTree_GetField(tree, 0, field.out()), VANILLAPDF_ERROR_OBJECT_MISSING);
+    EXPECT_EQ(FieldTree_GetRootChild(tree, 0, field.out()), VANILLAPDF_ERROR_OBJECT_MISSING);
+    EXPECT_EQ(FindFieldByName(tree, "missing", field.out()), VANILLAPDF_ERROR_OBJECT_MISSING);
+
+    // The attached instance is the one the form hands out from now on
+    HandleGuard<FieldTreeHandle, FieldTree_Release> found_tree;
+    ASSERT_EQ(InteractiveForm_GetFieldTree(form, found_tree.out()), VANILLAPDF_ERROR_SUCCESS);
+    EXPECT_EQ(found_tree.get(), tree.get());
 }
 
 // The enumeration hides grouping nodes and yields the logical terminal
@@ -528,19 +586,20 @@ TEST(InteractiveForm, FlatEnumerationSkipsNonTerminals) {
     InsertReferenceArrayEntry(form_dictionary, "Fields", { group.get(), standalone.get() });
 
     HandleGuard<InteractiveFormHandle, InteractiveForm_Release> form;
-    ASSERT_EQ(InteractiveForm_CreateFromDictionary(form_dictionary, form.out()), VANILLAPDF_ERROR_SUCCESS);
+    HandleGuard<FieldTreeHandle, FieldTree_Release> tree;
+    CreateFormWithTree(form_dictionary, form, tree);
 
     size_type count = 0;
-    ASSERT_EQ(InteractiveForm_GetFieldCount(form, &count), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(FieldTree_GetFieldCount(tree, &count), VANILLAPDF_ERROR_SUCCESS);
     ASSERT_EQ(count, 3u);
 
-    EXPECT_EQ(GetFieldQualifiedName(form, 0), "group.first");
-    EXPECT_EQ(GetFieldQualifiedName(form, 1), "group.second");
-    EXPECT_EQ(GetFieldQualifiedName(form, 2), "email");
+    EXPECT_EQ(GetFieldQualifiedName(tree, 0), "group.first");
+    EXPECT_EQ(GetFieldQualifiedName(tree, 1), "group.second");
+    EXPECT_EQ(GetFieldQualifiedName(tree, 2), "email");
 
     // Children carry no /FT of their own - the type resolves from the group
     HandleGuard<FieldHandle, Field_Release> first_field;
-    ASSERT_EQ(InteractiveForm_GetField(form, 0, first_field.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(FieldTree_GetField(tree, 0, first_field.out()), VANILLAPDF_ERROR_SUCCESS);
 
     FieldType first_field_type = FieldType_Undefined;
     ASSERT_EQ(Field_GetType(first_field, &first_field_type), VANILLAPDF_ERROR_SUCCESS);
@@ -584,14 +643,15 @@ TEST(InteractiveForm, RadioGroupIsSingleField) {
     InsertReferenceArrayEntry(form_dictionary, "Fields", { radio_group.get() });
 
     HandleGuard<InteractiveFormHandle, InteractiveForm_Release> form;
-    ASSERT_EQ(InteractiveForm_CreateFromDictionary(form_dictionary, form.out()), VANILLAPDF_ERROR_SUCCESS);
+    HandleGuard<FieldTreeHandle, FieldTree_Release> tree;
+    CreateFormWithTree(form_dictionary, form, tree);
 
     size_type count = 0;
-    ASSERT_EQ(InteractiveForm_GetFieldCount(form, &count), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(FieldTree_GetFieldCount(tree, &count), VANILLAPDF_ERROR_SUCCESS);
     ASSERT_EQ(count, 1u);
 
     HandleGuard<FieldHandle, Field_Release> field;
-    ASSERT_EQ(InteractiveForm_GetField(form, 0, field.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(FieldTree_GetField(tree, 0, field.out()), VANILLAPDF_ERROR_SUCCESS);
 
     FieldType field_type = FieldType_Undefined;
     ASSERT_EQ(Field_GetType(field, &field_type), VANILLAPDF_ERROR_SUCCESS);
@@ -600,6 +660,11 @@ TEST(InteractiveForm, RadioGroupIsSingleField) {
     boolean_type terminal = VANILLAPDF_RV_FALSE;
     ASSERT_EQ(Field_IsTerminal(field, &terminal), VANILLAPDF_ERROR_SUCCESS);
     EXPECT_EQ(terminal, VANILLAPDF_RV_TRUE);
+
+    // The widgets are not children of the field
+    size_type child_count = 1;
+    ASSERT_EQ(Field_GetChildCount(field, &child_count), VANILLAPDF_ERROR_SUCCESS);
+    EXPECT_EQ(child_count, 0u);
 }
 
 TEST(InteractiveForm, FindFieldByQualifiedName) {
@@ -627,10 +692,11 @@ TEST(InteractiveForm, FindFieldByQualifiedName) {
     InsertReferenceArrayEntry(form_dictionary, "Fields", { group.get() });
 
     HandleGuard<InteractiveFormHandle, InteractiveForm_Release> form;
-    ASSERT_EQ(InteractiveForm_CreateFromDictionary(form_dictionary, form.out()), VANILLAPDF_ERROR_SUCCESS);
+    HandleGuard<FieldTreeHandle, FieldTree_Release> tree;
+    CreateFormWithTree(form_dictionary, form, tree);
 
     HandleGuard<FieldHandle, Field_Release> found;
-    ASSERT_EQ(InteractiveForm_FindField(form, "group.first", found.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(FindFieldByName(tree, "group.first", found.out()), VANILLAPDF_ERROR_SUCCESS);
 
     HandleGuard<StringObjectHandle, StringObject_Release> partial_name;
     ASSERT_EQ(Field_GetName(found, partial_name.out()), VANILLAPDF_ERROR_SUCCESS);
@@ -641,15 +707,15 @@ TEST(InteractiveForm, FindFieldByQualifiedName) {
 
     // The grouping node is not part of the enumeration
     HandleGuard<FieldHandle, Field_Release> group_lookup;
-    EXPECT_EQ(InteractiveForm_FindField(form, "group", group_lookup.out()), VANILLAPDF_ERROR_OBJECT_MISSING);
+    EXPECT_EQ(FindFieldByName(tree, "group", group_lookup.out()), VANILLAPDF_ERROR_OBJECT_MISSING);
 
     HandleGuard<FieldHandle, Field_Release> missing;
-    EXPECT_EQ(InteractiveForm_FindField(form, "group.missing", missing.out()), VANILLAPDF_ERROR_OBJECT_MISSING);
+    EXPECT_EQ(FindFieldByName(tree, "group.missing", missing.out()), VANILLAPDF_ERROR_OBJECT_MISSING);
 }
 
-// Appending a field through AddField must be reflected by the enumeration
+// Appending a field through AddChild must be reflected by the enumeration
 // built before the change
-TEST(InteractiveForm, FieldCacheInvalidatedOnAddField) {
+TEST(InteractiveForm, FieldCacheInvalidatedOnAddChild) {
     HandleGuard<InputOutputStreamHandle, InputOutputStream_Release> io_stream;
     HandleGuard<FileHandle, File_Release> file;
     HandleGuard<DocumentHandle, Document_Release> document;
@@ -666,67 +732,62 @@ TEST(InteractiveForm, FieldCacheInvalidatedOnAddField) {
     InsertReferenceArrayEntry(form_dictionary, "Fields", { standalone.get() });
 
     HandleGuard<InteractiveFormHandle, InteractiveForm_Release> form;
-    ASSERT_EQ(InteractiveForm_CreateFromDictionary(form_dictionary, form.out()), VANILLAPDF_ERROR_SUCCESS);
+    HandleGuard<FieldTreeHandle, FieldTree_Release> tree;
+    CreateFormWithTree(form_dictionary, form, tree);
 
     size_type count = 0;
-    ASSERT_EQ(InteractiveForm_GetFieldCount(form, &count), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(FieldTree_GetFieldCount(tree, &count), VANILLAPDF_ERROR_SUCCESS);
     ASSERT_EQ(count, 1u);
 
     HandleGuard<DictionaryObjectHandle, DictionaryObject_Release> appended;
-    ASSERT_EQ(DictionaryObject_Create(appended.out()), VANILLAPDF_ERROR_SUCCESS);
-    InsertStringEntry(appended, "T", "phone");
-    InsertNameEntry(appended, "FT", "Tx");
-    RegisterIndirectObject(file, appended);
-
     HandleGuard<FieldHandle, Field_Release> appended_field;
-    ASSERT_EQ(Field_CreateFromDictionary(appended, appended_field.out()), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(InteractiveForm_AddField(form, appended_field), VANILLAPDF_ERROR_SUCCESS);
+    CreateTextFieldDictionary(file, "phone", appended, appended_field);
 
-    ASSERT_EQ(InteractiveForm_GetFieldCount(form, &count), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(FieldTree_AddRootChild(tree, appended_field), VANILLAPDF_ERROR_SUCCESS);
+
+    ASSERT_EQ(FieldTree_GetFieldCount(tree, &count), VANILLAPDF_ERROR_SUCCESS);
     ASSERT_EQ(count, 2u);
 
     // Appending preserves document order
-    EXPECT_EQ(GetFieldQualifiedName(form, 0), "email");
-    EXPECT_EQ(GetFieldQualifiedName(form, 1), "phone");
+    EXPECT_EQ(GetFieldQualifiedName(tree, 0), "email");
+    EXPECT_EQ(GetFieldQualifiedName(tree, 1), "phone");
 }
 
-// AddField creates the /Fields array on a form that does not have one yet
-TEST(InteractiveForm, AddFieldCreatesFieldsArray) {
+// An empty hierarchy attached to a blank form accepts fields
+TEST(InteractiveForm, AttachedTreeAcceptsFields) {
     HandleGuard<InputOutputStreamHandle, InputOutputStream_Release> io_stream;
     HandleGuard<FileHandle, File_Release> file;
     HandleGuard<DocumentHandle, Document_Release> document;
     HandleGuard<InteractiveFormHandle, InteractiveForm_Release> form;
     CreateMemoryDocumentWithForm(io_stream, file, document, form);
 
-    size_type count = 1;
-    ASSERT_EQ(InteractiveForm_GetFieldCount(form, &count), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(count, 0u);
+    HandleGuard<FieldTreeHandle, FieldTree_Release> tree;
+    AttachEmptyTree(document, form, tree);
 
     HandleGuard<DictionaryObjectHandle, DictionaryObject_Release> field_dictionary;
-    ASSERT_EQ(DictionaryObject_Create(field_dictionary.out()), VANILLAPDF_ERROR_SUCCESS);
-    InsertStringEntry(field_dictionary, "T", "email");
-    InsertNameEntry(field_dictionary, "FT", "Tx");
-    RegisterIndirectObject(file, field_dictionary);
-
     HandleGuard<FieldHandle, Field_Release> field;
-    ASSERT_EQ(Field_CreateFromDictionary(field_dictionary, field.out()), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(InteractiveForm_AddField(form, field), VANILLAPDF_ERROR_SUCCESS);
+    CreateTextFieldDictionary(file, "email", field_dictionary, field);
+    ASSERT_EQ(FieldTree_AddRootChild(tree, field), VANILLAPDF_ERROR_SUCCESS);
 
-    ASSERT_EQ(InteractiveForm_GetFieldCount(form, &count), VANILLAPDF_ERROR_SUCCESS);
+    size_type count = 0;
+    ASSERT_EQ(FieldTree_GetFieldCount(tree, &count), VANILLAPDF_ERROR_SUCCESS);
     EXPECT_EQ(count, 1u);
 
     HandleGuard<FieldHandle, Field_Release> found;
-    EXPECT_EQ(InteractiveForm_FindField(form, "email", found.out()), VANILLAPDF_ERROR_SUCCESS);
+    EXPECT_EQ(FindFieldByName(tree, "email", found.out()), VANILLAPDF_ERROR_SUCCESS);
 }
 
-// The /Fields array holds indirect references, so a field backed by a direct
-// dictionary is refused instead of serializing a dangling reference
-TEST(InteractiveForm, AddFieldRejectsDirectDictionary) {
+// The container arrays hold indirect references, so a field backed by a
+// direct dictionary is refused instead of serializing a dangling reference
+TEST(InteractiveForm, AddRootChildRejectsDirectDictionary) {
     HandleGuard<InputOutputStreamHandle, InputOutputStream_Release> io_stream;
     HandleGuard<FileHandle, File_Release> file;
     HandleGuard<DocumentHandle, Document_Release> document;
     HandleGuard<InteractiveFormHandle, InteractiveForm_Release> form;
     CreateMemoryDocumentWithForm(io_stream, file, document, form);
+
+    HandleGuard<FieldTreeHandle, FieldTree_Release> tree;
+    AttachEmptyTree(document, form, tree);
 
     HandleGuard<DictionaryObjectHandle, DictionaryObject_Release> field_dictionary;
     ASSERT_EQ(DictionaryObject_Create(field_dictionary.out()), VANILLAPDF_ERROR_SUCCESS);
@@ -735,26 +796,65 @@ TEST(InteractiveForm, AddFieldRejectsDirectDictionary) {
 
     HandleGuard<FieldHandle, Field_Release> field;
     ASSERT_EQ(Field_CreateFromDictionary(field_dictionary, field.out()), VANILLAPDF_ERROR_SUCCESS);
-    EXPECT_EQ(InteractiveForm_AddField(form, field), VANILLAPDF_ERROR_PARAMETER_VALUE);
+    EXPECT_EQ(FieldTree_AddRootChild(tree, field), VANILLAPDF_ERROR_PARAMETER_VALUE);
 
-    // The refused append must not leave a half-created /Fields array behind
     size_type count = 1;
-    ASSERT_EQ(InteractiveForm_GetFieldCount(form, &count), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(FieldTree_GetFieldCount(tree, &count), VANILLAPDF_ERROR_SUCCESS);
     EXPECT_EQ(count, 0u);
 }
 
-TEST(InteractiveForm, AddFieldRejectsNullParameters) {
+TEST(InteractiveForm, FieldTreeRejectsNullParameters) {
     HandleGuard<InputOutputStreamHandle, InputOutputStream_Release> io_stream;
     HandleGuard<FileHandle, File_Release> file;
     HandleGuard<DocumentHandle, Document_Release> document;
     HandleGuard<InteractiveFormHandle, InteractiveForm_Release> form;
     CreateMemoryDocumentWithForm(io_stream, file, document, form);
 
-    EXPECT_EQ(InteractiveForm_AddField(nullptr, nullptr), VANILLAPDF_ERROR_PARAMETER_VALUE);
-    EXPECT_EQ(InteractiveForm_AddField(form, nullptr), VANILLAPDF_ERROR_PARAMETER_VALUE);
+    HandleGuard<FieldTreeHandle, FieldTree_Release> tree;
+    AttachEmptyTree(document, form, tree);
+
+    HandleGuard<DictionaryObjectHandle, DictionaryObject_Release> field_dictionary;
+    HandleGuard<FieldHandle, Field_Release> field;
+    CreateTextFieldDictionary(file, "email", field_dictionary, field);
+
+    EXPECT_EQ(InteractiveForm_GetFieldTree(nullptr, nullptr), VANILLAPDF_ERROR_PARAMETER_VALUE);
+    EXPECT_EQ(InteractiveForm_SetFieldTree(nullptr, nullptr), VANILLAPDF_ERROR_PARAMETER_VALUE);
+    EXPECT_EQ(InteractiveForm_SetFieldTree(form, nullptr), VANILLAPDF_ERROR_PARAMETER_VALUE);
+    EXPECT_EQ(InteractiveForm_ResolveDefaultAppearance(nullptr, field, nullptr), VANILLAPDF_ERROR_PARAMETER_VALUE);
+    EXPECT_EQ(InteractiveForm_ResolveDefaultAppearance(form, nullptr, nullptr), VANILLAPDF_ERROR_PARAMETER_VALUE);
+    EXPECT_EQ(InteractiveForm_ResolveQuadding(nullptr, field, nullptr), VANILLAPDF_ERROR_PARAMETER_VALUE);
+    EXPECT_EQ(InteractiveForm_ResolveQuadding(form, nullptr, nullptr), VANILLAPDF_ERROR_PARAMETER_VALUE);
+    EXPECT_EQ(FieldTree_CreateFromDocument(nullptr, nullptr), VANILLAPDF_ERROR_PARAMETER_VALUE);
+    EXPECT_EQ(FieldTree_GetFieldCount(nullptr, nullptr), VANILLAPDF_ERROR_PARAMETER_VALUE);
+    EXPECT_EQ(FieldTree_GetField(nullptr, 0, nullptr), VANILLAPDF_ERROR_PARAMETER_VALUE);
+    EXPECT_EQ(FieldTree_FindField(tree, nullptr, 0, nullptr), VANILLAPDF_ERROR_PARAMETER_VALUE);
+    EXPECT_EQ(FieldTree_FindField(tree, "email", 5, nullptr), VANILLAPDF_ERROR_PARAMETER_VALUE);
+    EXPECT_EQ(FieldTree_GetRootChildCount(nullptr, nullptr), VANILLAPDF_ERROR_PARAMETER_VALUE);
+    EXPECT_EQ(FieldTree_GetRootChild(nullptr, 0, nullptr), VANILLAPDF_ERROR_PARAMETER_VALUE);
+    EXPECT_EQ(FieldTree_AddRootChild(nullptr, field), VANILLAPDF_ERROR_PARAMETER_VALUE);
+    EXPECT_EQ(FieldTree_AddRootChild(tree, nullptr), VANILLAPDF_ERROR_PARAMETER_VALUE);
+    EXPECT_EQ(FieldTree_InsertRootChild(tree, 0, nullptr), VANILLAPDF_ERROR_PARAMETER_VALUE);
+    EXPECT_EQ(FieldTree_AddChild(nullptr, nullptr, nullptr), VANILLAPDF_ERROR_PARAMETER_VALUE);
+    EXPECT_EQ(FieldTree_AddChild(tree, field, nullptr), VANILLAPDF_ERROR_PARAMETER_VALUE);
+    EXPECT_EQ(FieldTree_AddChild(tree, nullptr, field), VANILLAPDF_ERROR_PARAMETER_VALUE);
+    EXPECT_EQ(FieldTree_InsertChild(tree, field, 0, nullptr), VANILLAPDF_ERROR_PARAMETER_VALUE);
+    EXPECT_EQ(FieldTree_RemoveChild(tree, nullptr), VANILLAPDF_ERROR_PARAMETER_VALUE);
+    EXPECT_EQ(FieldTree_Invalidate(nullptr), VANILLAPDF_ERROR_PARAMETER_VALUE);
+    EXPECT_EQ(Field_GetChildCount(nullptr, nullptr), VANILLAPDF_ERROR_PARAMETER_VALUE);
+    EXPECT_EQ(Field_GetChild(nullptr, 0, nullptr), VANILLAPDF_ERROR_PARAMETER_VALUE);
+    EXPECT_EQ(Field_GetParent(nullptr, nullptr), VANILLAPDF_ERROR_PARAMETER_VALUE);
+    EXPECT_EQ(Field_GetQualifiedName(nullptr, nullptr), VANILLAPDF_ERROR_PARAMETER_VALUE);
+    EXPECT_EQ(Field_GetValue(nullptr, nullptr), VANILLAPDF_ERROR_PARAMETER_VALUE);
+    EXPECT_EQ(Field_GetDefaultValue(nullptr, nullptr), VANILLAPDF_ERROR_PARAMETER_VALUE);
+
+    // Nothing above reached the hierarchy
+    size_type count = 1;
+    ASSERT_EQ(FieldTree_GetFieldCount(tree, &count), VANILLAPDF_ERROR_SUCCESS);
+    EXPECT_EQ(count, 0u);
 }
 
-// The appended reference has to survive a save and reopen cycle
+// The attached hierarchy and the appended reference have to survive a save
+// and reopen cycle
 TEST(InteractiveForm, AddedFieldPersistsAcrossSave) {
     HandleGuard<InputOutputStreamHandle, InputOutputStream_Release> io_stream;
     HandleGuard<FileHandle, File_Release> file;
@@ -762,15 +862,13 @@ TEST(InteractiveForm, AddedFieldPersistsAcrossSave) {
     HandleGuard<InteractiveFormHandle, InteractiveForm_Release> form;
     CreateMemoryDocumentWithForm(io_stream, file, document, form);
 
-    HandleGuard<DictionaryObjectHandle, DictionaryObject_Release> field_dictionary;
-    ASSERT_EQ(DictionaryObject_Create(field_dictionary.out()), VANILLAPDF_ERROR_SUCCESS);
-    InsertStringEntry(field_dictionary, "T", "email");
-    InsertNameEntry(field_dictionary, "FT", "Tx");
-    RegisterIndirectObject(file, field_dictionary);
+    HandleGuard<FieldTreeHandle, FieldTree_Release> tree;
+    AttachEmptyTree(document, form, tree);
 
+    HandleGuard<DictionaryObjectHandle, DictionaryObject_Release> field_dictionary;
     HandleGuard<FieldHandle, Field_Release> field;
-    ASSERT_EQ(Field_CreateFromDictionary(field_dictionary, field.out()), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(InteractiveForm_AddField(form, field), VANILLAPDF_ERROR_SUCCESS);
+    CreateTextFieldDictionary(file, "email", field_dictionary, field);
+    ASSERT_EQ(FieldTree_AddRootChild(tree, field), VANILLAPDF_ERROR_SUCCESS);
 
     HandleGuard<InputOutputStreamHandle, InputOutputStream_Release> destination_stream;
     HandleGuard<FileHandle, File_Release> destination_file;
@@ -789,10 +887,13 @@ TEST(InteractiveForm, AddedFieldPersistsAcrossSave) {
     HandleGuard<InteractiveFormHandle, InteractiveForm_Release> reloaded_form;
     ASSERT_EQ(Catalog_GetAcroForm(reloaded_catalog, reloaded_form.out()), VANILLAPDF_ERROR_SUCCESS);
 
+    HandleGuard<FieldTreeHandle, FieldTree_Release> reloaded_tree;
+    ASSERT_EQ(InteractiveForm_GetFieldTree(reloaded_form, reloaded_tree.out()), VANILLAPDF_ERROR_SUCCESS);
+
     size_type count = 0;
-    ASSERT_EQ(InteractiveForm_GetFieldCount(reloaded_form, &count), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(FieldTree_GetFieldCount(reloaded_tree, &count), VANILLAPDF_ERROR_SUCCESS);
     ASSERT_EQ(count, 1u);
-    EXPECT_EQ(GetFieldQualifiedName(reloaded_form, 0), "email");
+    EXPECT_EQ(GetFieldQualifiedName(reloaded_tree, 0), "email");
 }
 
 // Malformed documents can link /Kids in a cycle; the enumeration has to
@@ -820,17 +921,18 @@ TEST(InteractiveForm, CyclicKidsTerminates) {
     InsertReferenceArrayEntry(form_dictionary, "Fields", { first_group.get() });
 
     HandleGuard<InteractiveFormHandle, InteractiveForm_Release> form;
-    ASSERT_EQ(InteractiveForm_CreateFromDictionary(form_dictionary, form.out()), VANILLAPDF_ERROR_SUCCESS);
+    HandleGuard<FieldTreeHandle, FieldTree_Release> tree;
+    CreateFormWithTree(form_dictionary, form, tree);
 
     // Both nodes are non-terminal grouping nodes, so nothing is enumerated -
     // the point is that the call returns instead of looping forever
     size_type count = 1;
-    ASSERT_EQ(InteractiveForm_GetFieldCount(form, &count), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(FieldTree_GetFieldCount(tree, &count), VANILLAPDF_ERROR_SUCCESS);
     EXPECT_EQ(count, 0u);
 }
 
-// Fields resolve /DA and /Q through the /Parent chain only - the document
-// default in the form dictionary is applied by the caller
+// Fields resolve /DA and /Q through the /Parent chain only; the form owns
+// the document default and performs the full lookup on request
 TEST(InteractiveForm, DefaultAppearanceAndQuaddingFallback) {
     HandleGuard<InputOutputStreamHandle, InputOutputStream_Release> io_stream;
     HandleGuard<FileHandle, File_Release> file;
@@ -858,11 +960,12 @@ TEST(InteractiveForm, DefaultAppearanceAndQuaddingFallback) {
     InsertReferenceArrayEntry(form_dictionary, "Fields", { plain_field.get(), styled_field.get() });
 
     HandleGuard<InteractiveFormHandle, InteractiveForm_Release> form;
-    ASSERT_EQ(InteractiveForm_CreateFromDictionary(form_dictionary, form.out()), VANILLAPDF_ERROR_SUCCESS);
+    HandleGuard<FieldTreeHandle, FieldTree_Release> tree;
+    CreateFormWithTree(form_dictionary, form, tree);
 
     // The plain field carries no /DA or /Q - the caller falls back to the form
     HandleGuard<FieldHandle, Field_Release> plain;
-    ASSERT_EQ(InteractiveForm_GetField(form, 0, plain.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(FieldTree_GetField(tree, 0, plain.out()), VANILLAPDF_ERROR_SUCCESS);
 
     HandleGuard<StringObjectHandle, StringObject_Release> plain_appearance;
     EXPECT_EQ(Field_GetDefaultAppearance(plain, plain_appearance.out()), VANILLAPDF_ERROR_OBJECT_MISSING);
@@ -881,9 +984,21 @@ TEST(InteractiveForm, DefaultAppearanceAndQuaddingFallback) {
     ASSERT_EQ(InteractiveForm_GetQuadding(form, &form_quadding), VANILLAPDF_ERROR_SUCCESS);
     EXPECT_EQ(form_quadding, QuaddingType_Centered);
 
-    // The styled field carries its own /DA and /Q
+    // The form performs that fallback itself on request
+    HandleGuard<StringObjectHandle, StringObject_Release> plain_resolved_appearance;
+    ASSERT_EQ(InteractiveForm_ResolveDefaultAppearance(form, plain, plain_resolved_appearance.out()), VANILLAPDF_ERROR_SUCCESS);
+
+    HandleGuard<BufferHandle, Buffer_Release> plain_resolved_appearance_value;
+    ASSERT_EQ(StringObject_GetValue(plain_resolved_appearance, plain_resolved_appearance_value.out()), VANILLAPDF_ERROR_SUCCESS);
+    EXPECT_EQ(BufferToString(plain_resolved_appearance_value), "/Helv 0 Tf 0 g");
+
+    QuaddingType plain_resolved_quadding = QuaddingType_LeftJustified;
+    ASSERT_EQ(InteractiveForm_ResolveQuadding(form, plain, &plain_resolved_quadding), VANILLAPDF_ERROR_SUCCESS);
+    EXPECT_EQ(plain_resolved_quadding, QuaddingType_Centered);
+
+    // The styled field carries its own /DA and /Q, which win over the form
     HandleGuard<FieldHandle, Field_Release> styled;
-    ASSERT_EQ(InteractiveForm_GetField(form, 1, styled.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(FieldTree_GetField(tree, 1, styled.out()), VANILLAPDF_ERROR_SUCCESS);
 
     HandleGuard<StringObjectHandle, StringObject_Release> styled_appearance;
     ASSERT_EQ(Field_GetDefaultAppearance(styled, styled_appearance.out()), VANILLAPDF_ERROR_SUCCESS);
@@ -895,6 +1010,42 @@ TEST(InteractiveForm, DefaultAppearanceAndQuaddingFallback) {
     QuaddingType styled_quadding = QuaddingType_LeftJustified;
     ASSERT_EQ(Field_GetQuadding(styled, &styled_quadding), VANILLAPDF_ERROR_SUCCESS);
     EXPECT_EQ(styled_quadding, QuaddingType_RightJustified);
+
+    HandleGuard<StringObjectHandle, StringObject_Release> styled_resolved_appearance;
+    ASSERT_EQ(InteractiveForm_ResolveDefaultAppearance(form, styled, styled_resolved_appearance.out()), VANILLAPDF_ERROR_SUCCESS);
+
+    HandleGuard<BufferHandle, Buffer_Release> styled_resolved_appearance_value;
+    ASSERT_EQ(StringObject_GetValue(styled_resolved_appearance, styled_resolved_appearance_value.out()), VANILLAPDF_ERROR_SUCCESS);
+    EXPECT_EQ(BufferToString(styled_resolved_appearance_value), "/TiRo 12 Tf 0 g");
+
+    QuaddingType styled_resolved_quadding = QuaddingType_LeftJustified;
+    ASSERT_EQ(InteractiveForm_ResolveQuadding(form, styled, &styled_resolved_quadding), VANILLAPDF_ERROR_SUCCESS);
+    EXPECT_EQ(styled_resolved_quadding, QuaddingType_RightJustified);
+}
+
+// With no /DA anywhere the lookup is honestly empty; /Q has a specification
+// default (Table 222) and always resolves
+TEST(InteractiveForm, ResolveWithoutDocumentDefaults) {
+    HandleGuard<InputOutputStreamHandle, InputOutputStream_Release> io_stream;
+    HandleGuard<FileHandle, File_Release> file;
+    HandleGuard<DocumentHandle, Document_Release> document;
+    HandleGuard<InteractiveFormHandle, InteractiveForm_Release> form;
+    CreateMemoryDocumentWithForm(io_stream, file, document, form);
+
+    HandleGuard<FieldTreeHandle, FieldTree_Release> tree;
+    AttachEmptyTree(document, form, tree);
+
+    HandleGuard<DictionaryObjectHandle, DictionaryObject_Release> field_dictionary;
+    HandleGuard<FieldHandle, Field_Release> field;
+    CreateTextFieldDictionary(file, "notes", field_dictionary, field);
+    ASSERT_EQ(FieldTree_AddRootChild(tree, field), VANILLAPDF_ERROR_SUCCESS);
+
+    HandleGuard<StringObjectHandle, StringObject_Release> appearance;
+    EXPECT_EQ(InteractiveForm_ResolveDefaultAppearance(form, field, appearance.out()), VANILLAPDF_ERROR_OBJECT_MISSING);
+
+    QuaddingType quadding = QuaddingType_RightJustified;
+    ASSERT_EQ(InteractiveForm_ResolveQuadding(form, field, &quadding), VANILLAPDF_ERROR_SUCCESS);
+    EXPECT_EQ(quadding, QuaddingType_LeftJustified);
 }
 
 } // namespace interactive_forms

--- a/src/vanillapdf.unittest/signature_verifier_test.cpp
+++ b/src/vanillapdf.unittest/signature_verifier_test.cpp
@@ -1160,11 +1160,14 @@ TEST(DigitalSignatureExtensions, SignAndVerifyDocument) {
     ASSERT_EQ(Catalog_GetAcroForm(catalog, acro_form.out()), VANILLAPDF_ERROR_SUCCESS);
     ASSERT_NE(acro_form.get(), nullptr);
 
+    HandleGuard<FieldTreeHandle, FieldTree_Release> field_tree;
+    ASSERT_EQ(InteractiveForm_GetFieldTree(acro_form, field_tree.out()), VANILLAPDF_ERROR_SUCCESS);
+
     size_type field_count = 0;
-    ASSERT_EQ(InteractiveForm_GetFieldCount(acro_form, &field_count), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(FieldTree_GetFieldCount(field_tree, &field_count), VANILLAPDF_ERROR_SUCCESS);
     ASSERT_GT(field_count, 0);
 
-    ASSERT_EQ(InteractiveForm_GetField(acro_form, 0, field.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(FieldTree_GetField(field_tree, 0, field.out()), VANILLAPDF_ERROR_SUCCESS);
     ASSERT_NE(field.get(), nullptr);
 
     ASSERT_EQ(SignatureField_FromField(field, sig_field.out()), VANILLAPDF_ERROR_SUCCESS);
@@ -1426,7 +1429,10 @@ TEST(FieldAndDigitalSignature, ToUnknown_FromUnknown) {
 
     ASSERT_EQ(Document_GetCatalog(signed_document, catalog.out()), VANILLAPDF_ERROR_SUCCESS);
     ASSERT_EQ(Catalog_GetAcroForm(catalog, acro_form.out()), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(InteractiveForm_GetField(acro_form, 0, field.out()), VANILLAPDF_ERROR_SUCCESS);
+
+    HandleGuard<FieldTreeHandle, FieldTree_Release> reloaded_field_tree;
+    ASSERT_EQ(InteractiveForm_GetFieldTree(acro_form, reloaded_field_tree.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(FieldTree_GetField(reloaded_field_tree, 0, field.out()), VANILLAPDF_ERROR_SUCCESS);
     ASSERT_NE(field.get(), nullptr);
 
     ASSERT_EQ(SignatureField_FromField(field, sig_field.out()), VANILLAPDF_ERROR_SUCCESS);

--- a/src/vanillapdf.unittest/signature_verifier_test.cpp
+++ b/src/vanillapdf.unittest/signature_verifier_test.cpp
@@ -1086,7 +1086,6 @@ TEST(DigitalSignatureExtensions, SignAndVerifyDocument) {
     HandleGuard<DocumentHandle, Document_Release> signed_document;
     HandleGuard<CatalogHandle, Catalog_Release> catalog;
     HandleGuard<InteractiveFormHandle, InteractiveForm_Release> acro_form;
-    HandleGuard<FieldCollectionHandle, FieldCollection_Release> fields;
     HandleGuard<FieldHandle, Field_Release> field;
     HandleGuard<SignatureFieldHandle, SignatureField_Release> sig_field;
     HandleGuard<DigitalSignatureHandle, DigitalSignature_Release> digital_signature;
@@ -1161,14 +1160,11 @@ TEST(DigitalSignatureExtensions, SignAndVerifyDocument) {
     ASSERT_EQ(Catalog_GetAcroForm(catalog, acro_form.out()), VANILLAPDF_ERROR_SUCCESS);
     ASSERT_NE(acro_form.get(), nullptr);
 
-    ASSERT_EQ(InteractiveForm_GetFields(acro_form, fields.out()), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_NE(fields.get(), nullptr);
-
     size_type field_count = 0;
-    ASSERT_EQ(FieldCollection_GetSize(fields, &field_count), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(InteractiveForm_GetFieldCount(acro_form, &field_count), VANILLAPDF_ERROR_SUCCESS);
     ASSERT_GT(field_count, 0);
 
-    ASSERT_EQ(FieldCollection_At(fields, 0, field.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(InteractiveForm_GetField(acro_form, 0, field.out()), VANILLAPDF_ERROR_SUCCESS);
     ASSERT_NE(field.get(), nullptr);
 
     ASSERT_EQ(SignatureField_FromField(field, sig_field.out()), VANILLAPDF_ERROR_SUCCESS);
@@ -1397,7 +1393,6 @@ TEST(FieldAndDigitalSignature, ToUnknown_FromUnknown) {
     HandleGuard<DocumentHandle, Document_Release> signed_document;
     HandleGuard<CatalogHandle, Catalog_Release> catalog;
     HandleGuard<InteractiveFormHandle, InteractiveForm_Release> acro_form;
-    HandleGuard<FieldCollectionHandle, FieldCollection_Release> fields;
     HandleGuard<FieldHandle, Field_Release> field;
     HandleGuard<SignatureFieldHandle, SignatureField_Release> sig_field;
     HandleGuard<DigitalSignatureHandle, DigitalSignature_Release> digital_signature;
@@ -1431,8 +1426,7 @@ TEST(FieldAndDigitalSignature, ToUnknown_FromUnknown) {
 
     ASSERT_EQ(Document_GetCatalog(signed_document, catalog.out()), VANILLAPDF_ERROR_SUCCESS);
     ASSERT_EQ(Catalog_GetAcroForm(catalog, acro_form.out()), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(InteractiveForm_GetFields(acro_form, fields.out()), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(FieldCollection_At(fields, 0, field.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(InteractiveForm_GetField(acro_form, 0, field.out()), VANILLAPDF_ERROR_SUCCESS);
     ASSERT_NE(field.get(), nullptr);
 
     ASSERT_EQ(SignatureField_FromField(field, sig_field.out()), VANILLAPDF_ERROR_SUCCESS);

--- a/src/vanillapdf.unittest/thread_safety_test.cpp
+++ b/src/vanillapdf.unittest/thread_safety_test.cpp
@@ -632,6 +632,126 @@ TEST(CatalogThreadSafety, ConcurrentLazyInitReturnsSameInstance) {
         << "Document::GetDocumentCatalog returned multiple Catalog instances under concurrency";
 }
 
+// InteractiveForm::AddField holds the field-cache lock across the whole
+// mutation, so concurrent appends on the same form must never lose a field or
+// throw on the create-if-missing /Fields insert, and concurrent readers must
+// never observe the append-only enumeration shrinking.
+TEST(InteractiveFormThreadSafety, ConcurrentAddFieldKeepsEnumerationConsistent) {
+    constexpr int NUM_WRITER_THREADS = 8;
+    constexpr int FIELDS_PER_THREAD = 100;
+    constexpr int NUM_READER_THREADS = 4;
+    constexpr int TOTAL_FIELDS = NUM_WRITER_THREADS * FIELDS_PER_THREAD;
+
+    HandleGuard<InputOutputStreamHandle, InputOutputStream_Release> io_stream;
+    HandleGuard<FileHandle, File_Release> file;
+    HandleGuard<DocumentHandle, Document_Release> doc;
+
+    ASSERT_EQ(InputOutputStream_CreateFromMemory(io_stream.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(File_CreateStream(io_stream, "form_addfield_race", file.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(Document_CreateFile(file, doc.out()), VANILLAPDF_ERROR_SUCCESS);
+
+    HandleGuard<InteractiveFormHandle, InteractiveForm_Release> form;
+    ASSERT_EQ(InteractiveForm_CreateFromDocument(doc, form.out()), VANILLAPDF_ERROR_SUCCESS);
+
+    // Registering the field dictionaries allocates cross-reference entries,
+    // which is not the subject here - prepare every field up front so the
+    // threads race purely on AddField against a form without a /Fields array
+    std::vector<FieldHandle*> fields(TOTAL_FIELDS, nullptr);
+
+    for (int i = 0; i < TOTAL_FIELDS; ++i) {
+        HandleGuard<DictionaryObjectHandle, DictionaryObject_Release> field_dictionary;
+        ASSERT_EQ(DictionaryObject_Create(field_dictionary.out()), VANILLAPDF_ERROR_SUCCESS);
+
+        HandleGuard<ObjectHandle, Object_Release> dictionary_object;
+        ASSERT_EQ(DictionaryObject_ToObject(field_dictionary, dictionary_object.out()), VANILLAPDF_ERROR_SUCCESS);
+
+        HandleGuard<XrefUsedEntryHandle, XrefUsedEntry_Release> entry;
+        ASSERT_EQ(File_AllocateNewEntry(file, entry.out()), VANILLAPDF_ERROR_SUCCESS);
+        ASSERT_EQ(XrefUsedEntry_SetReference(entry, dictionary_object), VANILLAPDF_ERROR_SUCCESS);
+
+        ASSERT_EQ(Field_CreateFromDictionary(field_dictionary, &fields[i]), VANILLAPDF_ERROR_SUCCESS);
+    }
+
+    // Spin barrier so the writers race the cold create-if-missing path
+    std::atomic<int> ready{0};
+    std::atomic<bool> go{false};
+    std::atomic<int> writers_remaining{NUM_WRITER_THREADS};
+    std::atomic<int> error_count{0};
+    std::atomic<int> shrink_count{0};
+
+    std::vector<std::thread> threads;
+    threads.reserve(NUM_WRITER_THREADS + NUM_READER_THREADS);
+
+    for (int t = 0; t < NUM_WRITER_THREADS; ++t) {
+        threads.emplace_back([&, t]() {
+            ready.fetch_add(1);
+            while (!go.load()) { std::this_thread::yield(); }
+
+            for (int i = 0; i < FIELDS_PER_THREAD; ++i) {
+                if (InteractiveForm_AddField(form, fields[t * FIELDS_PER_THREAD + i]) != VANILLAPDF_ERROR_SUCCESS) {
+                    error_count.fetch_add(1);
+                }
+            }
+
+            writers_remaining.fetch_sub(1);
+        });
+    }
+
+    for (int t = 0; t < NUM_READER_THREADS; ++t) {
+        threads.emplace_back([&]() {
+            ready.fetch_add(1);
+            while (!go.load()) { std::this_thread::yield(); }
+
+            size_type last_count = 0;
+            while (writers_remaining.load() > 0) {
+                size_type count = 0;
+                if (InteractiveForm_GetFieldCount(form, &count) != VANILLAPDF_ERROR_SUCCESS) {
+                    error_count.fetch_add(1);
+                    continue;
+                }
+
+                // Fields are only appended, so the enumeration never shrinks
+                if (count < last_count) {
+                    shrink_count.fetch_add(1);
+                }
+                last_count = count;
+
+                // The observed count only grows, so the last index stays valid
+                if (count > 0) {
+                    FieldHandle* observed_field = nullptr;
+                    if (InteractiveForm_GetField(form, count - 1, &observed_field) != VANILLAPDF_ERROR_SUCCESS) {
+                        error_count.fetch_add(1);
+                    } else {
+                        Field_Release(observed_field);
+                    }
+                }
+            }
+        });
+    }
+
+    while (ready.load() < NUM_WRITER_THREADS + NUM_READER_THREADS) { std::this_thread::yield(); }
+    go.store(true);
+
+    for (auto& thread : threads) {
+        thread.join();
+    }
+
+    EXPECT_EQ(error_count.load(), 0);
+    EXPECT_EQ(shrink_count.load(), 0)
+        << "A concurrent reader observed the append-only field enumeration shrinking";
+
+    size_type final_count = 0;
+    ASSERT_EQ(InteractiveForm_GetFieldCount(form, &final_count), VANILLAPDF_ERROR_SUCCESS);
+    EXPECT_EQ(final_count, static_cast<size_type>(TOTAL_FIELDS))
+        << "Concurrent AddField calls lost fields";
+
+    for (auto* prepared_field : fields) {
+        if (prepared_field != nullptr) {
+            Field_Release(prepared_field);
+        }
+    }
+}
+
 // Give the document a few more pages, each carrying a content stream, so that
 // the walk below has a real page pipeline to traverse rather than the single
 // empty page Document_CreateFile leaves behind.

--- a/src/vanillapdf.unittest/thread_safety_test.cpp
+++ b/src/vanillapdf.unittest/thread_safety_test.cpp
@@ -5,6 +5,7 @@
 #include <thread>
 #include <vector>
 #include <atomic>
+#include <string>
 
 namespace thread_safety {
 
@@ -632,11 +633,11 @@ TEST(CatalogThreadSafety, ConcurrentLazyInitReturnsSameInstance) {
         << "Document::GetDocumentCatalog returned multiple Catalog instances under concurrency";
 }
 
-// InteractiveForm::AddField holds the field-cache lock across the whole
-// mutation, so concurrent appends on the same form must never lose a field or
-// throw on the create-if-missing /Fields insert, and concurrent readers must
-// never observe the append-only enumeration shrinking.
-TEST(InteractiveFormThreadSafety, ConcurrentAddFieldKeepsEnumerationConsistent) {
+// FieldTree::AddRootChild holds the field-cache lock across the whole mutation,
+// so concurrent appends on the same tree must never lose a field, and
+// concurrent readers must never observe the append-only enumeration
+// shrinking.
+TEST(FieldTreeThreadSafety, ConcurrentAddRootChildKeepsEnumerationConsistent) {
     constexpr int NUM_WRITER_THREADS = 8;
     constexpr int FIELDS_PER_THREAD = 100;
     constexpr int NUM_READER_THREADS = 4;
@@ -653,14 +654,31 @@ TEST(InteractiveFormThreadSafety, ConcurrentAddFieldKeepsEnumerationConsistent) 
     HandleGuard<InteractiveFormHandle, InteractiveForm_Release> form;
     ASSERT_EQ(InteractiveForm_CreateFromDocument(doc, form.out()), VANILLAPDF_ERROR_SUCCESS);
 
+    HandleGuard<FieldTreeHandle, FieldTree_Release> tree;
+    ASSERT_EQ(FieldTree_CreateFromDocument(doc, tree.out()), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(InteractiveForm_SetFieldTree(form, tree), VANILLAPDF_ERROR_SUCCESS);
+
     // Registering the field dictionaries allocates cross-reference entries,
     // which is not the subject here - prepare every field up front so the
-    // threads race purely on AddField against a form without a /Fields array
+    // threads race purely on AddRootChild against an empty hierarchy. Each field
+    // needs a distinct name, since duplicates are rejected on write.
     std::vector<FieldHandle*> fields(TOTAL_FIELDS, nullptr);
 
     for (int i = 0; i < TOTAL_FIELDS; ++i) {
         HandleGuard<DictionaryObjectHandle, DictionaryObject_Release> field_dictionary;
         ASSERT_EQ(DictionaryObject_Create(field_dictionary.out()), VANILLAPDF_ERROR_SUCCESS);
+
+        std::string partial_name = "field" + std::to_string(i);
+
+        HandleGuard<NameObjectHandle, NameObject_Release> name_key;
+        HandleGuard<LiteralStringObjectHandle, LiteralStringObject_Release> name_literal;
+        HandleGuard<StringObjectHandle, StringObject_Release> name_string;
+        HandleGuard<ObjectHandle, Object_Release> name_object;
+        ASSERT_EQ(NameObject_CreateFromDecodedString("T", name_key.out()), VANILLAPDF_ERROR_SUCCESS);
+        ASSERT_EQ(LiteralStringObject_CreateFromDecodedString(partial_name.c_str(), name_literal.out()), VANILLAPDF_ERROR_SUCCESS);
+        ASSERT_EQ(LiteralStringObject_ToStringObject(name_literal, name_string.out()), VANILLAPDF_ERROR_SUCCESS);
+        ASSERT_EQ(StringObject_ToObject(name_string, name_object.out()), VANILLAPDF_ERROR_SUCCESS);
+        ASSERT_EQ(DictionaryObject_Insert(field_dictionary, name_key, name_object, VANILLAPDF_RV_TRUE), VANILLAPDF_ERROR_SUCCESS);
 
         HandleGuard<ObjectHandle, Object_Release> dictionary_object;
         ASSERT_EQ(DictionaryObject_ToObject(field_dictionary, dictionary_object.out()), VANILLAPDF_ERROR_SUCCESS);
@@ -672,7 +690,7 @@ TEST(InteractiveFormThreadSafety, ConcurrentAddFieldKeepsEnumerationConsistent) 
         ASSERT_EQ(Field_CreateFromDictionary(field_dictionary, &fields[i]), VANILLAPDF_ERROR_SUCCESS);
     }
 
-    // Spin barrier so the writers race the cold create-if-missing path
+    // Spin barrier so the writers race the cold cache-build path
     std::atomic<int> ready{0};
     std::atomic<bool> go{false};
     std::atomic<int> writers_remaining{NUM_WRITER_THREADS};
@@ -688,7 +706,7 @@ TEST(InteractiveFormThreadSafety, ConcurrentAddFieldKeepsEnumerationConsistent) 
             while (!go.load()) { std::this_thread::yield(); }
 
             for (int i = 0; i < FIELDS_PER_THREAD; ++i) {
-                if (InteractiveForm_AddField(form, fields[t * FIELDS_PER_THREAD + i]) != VANILLAPDF_ERROR_SUCCESS) {
+                if (FieldTree_AddRootChild(tree, fields[t * FIELDS_PER_THREAD + i]) != VANILLAPDF_ERROR_SUCCESS) {
                     error_count.fetch_add(1);
                 }
             }
@@ -705,7 +723,7 @@ TEST(InteractiveFormThreadSafety, ConcurrentAddFieldKeepsEnumerationConsistent) 
             size_type last_count = 0;
             while (writers_remaining.load() > 0) {
                 size_type count = 0;
-                if (InteractiveForm_GetFieldCount(form, &count) != VANILLAPDF_ERROR_SUCCESS) {
+                if (FieldTree_GetFieldCount(tree, &count) != VANILLAPDF_ERROR_SUCCESS) {
                     error_count.fetch_add(1);
                     continue;
                 }
@@ -719,7 +737,7 @@ TEST(InteractiveFormThreadSafety, ConcurrentAddFieldKeepsEnumerationConsistent) 
                 // The observed count only grows, so the last index stays valid
                 if (count > 0) {
                     FieldHandle* observed_field = nullptr;
-                    if (InteractiveForm_GetField(form, count - 1, &observed_field) != VANILLAPDF_ERROR_SUCCESS) {
+                    if (FieldTree_GetField(tree, count - 1, &observed_field) != VANILLAPDF_ERROR_SUCCESS) {
                         error_count.fetch_add(1);
                     } else {
                         Field_Release(observed_field);
@@ -741,9 +759,9 @@ TEST(InteractiveFormThreadSafety, ConcurrentAddFieldKeepsEnumerationConsistent) 
         << "A concurrent reader observed the append-only field enumeration shrinking";
 
     size_type final_count = 0;
-    ASSERT_EQ(InteractiveForm_GetFieldCount(form, &final_count), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(FieldTree_GetFieldCount(tree, &final_count), VANILLAPDF_ERROR_SUCCESS);
     EXPECT_EQ(final_count, static_cast<size_type>(TOTAL_FIELDS))
-        << "Concurrent AddField calls lost fields";
+        << "Concurrent AddRootChild calls lost fields";
 
     for (auto* prepared_field : fields) {
         if (prepared_field != nullptr) {
@@ -1003,6 +1021,7 @@ TEST(GetByteRangeThreadSafety, ConcurrentSignatureValidationKeepsDocumentIntact)
     DocumentHandle* signed_document = nullptr;
     CatalogHandle* catalog = nullptr;
     InteractiveFormHandle* acro_form = nullptr;
+    FieldTreeHandle* field_tree = nullptr;
     FieldHandle* field = nullptr;
     SignatureFieldHandle* sig_field = nullptr;
     DigitalSignatureHandle* digital_signature = nullptr;
@@ -1043,11 +1062,13 @@ TEST(GetByteRangeThreadSafety, ConcurrentSignatureValidationKeepsDocumentIntact)
     ASSERT_EQ(Document_GetCatalog(signed_document, &catalog), VANILLAPDF_ERROR_SUCCESS);
     ASSERT_EQ(Catalog_GetAcroForm(catalog, &acro_form), VANILLAPDF_ERROR_SUCCESS);
 
+    ASSERT_EQ(InteractiveForm_GetFieldTree(acro_form, &field_tree), VANILLAPDF_ERROR_SUCCESS);
+
     size_type field_count = 0;
-    ASSERT_EQ(InteractiveForm_GetFieldCount(acro_form, &field_count), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(FieldTree_GetFieldCount(field_tree, &field_count), VANILLAPDF_ERROR_SUCCESS);
     ASSERT_GT(field_count, 0);
 
-    ASSERT_EQ(InteractiveForm_GetField(acro_form, 0, &field), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(FieldTree_GetField(field_tree, 0, &field), VANILLAPDF_ERROR_SUCCESS);
     ASSERT_EQ(SignatureField_FromField(field, &sig_field), VANILLAPDF_ERROR_SUCCESS);
     ASSERT_EQ(SignatureField_GetValue(sig_field, &digital_signature), VANILLAPDF_ERROR_SUCCESS);
     ASSERT_NE(digital_signature, nullptr);
@@ -1124,6 +1145,7 @@ TEST(GetByteRangeThreadSafety, ConcurrentSignatureValidationKeepsDocumentIntact)
     if (digital_signature) DigitalSignature_Release(digital_signature);
     if (sig_field) SignatureField_Release(sig_field);
     if (field) Field_Release(field);
+    if (field_tree) FieldTree_Release(field_tree);
     if (acro_form) InteractiveForm_Release(acro_form);
     if (catalog) Catalog_Release(catalog);
     if (trust_store) TrustedCertificateStore_Release(trust_store);

--- a/src/vanillapdf.unittest/thread_safety_test.cpp
+++ b/src/vanillapdf.unittest/thread_safety_test.cpp
@@ -883,7 +883,6 @@ TEST(GetByteRangeThreadSafety, ConcurrentSignatureValidationKeepsDocumentIntact)
     DocumentHandle* signed_document = nullptr;
     CatalogHandle* catalog = nullptr;
     InteractiveFormHandle* acro_form = nullptr;
-    FieldCollectionHandle* fields = nullptr;
     FieldHandle* field = nullptr;
     SignatureFieldHandle* sig_field = nullptr;
     DigitalSignatureHandle* digital_signature = nullptr;
@@ -923,13 +922,12 @@ TEST(GetByteRangeThreadSafety, ConcurrentSignatureValidationKeepsDocumentIntact)
 
     ASSERT_EQ(Document_GetCatalog(signed_document, &catalog), VANILLAPDF_ERROR_SUCCESS);
     ASSERT_EQ(Catalog_GetAcroForm(catalog, &acro_form), VANILLAPDF_ERROR_SUCCESS);
-    ASSERT_EQ(InteractiveForm_GetFields(acro_form, &fields), VANILLAPDF_ERROR_SUCCESS);
 
     size_type field_count = 0;
-    ASSERT_EQ(FieldCollection_GetSize(fields, &field_count), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(InteractiveForm_GetFieldCount(acro_form, &field_count), VANILLAPDF_ERROR_SUCCESS);
     ASSERT_GT(field_count, 0);
 
-    ASSERT_EQ(FieldCollection_At(fields, 0, &field), VANILLAPDF_ERROR_SUCCESS);
+    ASSERT_EQ(InteractiveForm_GetField(acro_form, 0, &field), VANILLAPDF_ERROR_SUCCESS);
     ASSERT_EQ(SignatureField_FromField(field, &sig_field), VANILLAPDF_ERROR_SUCCESS);
     ASSERT_EQ(SignatureField_GetValue(sig_field, &digital_signature), VANILLAPDF_ERROR_SUCCESS);
     ASSERT_NE(digital_signature, nullptr);
@@ -1006,7 +1004,6 @@ TEST(GetByteRangeThreadSafety, ConcurrentSignatureValidationKeepsDocumentIntact)
     if (digital_signature) DigitalSignature_Release(digital_signature);
     if (sig_field) SignatureField_Release(sig_field);
     if (field) Field_Release(field);
-    if (fields) FieldCollection_Release(fields);
     if (acro_form) InteractiveForm_Release(acro_form);
     if (catalog) Catalog_Release(catalog);
     if (trust_store) TrustedCertificateStore_Release(trust_store);

--- a/src/vanillapdf/CMakeLists.txt
+++ b/src/vanillapdf/CMakeLists.txt
@@ -76,6 +76,7 @@ set(VANILLAPDF_C_IMPLEMENTATION_SEMANTICS_SOURCES
     implementation/semantics/c_document_info.cpp
     implementation/semantics/c_document_signature_settings.cpp
     implementation/semantics/c_fields.cpp
+    implementation/semantics/c_field_tree.cpp
     implementation/semantics/c_font.cpp
     implementation/semantics/c_font_map.cpp
     implementation/semantics/c_interactive_forms.cpp
@@ -135,6 +136,7 @@ set(VANILLAPDF_SEMANTICS_SOURCES
     semantics/objects/tree.cpp
     semantics/objects/name_dictionary.cpp
     semantics/objects/fields.cpp
+    semantics/objects/field_tree.cpp
     semantics/objects/interactive_forms.cpp
     semantics/objects/viewer_preferences.cpp
     semantics/objects/page_node_base.cpp
@@ -265,6 +267,7 @@ set(VANILLAPDF_SEMANTICS_HEADERS
     semantics/objects/digital_signature.h
     semantics/objects/document_info.h
     semantics/objects/fields.h
+    semantics/objects/field_tree.h
     semantics/objects/font.h
     semantics/objects/interactive_forms.h
     semantics/objects/high_level_object.h

--- a/src/vanillapdf/implementation/semantics/c_field_tree.cpp
+++ b/src/vanillapdf/implementation/semantics/c_field_tree.cpp
@@ -1,0 +1,177 @@
+#include "precompiled.h"
+
+#include "semantics/objects/field_tree.h"
+#include "semantics/objects/fields.h"
+#include "semantics/objects/document.h"
+
+#include "utils/buffer.h"
+
+#include "vanillapdf/semantics/c_field_tree.h"
+#include "implementation/c_helper.h"
+
+using namespace vanillapdf;
+using namespace vanillapdf::syntax;
+using namespace vanillapdf::semantics;
+
+VANILLAPDF_API error_type CALLING_CONVENTION FieldTree_CreateFromDocument(DocumentHandle* handle, FieldTreeHandle** result) {
+    Document* document = reinterpret_cast<Document*>(handle);
+    RETURN_ERROR_PARAM_VALUE_IF_NULL(document);
+    RETURN_ERROR_PARAM_VALUE_IF_NULL(result);
+
+    try {
+        auto tree = FieldTree::Create(document);
+        auto ptr = tree.AddRefGet();
+        *result = reinterpret_cast<FieldTreeHandle*>(ptr);
+        return VANILLAPDF_ERROR_SUCCESS;
+    } CATCH_VANILLAPDF_EXCEPTIONS
+}
+
+VANILLAPDF_API error_type CALLING_CONVENTION FieldTree_GetFieldCount(FieldTreeHandle* handle, size_type* result) {
+    FieldTree* tree = reinterpret_cast<FieldTree*>(handle);
+    RETURN_ERROR_PARAM_VALUE_IF_NULL(tree);
+    RETURN_ERROR_PARAM_VALUE_IF_NULL(result);
+
+    try {
+        *result = tree->GetFieldCount();
+        return VANILLAPDF_ERROR_SUCCESS;
+    } CATCH_VANILLAPDF_EXCEPTIONS
+}
+
+VANILLAPDF_API error_type CALLING_CONVENTION FieldTree_GetField(FieldTreeHandle* handle, size_type index, FieldHandle** result) {
+    FieldTree* tree = reinterpret_cast<FieldTree*>(handle);
+    RETURN_ERROR_PARAM_VALUE_IF_NULL(tree);
+    RETURN_ERROR_PARAM_VALUE_IF_NULL(result);
+
+    try {
+        auto field = tree->GetField(index);
+        auto ptr = field.AddRefGet();
+        *result = reinterpret_cast<FieldHandle*>(ptr);
+        return VANILLAPDF_ERROR_SUCCESS;
+    } CATCH_VANILLAPDF_EXCEPTIONS
+}
+
+VANILLAPDF_API error_type CALLING_CONVENTION FieldTree_FindField(FieldTreeHandle* handle, string_type qualified_name, size_type size, FieldHandle** result) {
+    FieldTree* tree = reinterpret_cast<FieldTree*>(handle);
+    RETURN_ERROR_PARAM_VALUE_IF_NULL(tree);
+    RETURN_ERROR_PARAM_VALUE_IF_NULL(qualified_name);
+    RETURN_ERROR_PARAM_VALUE_IF_NULL(result);
+
+    try {
+        OuputFieldPtr field;
+        bool found = tree->TryFindField(std::string_view(qualified_name, size), field);
+        if (!found) return VANILLAPDF_ERROR_OBJECT_MISSING;
+        auto ptr = field.AddRefGet();
+        *result = reinterpret_cast<FieldHandle*>(ptr);
+        return VANILLAPDF_ERROR_SUCCESS;
+    } CATCH_VANILLAPDF_EXCEPTIONS
+}
+
+VANILLAPDF_API error_type CALLING_CONVENTION FieldTree_GetRootChildCount(FieldTreeHandle* handle, size_type* result) {
+    FieldTree* tree = reinterpret_cast<FieldTree*>(handle);
+    RETURN_ERROR_PARAM_VALUE_IF_NULL(tree);
+    RETURN_ERROR_PARAM_VALUE_IF_NULL(result);
+
+    try {
+        *result = tree->GetRootChildCount();
+        return VANILLAPDF_ERROR_SUCCESS;
+    } CATCH_VANILLAPDF_EXCEPTIONS
+}
+
+VANILLAPDF_API error_type CALLING_CONVENTION FieldTree_GetRootChild(FieldTreeHandle* handle, size_type index, FieldHandle** result) {
+    FieldTree* tree = reinterpret_cast<FieldTree*>(handle);
+    RETURN_ERROR_PARAM_VALUE_IF_NULL(tree);
+    RETURN_ERROR_PARAM_VALUE_IF_NULL(result);
+
+    try {
+        auto child = tree->GetRootChild(index);
+        auto ptr = child.AddRefGet();
+        *result = reinterpret_cast<FieldHandle*>(ptr);
+        return VANILLAPDF_ERROR_SUCCESS;
+    } CATCH_VANILLAPDF_EXCEPTIONS
+}
+
+VANILLAPDF_API error_type CALLING_CONVENTION FieldTree_AddRootChild(FieldTreeHandle* handle, FieldHandle* child) {
+    FieldTree* tree = reinterpret_cast<FieldTree*>(handle);
+    Field* child_field = reinterpret_cast<Field*>(child);
+    RETURN_ERROR_PARAM_VALUE_IF_NULL(tree);
+    RETURN_ERROR_PARAM_VALUE_IF_NULL(child_field);
+
+    try {
+        tree->AddRootChild(child_field);
+        return VANILLAPDF_ERROR_SUCCESS;
+    } CATCH_VANILLAPDF_EXCEPTIONS
+}
+
+VANILLAPDF_API error_type CALLING_CONVENTION FieldTree_InsertRootChild(FieldTreeHandle* handle, size_type index, FieldHandle* child) {
+    FieldTree* tree = reinterpret_cast<FieldTree*>(handle);
+    Field* child_field = reinterpret_cast<Field*>(child);
+    RETURN_ERROR_PARAM_VALUE_IF_NULL(tree);
+    RETURN_ERROR_PARAM_VALUE_IF_NULL(child_field);
+
+    try {
+        tree->InsertRootChild(index, child_field);
+        return VANILLAPDF_ERROR_SUCCESS;
+    } CATCH_VANILLAPDF_EXCEPTIONS
+}
+
+VANILLAPDF_API error_type CALLING_CONVENTION FieldTree_AddChild(FieldTreeHandle* handle, FieldHandle* parent, FieldHandle* child) {
+    FieldTree* tree = reinterpret_cast<FieldTree*>(handle);
+    Field* parent_field = reinterpret_cast<Field*>(parent);
+    Field* child_field = reinterpret_cast<Field*>(child);
+    RETURN_ERROR_PARAM_VALUE_IF_NULL(tree);
+    RETURN_ERROR_PARAM_VALUE_IF_NULL(parent_field);
+    RETURN_ERROR_PARAM_VALUE_IF_NULL(child_field);
+
+    try {
+        tree->AddChild(parent_field, child_field);
+        return VANILLAPDF_ERROR_SUCCESS;
+    } CATCH_VANILLAPDF_EXCEPTIONS
+}
+
+VANILLAPDF_API error_type CALLING_CONVENTION FieldTree_InsertChild(FieldTreeHandle* handle, FieldHandle* parent, size_type index, FieldHandle* child) {
+    FieldTree* tree = reinterpret_cast<FieldTree*>(handle);
+    Field* parent_field = reinterpret_cast<Field*>(parent);
+    Field* child_field = reinterpret_cast<Field*>(child);
+    RETURN_ERROR_PARAM_VALUE_IF_NULL(tree);
+    RETURN_ERROR_PARAM_VALUE_IF_NULL(parent_field);
+    RETURN_ERROR_PARAM_VALUE_IF_NULL(child_field);
+
+    try {
+        tree->InsertChild(parent_field, index, child_field);
+        return VANILLAPDF_ERROR_SUCCESS;
+    } CATCH_VANILLAPDF_EXCEPTIONS
+}
+
+VANILLAPDF_API error_type CALLING_CONVENTION FieldTree_RemoveChild(FieldTreeHandle* handle, FieldHandle* field) {
+    FieldTree* tree = reinterpret_cast<FieldTree*>(handle);
+    Field* removed_field = reinterpret_cast<Field*>(field);
+    RETURN_ERROR_PARAM_VALUE_IF_NULL(tree);
+    RETURN_ERROR_PARAM_VALUE_IF_NULL(removed_field);
+
+    try {
+        tree->RemoveChild(removed_field);
+        return VANILLAPDF_ERROR_SUCCESS;
+    } CATCH_VANILLAPDF_EXCEPTIONS
+}
+
+VANILLAPDF_API error_type CALLING_CONVENTION FieldTree_Invalidate(FieldTreeHandle* handle) {
+    FieldTree* tree = reinterpret_cast<FieldTree*>(handle);
+    RETURN_ERROR_PARAM_VALUE_IF_NULL(tree);
+
+    try {
+        tree->Invalidate();
+        return VANILLAPDF_ERROR_SUCCESS;
+    } CATCH_VANILLAPDF_EXCEPTIONS
+}
+
+VANILLAPDF_API error_type CALLING_CONVENTION FieldTree_ToUnknown(FieldTreeHandle* handle, IUnknownHandle** result) {
+    return SafeObjectConvert<FieldTree, IUnknown, FieldTreeHandle, IUnknownHandle>(handle, result);
+}
+
+VANILLAPDF_API error_type CALLING_CONVENTION FieldTree_FromUnknown(IUnknownHandle* handle, FieldTreeHandle** result) {
+    return SafeObjectConvert<IUnknown, FieldTree, IUnknownHandle, FieldTreeHandle>(handle, result);
+}
+
+VANILLAPDF_API error_type CALLING_CONVENTION FieldTree_Release(FieldTreeHandle* handle) {
+    return ObjectRelease<FieldTree, FieldTreeHandle>(handle);
+}

--- a/src/vanillapdf/implementation/semantics/c_fields.cpp
+++ b/src/vanillapdf/implementation/semantics/c_fields.cpp
@@ -1,6 +1,8 @@
 #include "precompiled.h"
 
 #include "semantics/objects/fields.h"
+
+#include "utils/buffer.h"
 #include "syntax/objects/dictionary_object.h"
 
 #include "vanillapdf/semantics/c_fields.h"
@@ -178,6 +180,75 @@ VANILLAPDF_API error_type CALLING_CONVENTION Field_GetQualifiedName(FieldHandle*
         auto qualified_name = obj->GetQualifiedName();
         auto ptr = qualified_name.AddRefGet();
         *result = reinterpret_cast<BufferHandle*>(ptr);
+        return VANILLAPDF_ERROR_SUCCESS;
+    } CATCH_VANILLAPDF_EXCEPTIONS
+}
+
+VANILLAPDF_API error_type CALLING_CONVENTION Field_GetChildCount(FieldHandle* handle, size_type* result) {
+    Field* obj = reinterpret_cast<Field*>(handle);
+    RETURN_ERROR_PARAM_VALUE_IF_NULL(obj);
+    RETURN_ERROR_PARAM_VALUE_IF_NULL(result);
+
+    try {
+        *result = obj->GetChildCount();
+        return VANILLAPDF_ERROR_SUCCESS;
+    } CATCH_VANILLAPDF_EXCEPTIONS
+}
+
+VANILLAPDF_API error_type CALLING_CONVENTION Field_GetChild(FieldHandle* handle, size_type index, FieldHandle** result) {
+    Field* obj = reinterpret_cast<Field*>(handle);
+    RETURN_ERROR_PARAM_VALUE_IF_NULL(obj);
+    RETURN_ERROR_PARAM_VALUE_IF_NULL(result);
+
+    try {
+        auto child = obj->GetChild(index);
+        auto ptr = child.AddRefGet();
+        *result = reinterpret_cast<FieldHandle*>(ptr);
+        return VANILLAPDF_ERROR_SUCCESS;
+    } CATCH_VANILLAPDF_EXCEPTIONS
+}
+
+VANILLAPDF_API error_type CALLING_CONVENTION Field_GetParent(FieldHandle* handle, FieldHandle** result) {
+    Field* obj = reinterpret_cast<Field*>(handle);
+    RETURN_ERROR_PARAM_VALUE_IF_NULL(obj);
+    RETURN_ERROR_PARAM_VALUE_IF_NULL(result);
+
+    try {
+        OuputFieldPtr parent;
+        bool contains = obj->GetParent(parent);
+        if (!contains) return VANILLAPDF_ERROR_OBJECT_MISSING;
+        auto ptr = parent.AddRefGet();
+        *result = reinterpret_cast<FieldHandle*>(ptr);
+        return VANILLAPDF_ERROR_SUCCESS;
+    } CATCH_VANILLAPDF_EXCEPTIONS
+}
+
+VANILLAPDF_API error_type CALLING_CONVENTION Field_GetValue(FieldHandle* handle, ObjectHandle** result) {
+    Field* obj = reinterpret_cast<Field*>(handle);
+    RETURN_ERROR_PARAM_VALUE_IF_NULL(obj);
+    RETURN_ERROR_PARAM_VALUE_IF_NULL(result);
+
+    try {
+        OutputObjectPtr value;
+        bool contains = obj->GetValueObject(value);
+        if (!contains) return VANILLAPDF_ERROR_OBJECT_MISSING;
+        auto ptr = value.AddRefGet();
+        *result = reinterpret_cast<ObjectHandle*>(ptr);
+        return VANILLAPDF_ERROR_SUCCESS;
+    } CATCH_VANILLAPDF_EXCEPTIONS
+}
+
+VANILLAPDF_API error_type CALLING_CONVENTION Field_GetDefaultValue(FieldHandle* handle, ObjectHandle** result) {
+    Field* obj = reinterpret_cast<Field*>(handle);
+    RETURN_ERROR_PARAM_VALUE_IF_NULL(obj);
+    RETURN_ERROR_PARAM_VALUE_IF_NULL(result);
+
+    try {
+        OutputObjectPtr value;
+        bool contains = obj->GetDefaultValueObject(value);
+        if (!contains) return VANILLAPDF_ERROR_OBJECT_MISSING;
+        auto ptr = value.AddRefGet();
+        *result = reinterpret_cast<ObjectHandle*>(ptr);
         return VANILLAPDF_ERROR_SUCCESS;
     } CATCH_VANILLAPDF_EXCEPTIONS
 }
@@ -371,17 +442,6 @@ VANILLAPDF_API error_type CALLING_CONVENTION ChoiceField_GetOptionAt(ChoiceField
         if (!contains) return VANILLAPDF_ERROR_OBJECT_MISSING;
         auto ptr = direct.AddRefGet();
         *result = reinterpret_cast<ObjectHandle*>(ptr);
-        return VANILLAPDF_ERROR_SUCCESS;
-    } CATCH_VANILLAPDF_EXCEPTIONS
-}
-
-VANILLAPDF_API error_type CALLING_CONVENTION FieldCollection_Create(FieldCollectionHandle** result) {
-    RETURN_ERROR_PARAM_VALUE_IF_NULL(result);
-
-    try {
-        auto collection = FieldCollection::Create();
-        auto ptr = collection.AddRefGet();
-        *result = reinterpret_cast<FieldCollectionHandle*>(ptr);
         return VANILLAPDF_ERROR_SUCCESS;
     } CATCH_VANILLAPDF_EXCEPTIONS
 }

--- a/src/vanillapdf/implementation/semantics/c_interactive_forms.cpp
+++ b/src/vanillapdf/implementation/semantics/c_interactive_forms.cpp
@@ -70,6 +70,18 @@ VANILLAPDF_API error_type CALLING_CONVENTION InteractiveForm_SetFields(Interacti
     } CATCH_VANILLAPDF_EXCEPTIONS
 }
 
+VANILLAPDF_API error_type CALLING_CONVENTION InteractiveForm_AddField(InteractiveFormHandle* handle, FieldHandle* value) {
+    InteractiveForm* form = reinterpret_cast<InteractiveForm*>(handle);
+    Field* field = reinterpret_cast<Field*>(value);
+    RETURN_ERROR_PARAM_VALUE_IF_NULL(form);
+    RETURN_ERROR_PARAM_VALUE_IF_NULL(field);
+
+    try {
+        form->AddField(field);
+        return VANILLAPDF_ERROR_SUCCESS;
+    } CATCH_VANILLAPDF_EXCEPTIONS
+}
+
 VANILLAPDF_API error_type CALLING_CONVENTION InteractiveForm_GetSignatureFlags(InteractiveFormHandle* handle, SignatureFlagsHandle** result) {
     InteractiveForm* form = reinterpret_cast<InteractiveForm*>(handle);
     RETURN_ERROR_PARAM_VALUE_IF_NULL(form);

--- a/src/vanillapdf/implementation/semantics/c_interactive_forms.cpp
+++ b/src/vanillapdf/implementation/semantics/c_interactive_forms.cpp
@@ -1,6 +1,7 @@
 #include "precompiled.h"
 
 #include "semantics/objects/interactive_forms.h"
+#include "semantics/objects/field_tree.h"
 #include "semantics/objects/signature_flags.h"
 #include "semantics/objects/fields.h"
 #include "semantics/objects/document.h"
@@ -40,6 +41,33 @@ VANILLAPDF_API error_type CALLING_CONVENTION InteractiveForm_CreateFromDocument(
     } CATCH_VANILLAPDF_EXCEPTIONS
 }
 
+VANILLAPDF_API error_type CALLING_CONVENTION InteractiveForm_GetFieldTree(InteractiveFormHandle* handle, FieldTreeHandle** result) {
+    InteractiveForm* form = reinterpret_cast<InteractiveForm*>(handle);
+    RETURN_ERROR_PARAM_VALUE_IF_NULL(form);
+    RETURN_ERROR_PARAM_VALUE_IF_NULL(result);
+
+    try {
+        OutputFieldTreePtr tree;
+        bool contains = form->GetFieldTree(tree);
+        if (!contains) return VANILLAPDF_ERROR_OBJECT_MISSING;
+        auto ptr = tree.AddRefGet();
+        *result = reinterpret_cast<FieldTreeHandle*>(ptr);
+        return VANILLAPDF_ERROR_SUCCESS;
+    } CATCH_VANILLAPDF_EXCEPTIONS
+}
+
+VANILLAPDF_API error_type CALLING_CONVENTION InteractiveForm_SetFieldTree(InteractiveFormHandle* handle, FieldTreeHandle* value) {
+    InteractiveForm* form = reinterpret_cast<InteractiveForm*>(handle);
+    FieldTree* tree = reinterpret_cast<FieldTree*>(value);
+    RETURN_ERROR_PARAM_VALUE_IF_NULL(form);
+    RETURN_ERROR_PARAM_VALUE_IF_NULL(tree);
+
+    try {
+        form->SetFieldTree(tree);
+        return VANILLAPDF_ERROR_SUCCESS;
+    } CATCH_VANILLAPDF_EXCEPTIONS
+}
+
 VANILLAPDF_API error_type CALLING_CONVENTION InteractiveForm_GetFields(InteractiveFormHandle* handle, FieldCollectionHandle** result) {
     InteractiveForm* form = reinterpret_cast<InteractiveForm*>(handle);
     RETURN_ERROR_PARAM_VALUE_IF_NULL(form);
@@ -54,30 +82,6 @@ VANILLAPDF_API error_type CALLING_CONVENTION InteractiveForm_GetFields(Interacti
 
         auto ptr = fields.AddRefGet();
         *result = reinterpret_cast<FieldCollectionHandle*>(ptr);
-        return VANILLAPDF_ERROR_SUCCESS;
-    } CATCH_VANILLAPDF_EXCEPTIONS
-}
-
-VANILLAPDF_API error_type CALLING_CONVENTION InteractiveForm_SetFields(InteractiveFormHandle* handle, FieldCollectionHandle* value) {
-    InteractiveForm* form = reinterpret_cast<InteractiveForm*>(handle);
-    FieldCollection* fields = reinterpret_cast<FieldCollection*>(value);
-    RETURN_ERROR_PARAM_VALUE_IF_NULL(form);
-    RETURN_ERROR_PARAM_VALUE_IF_NULL(fields);
-
-    try {
-        form->SetFields(fields);
-        return VANILLAPDF_ERROR_SUCCESS;
-    } CATCH_VANILLAPDF_EXCEPTIONS
-}
-
-VANILLAPDF_API error_type CALLING_CONVENTION InteractiveForm_AddField(InteractiveFormHandle* handle, FieldHandle* value) {
-    InteractiveForm* form = reinterpret_cast<InteractiveForm*>(handle);
-    Field* field = reinterpret_cast<Field*>(value);
-    RETURN_ERROR_PARAM_VALUE_IF_NULL(form);
-    RETURN_ERROR_PARAM_VALUE_IF_NULL(field);
-
-    try {
-        form->AddField(field);
         return VANILLAPDF_ERROR_SUCCESS;
     } CATCH_VANILLAPDF_EXCEPTIONS
 }
@@ -132,49 +136,6 @@ VANILLAPDF_API error_type CALLING_CONVENTION InteractiveForm_SetNeedAppearances(
 
     try {
         form->SetNeedAppearances(value == VANILLAPDF_RV_TRUE);
-        return VANILLAPDF_ERROR_SUCCESS;
-    } CATCH_VANILLAPDF_EXCEPTIONS
-}
-
-VANILLAPDF_API error_type CALLING_CONVENTION InteractiveForm_GetFieldCount(InteractiveFormHandle* handle, size_type* result) {
-    InteractiveForm* form = reinterpret_cast<InteractiveForm*>(handle);
-    RETURN_ERROR_PARAM_VALUE_IF_NULL(form);
-    RETURN_ERROR_PARAM_VALUE_IF_NULL(result);
-
-    try {
-        *result = form->GetFieldCount();
-        return VANILLAPDF_ERROR_SUCCESS;
-    } CATCH_VANILLAPDF_EXCEPTIONS
-}
-
-VANILLAPDF_API error_type CALLING_CONVENTION InteractiveForm_GetField(InteractiveFormHandle* handle, size_type index, FieldHandle** result) {
-    InteractiveForm* form = reinterpret_cast<InteractiveForm*>(handle);
-    RETURN_ERROR_PARAM_VALUE_IF_NULL(form);
-    RETURN_ERROR_PARAM_VALUE_IF_NULL(result);
-
-    try {
-        auto field = form->GetField(index);
-        auto ptr = field.AddRefGet();
-        *result = reinterpret_cast<FieldHandle*>(ptr);
-        return VANILLAPDF_ERROR_SUCCESS;
-    } CATCH_VANILLAPDF_EXCEPTIONS
-}
-
-VANILLAPDF_API error_type CALLING_CONVENTION InteractiveForm_FindField(InteractiveFormHandle* handle, string_type qualified_name, FieldHandle** result) {
-    InteractiveForm* form = reinterpret_cast<InteractiveForm*>(handle);
-    RETURN_ERROR_PARAM_VALUE_IF_NULL(form);
-    RETURN_ERROR_PARAM_VALUE_IF_NULL(qualified_name);
-    RETURN_ERROR_PARAM_VALUE_IF_NULL(result);
-
-    try {
-        OuputFieldPtr field;
-        bool found = form->TryFindField(qualified_name, field);
-        if (!found) {
-            return VANILLAPDF_ERROR_OBJECT_MISSING;
-        }
-
-        auto ptr = field.AddRefGet();
-        *result = reinterpret_cast<FieldHandle*>(ptr);
         return VANILLAPDF_ERROR_SUCCESS;
     } CATCH_VANILLAPDF_EXCEPTIONS
 }
@@ -242,6 +203,51 @@ VANILLAPDF_API error_type CALLING_CONVENTION InteractiveForm_GetQuadding(Interac
         if (!contains) {
             return VANILLAPDF_ERROR_OBJECT_MISSING;
         }
+
+        switch (quadding) {
+            case Field::Quadding::LeftJustified:
+                *result = QuaddingType_LeftJustified; break;
+            case Field::Quadding::Centered:
+                *result = QuaddingType_Centered; break;
+            case Field::Quadding::RightJustified:
+                *result = QuaddingType_RightJustified; break;
+            default:
+                return VANILLAPDF_ERROR_GENERAL;
+        }
+
+        return VANILLAPDF_ERROR_SUCCESS;
+    } CATCH_VANILLAPDF_EXCEPTIONS
+}
+
+VANILLAPDF_API error_type CALLING_CONVENTION InteractiveForm_ResolveDefaultAppearance(InteractiveFormHandle* handle, FieldHandle* field, StringObjectHandle** result) {
+    InteractiveForm* form = reinterpret_cast<InteractiveForm*>(handle);
+    Field* resolved_field = reinterpret_cast<Field*>(field);
+    RETURN_ERROR_PARAM_VALUE_IF_NULL(form);
+    RETURN_ERROR_PARAM_VALUE_IF_NULL(resolved_field);
+    RETURN_ERROR_PARAM_VALUE_IF_NULL(result);
+
+    try {
+        OutputStringObjectPtr appearance;
+        bool contains = form->ResolveDefaultAppearance(resolved_field, appearance);
+        if (!contains) {
+            return VANILLAPDF_ERROR_OBJECT_MISSING;
+        }
+
+        auto ptr = appearance.AddRefGet();
+        *result = reinterpret_cast<StringObjectHandle*>(ptr);
+        return VANILLAPDF_ERROR_SUCCESS;
+    } CATCH_VANILLAPDF_EXCEPTIONS
+}
+
+VANILLAPDF_API error_type CALLING_CONVENTION InteractiveForm_ResolveQuadding(InteractiveFormHandle* handle, FieldHandle* field, QuaddingType* result) {
+    InteractiveForm* form = reinterpret_cast<InteractiveForm*>(handle);
+    Field* resolved_field = reinterpret_cast<Field*>(field);
+    RETURN_ERROR_PARAM_VALUE_IF_NULL(form);
+    RETURN_ERROR_PARAM_VALUE_IF_NULL(resolved_field);
+    RETURN_ERROR_PARAM_VALUE_IF_NULL(result);
+
+    try {
+        Field::Quadding quadding = form->ResolveQuadding(resolved_field);
 
         switch (quadding) {
             case Field::Quadding::LeftJustified:

--- a/src/vanillapdf/semantics/objects/catalog.cpp
+++ b/src/vanillapdf/semantics/objects/catalog.cpp
@@ -22,6 +22,8 @@ namespace semantics {
 using namespace syntax;
 
 Catalog::Catalog(syntax::DictionaryObjectPtr root) : HighLevelObject(root) {
+    m_access_lock = std::unique_ptr<std::recursive_mutex>(pdf_new std::recursive_mutex());
+
     if (root->Contains(constant::Name::Type)) {
         auto type = root->FindAs<syntax::NameObjectPtr>(constant::Name::Type);
         if (type != constant::Name::Catalog) {
@@ -183,23 +185,37 @@ bool Catalog::Outlines(OutputOutlinePtr& result) const {
 }
 
 bool Catalog::AcroForm(OuputInteractiveFormPtr& result) const {
+    ACCESS_LOCK_GUARD(m_access_lock);
+
+    if (!m_acro_form.empty()) {
+        result = m_acro_form;
+        return true;
+    }
+
     if (!_obj->Contains(constant::Name::AcroForm)) {
         return false;
     }
 
     auto form_obj = _obj->FindAs<syntax::DictionaryObjectPtr>(constant::Name::AcroForm);
-    auto interactive_form = make_deferred<InteractiveForm>(form_obj);
-    result = interactive_form;
+    m_acro_form = make_deferred<InteractiveForm>(form_obj);
+
+    result = m_acro_form;
     return true;
 }
 
 void Catalog::SetAcroForm(InteractiveFormPtr value) {
+    ACCESS_LOCK_GUARD(m_access_lock);
 
     // The form is an indirect object, so the catalog stores a reference to it
     auto form_object = value->GetObject();
     IndirectReferenceObjectPtr reference = make_deferred<syntax::IndirectReferenceObject>(form_object);
 
     _obj->Insert(constant::Name::AcroForm, reference, true);
+
+    // The instance handed out is resolved by the getter alone - dropping
+    // the resolved one makes the next AcroForm() pick up the installed
+    // dictionary
+    m_acro_form = OuputInteractiveFormPtr();
 }
 
 bool Catalog::GetOpenAction(syntax::ObjectPtr& result) const {

--- a/src/vanillapdf/semantics/objects/catalog.cpp
+++ b/src/vanillapdf/semantics/objects/catalog.cpp
@@ -212,10 +212,11 @@ void Catalog::SetAcroForm(InteractiveFormPtr value) {
 
     _obj->Insert(constant::Name::AcroForm, reference, true);
 
-    // The instance handed out is resolved by the getter alone - dropping
-    // the resolved one makes the next AcroForm() pick up the installed
-    // dictionary
-    m_acro_form = OuputInteractiveFormPtr();
+    // The installed instance is the one handed out from now on, so that the
+    // caller's handle and everyone reaching the form through the catalog -
+    // Document::Sign included - share a single form, and with it a single
+    // field tree
+    m_acro_form = value;
 }
 
 bool Catalog::GetOpenAction(syntax::ObjectPtr& result) const {

--- a/src/vanillapdf/semantics/objects/catalog.h
+++ b/src/vanillapdf/semantics/objects/catalog.h
@@ -16,6 +16,8 @@
 #include "utils/pdf_version.h"
 #include "utils/cached_value.h"
 
+#include <mutex>
+
 namespace vanillapdf {
 namespace semantics {
 
@@ -56,6 +58,12 @@ public:
     bool Destinations(OutputNamedDestinationsPtr& result) const;
     bool Names(OutputNameDictionaryPtr& result) const;
     void SetNames(NameDictionaryPtr value);
+    // The interactive form over the /AcroForm entry. Resolved once and then
+    // handed out unchanged, so that the field tree the form owns is shared
+    // by everyone reaching the form through the catalog - Document::Sign
+    // included. SetAcroForm installs the form's dictionary and drops the
+    // resolved instance; the instance to work with afterwards is the one
+    // AcroForm hands out, not the argument.
     bool AcroForm(OuputInteractiveFormPtr& result) const;
     void SetAcroForm(InteractiveFormPtr value);
 
@@ -67,6 +75,13 @@ private:
     bool ResolvePages(OutputPageTreePtr& result) const;
 
     CachedValue<OutputPageTreePtr> m_pages;
+
+    // The form instance is resolved once from /AcroForm by the getter and
+    // then handed out unchanged; the setter drops it. A value that can be
+    // dropped is outside the compute-once contract of CachedValue, whose
+    // lock-free fast path would race the reset.
+    mutable std::unique_ptr<std::recursive_mutex> m_access_lock;
+    mutable OuputInteractiveFormPtr m_acro_form;
 };
 
 } // semantics

--- a/src/vanillapdf/semantics/objects/catalog.h
+++ b/src/vanillapdf/semantics/objects/catalog.h
@@ -58,12 +58,10 @@ public:
     bool Destinations(OutputNamedDestinationsPtr& result) const;
     bool Names(OutputNameDictionaryPtr& result) const;
     void SetNames(NameDictionaryPtr value);
-    // The interactive form over the /AcroForm entry. Resolved once and then
-    // handed out unchanged, so that the field tree the form owns is shared
-    // by everyone reaching the form through the catalog - Document::Sign
-    // included. SetAcroForm installs the form's dictionary and drops the
-    // resolved instance; the instance to work with afterwards is the one
-    // AcroForm hands out, not the argument.
+    // The interactive form over the /AcroForm entry. One instance per
+    // catalog, so that the field tree the form owns is shared by everyone
+    // reaching the form through the catalog - Document::Sign included; the
+    // instance installed by SetAcroForm is the one handed out.
     bool AcroForm(OuputInteractiveFormPtr& result) const;
     void SetAcroForm(InteractiveFormPtr value);
 
@@ -76,10 +74,10 @@ private:
 
     CachedValue<OutputPageTreePtr> m_pages;
 
-    // The form instance is resolved once from /AcroForm by the getter and
-    // then handed out unchanged; the setter drops it. A value that can be
-    // dropped is outside the compute-once contract of CachedValue, whose
-    // lock-free fast path would race the reset.
+    // The form instance is resolved once from /AcroForm and then handed out
+    // unchanged, or installed by SetAcroForm. The setter can replace it, so
+    // the lock-free fast path of CachedValue does not apply - the same
+    // arrangement InteractiveForm keeps for its field tree.
     mutable std::unique_ptr<std::recursive_mutex> m_access_lock;
     mutable OuputInteractiveFormPtr m_acro_form;
 };

--- a/src/vanillapdf/semantics/objects/document.cpp
+++ b/src/vanillapdf/semantics/objects/document.cpp
@@ -319,13 +319,7 @@ NameDictionaryPtr Document::CreateNameDictionary(CatalogPtr catalog) {
 InteractiveFormPtr Document::CreateAcroForm(CatalogPtr catalog) {
     auto created_form = InteractiveForm::Create(m_holder);
     catalog->SetAcroForm(created_form);
-
-    // The catalog hands out one form instance to everyone, so the one to
-    // return is the one it resolves over the installed dictionary
-    OuputInteractiveFormPtr installed_form;
-    catalog->AcroForm(installed_form);
-
-    return installed_form;
+    return created_form;
 }
 
 NameTreePtr<DestinationPtr> Document::CreateStringDestinations(NameDictionaryPtr dictionary) {

--- a/src/vanillapdf/semantics/objects/document.cpp
+++ b/src/vanillapdf/semantics/objects/document.cpp
@@ -317,20 +317,15 @@ NameDictionaryPtr Document::CreateNameDictionary(CatalogPtr catalog) {
 }
 
 InteractiveFormPtr Document::CreateAcroForm(CatalogPtr catalog) {
-    auto entry = m_holder->AllocateNewEntry();
+    auto created_form = InteractiveForm::Create(m_holder);
+    catalog->SetAcroForm(created_form);
 
-    DictionaryObjectPtr raw_dictionary;
-    raw_dictionary->SetFile(m_holder);
-    raw_dictionary->SetInitialized();
-    entry->SetReference(raw_dictionary);
-    entry->SetInitialized();
+    // The catalog hands out one form instance to everyone, so the one to
+    // return is the one it resolves over the installed dictionary
+    OuputInteractiveFormPtr installed_form;
+    catalog->AcroForm(installed_form);
 
-    auto raw_catalog = catalog->GetObject();
-
-    IndirectReferenceObjectPtr ref = make_deferred<IndirectReferenceObject>(raw_dictionary);
-    raw_catalog->Insert(constant::Name::AcroForm, ref);
-
-    return make_deferred<InteractiveForm>(raw_dictionary);
+    return installed_form;
 }
 
 NameTreePtr<DestinationPtr> Document::CreateStringDestinations(NameDictionaryPtr dictionary) {
@@ -803,10 +798,8 @@ void Document::Sign(FilePtr destination, DocumentSignatureSettingsPtr options) {
     signature_annotation->Insert(constant::Name::V, signature_dictionary_reference);
 
     OuputInteractiveFormPtr interactive_form;
-    bool has_interactive_form = catalog->AcroForm(interactive_form);
-    if (!has_interactive_form) {
+    if (!catalog->AcroForm(interactive_form)) {
         interactive_form = CreateAcroForm(catalog);
-        assert(!interactive_form.empty() && "CreateAcroForm returned empty result");
     }
 
     // Update signature flags
@@ -823,14 +816,13 @@ void Document::Sign(FilePtr destination, DocumentSignatureSettingsPtr options) {
     }
 
     // Fully qualified names shall be unique (12.7.3.2) and the tree
-    // refuses a duplicate, so a document signed before gets the next
-    // number
+    // refuses a duplicate - carried by a terminal or a group alike - so a
+    // document signed before, or one with a group of that name, gets the
+    // next number. The probe asks the same authority the refusal uses.
     std::string signature_field_name;
     for (types::size_type ordinal = 1;; ++ordinal) {
         signature_field_name = fmt::format("Signature{}", ordinal);
-
-        OuputFieldPtr existing_field;
-        if (!field_tree->TryFindField(signature_field_name, existing_field)) {
+        if (!field_tree->ContainsName(signature_field_name)) {
             break;
         }
     }

--- a/src/vanillapdf/semantics/objects/document.cpp
+++ b/src/vanillapdf/semantics/objects/document.cpp
@@ -10,6 +10,8 @@
 #include "syntax/utils/serialization_override_object_attribute.h"
 
 #include "semantics/objects/document.h"
+#include "semantics/objects/field_tree.h"
+#include "semantics/objects/fields.h"
 #include "semantics/objects/page_contents.h"
 #include "semantics/objects/annotations.h"
 #include "semantics/objects/name_dictionary.h"
@@ -796,7 +798,6 @@ void Document::Sign(FilePtr destination, DocumentSignatureSettingsPtr options) {
 
     // Create new signature field
     signature_annotation->Insert(constant::Name::FT, NameObject::CreateFromDecoded("Sig"));
-    signature_annotation->Insert(constant::Name::T, LiteralStringObject::CreateFromDecoded("Signature1"));
 
     auto signature_dictionary_reference = make_deferred<syntax::IndirectReferenceObject>(signature_dictionary);
     signature_annotation->Insert(constant::Name::V, signature_dictionary_reference);
@@ -813,13 +814,31 @@ void Document::Sign(FilePtr destination, DocumentSignatureSettingsPtr options) {
     signature_flags->SetSignaturesExist(true);
     signature_flags->SetAppendOnly(true);
 
-    // Create signature field dictionary within AcroForm
-    auto fields = interactive_form->CreateFields();
-    auto fields_obj = fields->GetObject();
-    auto fields_array = fields_obj->Data();
+    // The signature field joins the hierarchy the way any field does -
+    // through the tree, so that a tree the caller already holds sees it
+    OutputFieldTreePtr field_tree;
+    if (!interactive_form->GetFieldTree(field_tree)) {
+        field_tree = FieldTree::Create(m_holder);
+        interactive_form->SetFieldTree(field_tree);
+    }
 
-    auto signature_fields_reference = make_deferred<syntax::IndirectReferenceObject>(signature_annotation);
-    fields_array->Append(signature_fields_reference);
+    // Fully qualified names shall be unique (12.7.3.2) and the tree
+    // refuses a duplicate, so a document signed before gets the next
+    // number
+    std::string signature_field_name;
+    for (types::size_type ordinal = 1;; ++ordinal) {
+        signature_field_name = fmt::format("Signature{}", ordinal);
+
+        OuputFieldPtr existing_field;
+        if (!field_tree->TryFindField(signature_field_name, existing_field)) {
+            break;
+        }
+    }
+
+    signature_annotation->Insert(constant::Name::T, LiteralStringObject::CreateFromDecoded(signature_field_name));
+
+    auto signature_field = Field::Create(signature_annotation);
+    field_tree->AddRootChild(signature_field);
 
     // TODO:
     // Move the signature creation logic to new callback IFileWriterObserver::OnAfterXrefClone

--- a/src/vanillapdf/semantics/objects/field_tree.cpp
+++ b/src/vanillapdf/semantics/objects/field_tree.cpp
@@ -423,11 +423,9 @@ void FieldTree::ValidateInsertion(const syntax::OutputDictionaryObjectPtr& paren
         LOG_ERROR_AND_THROW(InvalidParameterException, "The field dictionary shall be an indirect object - allocate a cross-reference entry for it first");
     }
 
-    if (IsMember(child_dictionary)) {
-        LOG_ERROR_AND_THROW(InvalidParameterException, "The field already belongs to this field hierarchy");
-    }
+    EnsureCacheBuilt();
 
-    std::string qualified_name;
+    std::string parent_name;
 
     if (!parent.empty()) {
         auto parent_dictionary = *parent;
@@ -454,19 +452,59 @@ void FieldTree::ValidateInsertion(const syntax::OutputDictionaryObjectPtr& paren
             LOG_ERROR_AND_THROW(InvalidParameterException, "A field merged with its widget annotation cannot take child fields");
         }
 
-        qualified_name = GetMemberQualifiedName(parent_dictionary);
+        parent_name = GetMemberQualifiedName(parent_dictionary);
     }
 
-    // Fully qualified names shall be unique (12.7.3.2). The name the child
-    // would take is the parent's name extended by the child's partial name
-    // - the same way the walk will name it once it is in place; a child
-    // without a /T has no name of its own to collide with.
-    if (child_dictionary->Contains(constant::Name::T)) {
-        qualified_name = QualifiedNameOf(qualified_name, child_dictionary);
+    // The child may bring a subtree of its own - every node of it becomes
+    // a node of this tree and is held to the same rules, under the name
+    // the walk will give it once the child is in place
+    std::set<std::string> subtree_names;
+    std::unordered_set<syntax::DictionaryObjectPtr, DeferredIdentityHash<syntax::DictionaryObject>, DeferredIdentityEqual<syntax::DictionaryObject>> subtree_nodes;
+    ValidateSubtree(child_dictionary, parent_name, subtree_names, subtree_nodes);
+}
 
+void FieldTree::ValidateSubtree(
+    const syntax::DictionaryObjectPtr& node,
+    const std::string& parent_name,
+    std::set<std::string>& subtree_names,
+    std::unordered_set<syntax::DictionaryObjectPtr, DeferredIdentityHash<syntax::DictionaryObject>, DeferredIdentityEqual<syntax::DictionaryObject>>& subtree_nodes) const {
+
+    // A node reached twice within the subtree is enumerated once by the
+    // walk, so it is judged once here
+    if (!subtree_nodes.insert(node).second) {
+        return;
+    }
+
+    if (m_nodes.find(node) != m_nodes.end()) {
+        LOG_ERROR_AND_THROW(InvalidParameterException, "The field {} {} R already belongs to this field hierarchy", node->GetObjectNumber(), node->GetGenerationNumber());
+    }
+
+    // Fully qualified names shall be unique (12.7.3.2) - within this tree
+    // and within the subtree itself; a node without a /T has no name of its
+    // own to collide with
+    auto qualified_name = QualifiedNameOf(parent_name, node);
+    if (node->Contains(constant::Name::T)) {
         if (m_names.find(qualified_name) != m_names.end()) {
             LOG_ERROR_AND_THROW(InvalidParameterException, "A field with the fully qualified name \"{}\" already exists in this field hierarchy", qualified_name);
         }
+
+        if (!subtree_names.insert(qualified_name).second) {
+            LOG_ERROR_AND_THROW(InvalidParameterException, "The fully qualified name \"{}\" is taken by more than one field of the subtree being added", qualified_name);
+        }
+    }
+
+    if (Field::IsTerminalDictionary(node)) {
+        return;
+    }
+
+    auto kids = node->FindAs<syntax::MixedArrayObjectPtr>(constant::Name::Kids);
+    for (auto entry : kids) {
+        syntax::OutputDictionaryObjectPtr kid;
+        if (Field::ClassifyChildEntry(entry, kid) != Field::ChildEntryType::Field) {
+            continue;
+        }
+
+        ValidateSubtree(*kid, qualified_name, subtree_names, subtree_nodes);
     }
 }
 

--- a/src/vanillapdf/semantics/objects/field_tree.cpp
+++ b/src/vanillapdf/semantics/objects/field_tree.cpp
@@ -174,15 +174,22 @@ void FieldTree::RemoveChild(FieldPtr field) {
     // field to the root array, a wrong one to another node's /Kids.
     auto traversal_parent = node->second;
 
-    syntax::ArrayObjectPtr<syntax::IndirectReferenceObjectPtr> container = _obj;
+    syntax::MixedArrayObjectPtr container = _obj->Data();
     if (!traversal_parent.empty()) {
-        container = traversal_parent->FindAs<syntax::ArrayObjectPtr<syntax::IndirectReferenceObjectPtr>>(constant::Name::Kids);
+        container = traversal_parent->FindAs<syntax::MixedArrayObjectPtr>(constant::Name::Kids);
     }
 
+    // Only a reference can be this node - the walk skips every other kind
+    // of entry, so none of them ever became a member
     bool removed = false;
     auto container_size = container->GetSize();
     for (decltype(container_size) i = 0; i < container_size; ++i) {
-        auto entry_reference = container->GetValue(i);
+        syntax::ObjectPtr entry = container->GetValue(i);
+        if (!syntax::ObjectUtils::IsType<syntax::IndirectReferenceObjectPtr>(entry)) {
+            continue;
+        }
+
+        auto entry_reference = syntax::ObjectUtils::ConvertTo<syntax::IndirectReferenceObjectPtr>(entry);
         if (!entry_reference->GetReferencedObject()->Identity(field_dictionary)) {
             continue;
         }
@@ -228,9 +235,11 @@ void FieldTree::EnsureCacheBuilt() const {
 void FieldTree::BuildFieldCache() const {
 
     // Both /Fields and /Kids shall contain indirect references (Table 218,
-    // Table 220), so the tree is walked as references and every node is
-    // dereferenced only after the cycle check - the same way PageTree types
-    // its kids array.
+    // Table 220). The arrays are walked untyped and every entry classified
+    // by Field::ClassifyChildEntry - the same classification the field's
+    // own child walk applies - so a malformed entry is skipped with a
+    // warning here exactly where it is skipped there, and every node is
+    // dereferenced only after the cycle check.
     //
     // Malformed documents can link /Kids in a cycle. Visited nodes are
     // tracked by their object identity, the same way Field guards its
@@ -238,14 +247,19 @@ void FieldTree::BuildFieldCache() const {
     std::map<syntax::IndirectReferenceId, bool> visited;
     syntax::OutputDictionaryObjectPtr root_level;
 
-    for (auto field_reference : _obj) {
-        auto root_child = field_reference->GetReferencedObjectAs<syntax::DictionaryObjectPtr>();
+    for (auto entry : _obj->Data()) {
+        syntax::OutputDictionaryObjectPtr root_child;
+        auto entry_type = Field::ClassifyChildEntry(entry, root_child);
+        if (entry_type == Field::ChildEntryType::Malformed) {
+            continue;
+        }
+
+        auto field_reference = syntax::ObjectUtils::ConvertTo<syntax::IndirectReferenceObjectPtr>(entry);
 
         // The root array holds fields only (Table 218) - widget
         // annotations belong to a field's /Kids. A dictionary here that is
-        // not a field is a stray entry, classified the same way a /Kids
-        // entry is and skipped the same way
-        if (!Field::IsFieldDictionary(root_child)) {
+        // not a field is a stray entry, skipped the same way
+        if (entry_type != Field::ChildEntryType::Field) {
             spdlog::warn("Root /Fields entry {} {} R is not a field dictionary and is skipped", field_reference->GetReferencedObjectNumber(), field_reference->GetReferencedGenerationNumber());
             continue;
         }
@@ -253,12 +267,12 @@ void FieldTree::BuildFieldCache() const {
         // A node listed twice - or already reached through some /Kids - is
         // enumerated where it was first reached; the root view shows what
         // the walk shows
-        if (m_nodes.find(root_child) != m_nodes.end()) {
+        if (m_nodes.find(*root_child) != m_nodes.end()) {
             spdlog::warn("Root /Fields entry {} {} R was already reached - only the first path is enumerated", field_reference->GetReferencedObjectNumber(), field_reference->GetReferencedGenerationNumber());
             continue;
         }
 
-        m_root_children.push_back(root_child);
+        m_root_children.push_back(*root_child);
         BuildFieldCacheInternal(field_reference, root_level, visited);
     }
 
@@ -333,13 +347,14 @@ void FieldTree::BuildFieldCacheInternal(
 
     // Only field dictionaries are hierarchy nodes - widget annotations stay
     // attached to their field (12.7.3.2)
-    auto kids = node->FindAs<syntax::ArrayObjectPtr<syntax::IndirectReferenceObjectPtr>>(constant::Name::Kids);
-    for (auto kid_reference : kids) {
-        auto kid = kid_reference->GetReferencedObjectAs<syntax::DictionaryObjectPtr>();
-        if (!Field::IsFieldDictionary(kid)) {
+    auto kids = node->FindAs<syntax::MixedArrayObjectPtr>(constant::Name::Kids);
+    for (auto entry : kids) {
+        syntax::OutputDictionaryObjectPtr kid;
+        if (Field::ClassifyChildEntry(entry, kid) != Field::ChildEntryType::Field) {
             continue;
         }
 
+        auto kid_reference = syntax::ObjectUtils::ConvertTo<syntax::IndirectReferenceObjectPtr>(entry);
         BuildFieldCacheInternal(kid_reference, syntax::OutputDictionaryObjectPtr(node), visited);
     }
 }

--- a/src/vanillapdf/semantics/objects/field_tree.cpp
+++ b/src/vanillapdf/semantics/objects/field_tree.cpp
@@ -90,6 +90,13 @@ bool FieldTree::TryFindField(std::string_view qualified_name, OuputFieldPtr& res
     return true;
 }
 
+bool FieldTree::ContainsName(std::string_view qualified_name) const {
+    ACCESS_LOCK_GUARD(m_cache_lock);
+
+    EnsureIndexBuilt();
+    return m_names.find(std::string(qualified_name)) != m_names.end();
+}
+
 // Structure
 
 types::size_type FieldTree::GetRootChildCount() const {

--- a/src/vanillapdf/semantics/objects/field_tree.cpp
+++ b/src/vanillapdf/semantics/objects/field_tree.cpp
@@ -14,6 +14,27 @@
 namespace vanillapdf {
 namespace semantics {
 
+// The walk's fully qualified name of a node: the traversal parent's name
+// extended by the node's own /T. A node without a /T contributes no
+// segment and shares its parent's name (12.7.3.2).
+static std::string QualifiedNameOf(const std::string& parent_name, const syntax::DictionaryObjectPtr& node) {
+    if (!node->Contains(constant::Name::T)) {
+        return parent_name;
+    }
+
+    auto partial_name = node->FindAs<syntax::StringObjectPtr>(constant::Name::T);
+
+    // /T is a text string (7.9.2.2) - normalizing every segment to UTF-8
+    // lets PDFDocEncoding and UTF-16BE partial names join into a single
+    // coherent name
+    auto partial_name_utf8 = TextStringEncoding::ToUtf8(partial_name->GetValue()->ToStringView());
+    if (parent_name.empty()) {
+        return partial_name_utf8;
+    }
+
+    return parent_name + "." + partial_name_utf8;
+}
+
 FieldTree::FieldTree(syntax::ArrayObjectPtr<syntax::IndirectReferenceObjectPtr> fields) : HighLevelObject(fields) {
     m_cache_lock = std::unique_ptr<std::recursive_mutex>(pdf_new std::recursive_mutex());
 }
@@ -273,7 +294,7 @@ void FieldTree::BuildFieldCache() const {
         }
 
         m_root_children.push_back(*root_child);
-        BuildFieldCacheInternal(field_reference, root_level, visited);
+        BuildFieldCacheInternal(field_reference, root_level, std::string(), visited);
     }
 
     m_cache_built = true;
@@ -282,6 +303,7 @@ void FieldTree::BuildFieldCache() const {
 void FieldTree::BuildFieldCacheInternal(
     syntax::IndirectReferenceObjectPtr node_reference,
     const syntax::OutputDictionaryObjectPtr& traversal_parent,
+    const std::string& parent_name,
     std::map<syntax::IndirectReferenceId, bool>& visited) const {
 
     auto object_number = node_reference->GetReferencedObjectNumber();
@@ -303,9 +325,10 @@ void FieldTree::BuildFieldCacheInternal(
     m_nodes.emplace(node, traversal_parent);
 
     // A /Parent that disagrees with the /Kids entry that reached the node
-    // is the other common way a file is already dirty - the fully qualified
-    // name follows /Parent, the enumeration follows /Kids, and the two
-    // diverge from here on. Reported, not repaired.
+    // is the other common way a file is already dirty. Reported, not
+    // repaired: the walk is the authority for the name and the container,
+    // and Field::GetQualifiedName, which follows /Parent, diverges from
+    // here on.
     bool parent_is_root = traversal_parent.empty();
     if (node->Contains(constant::Name::Parent)) {
         auto parent_obj = node->Find(constant::Name::Parent);
@@ -326,10 +349,8 @@ void FieldTree::BuildFieldCacheInternal(
     // without one shares its parent's fully qualified name (12.7.3.2) and
     // would only ever report a false duplicate
     bool terminal = Field::IsTerminalDictionary(node);
+    auto name = QualifiedNameOf(parent_name, node);
     if (node->Contains(constant::Name::T)) {
-        auto field = Field::Create(node);
-        auto name = field->GetQualifiedName()->ToString();
-
         auto inserted = m_names.insert(name);
         if (!inserted.second) {
             spdlog::warn("Duplicate fully qualified field name \"{}\" - lookups resolve to the first field in document order", name);
@@ -355,7 +376,7 @@ void FieldTree::BuildFieldCacheInternal(
         }
 
         auto kid_reference = syntax::ObjectUtils::ConvertTo<syntax::IndirectReferenceObjectPtr>(entry);
-        BuildFieldCacheInternal(kid_reference, syntax::OutputDictionaryObjectPtr(node), visited);
+        BuildFieldCacheInternal(kid_reference, syntax::OutputDictionaryObjectPtr(node), name, visited);
     }
 }
 
@@ -364,6 +385,20 @@ void FieldTree::BuildFieldCacheInternal(
 bool FieldTree::IsMember(const syntax::DictionaryObjectPtr& dictionary) const {
     EnsureCacheBuilt();
     return m_nodes.find(dictionary) != m_nodes.end();
+}
+
+std::string FieldTree::GetMemberQualifiedName(const syntax::DictionaryObjectPtr& dictionary) const {
+    auto node = m_nodes.find(dictionary);
+    assert(node != m_nodes.end() && "The caller checks membership first");
+
+    // The chain of traversal parents ends at the root level, which has no
+    // name; it cannot cycle, since the walk visits every node once
+    std::string parent_name;
+    if (!node->second.empty()) {
+        parent_name = GetMemberQualifiedName(*node->second);
+    }
+
+    return QualifiedNameOf(parent_name, dictionary);
 }
 
 syntax::ArrayObjectPtr<syntax::IndirectReferenceObjectPtr> FieldTree::CreateKids(syntax::DictionaryObjectPtr parent) {
@@ -419,22 +454,15 @@ void FieldTree::ValidateInsertion(const syntax::OutputDictionaryObjectPtr& paren
             LOG_ERROR_AND_THROW(InvalidParameterException, "A field merged with its widget annotation cannot take child fields");
         }
 
-        auto parent_field = Field::Create(parent_dictionary);
-        qualified_name = parent_field->GetQualifiedName()->ToString();
+        qualified_name = GetMemberQualifiedName(parent_dictionary);
     }
 
     // Fully qualified names shall be unique (12.7.3.2). The name the child
-    // would take is the parent's name extended by the child's partial name;
-    // a child without a /T has no name of its own to collide with.
+    // would take is the parent's name extended by the child's partial name
+    // - the same way the walk will name it once it is in place; a child
+    // without a /T has no name of its own to collide with.
     if (child_dictionary->Contains(constant::Name::T)) {
-        auto child_partial_name = child_dictionary->FindAs<syntax::StringObjectPtr>(constant::Name::T);
-        auto child_partial_name_utf8 = TextStringEncoding::ToUtf8(child_partial_name->GetValue()->ToStringView());
-
-        if (!qualified_name.empty()) {
-            qualified_name += ".";
-        }
-
-        qualified_name += child_partial_name_utf8;
+        qualified_name = QualifiedNameOf(qualified_name, child_dictionary);
 
         if (m_names.find(qualified_name) != m_names.end()) {
             LOG_ERROR_AND_THROW(InvalidParameterException, "A field with the fully qualified name \"{}\" already exists in this field hierarchy", qualified_name);

--- a/src/vanillapdf/semantics/objects/field_tree.cpp
+++ b/src/vanillapdf/semantics/objects/field_tree.cpp
@@ -69,17 +69,22 @@ bool FieldTree::TryFindField(std::string_view qualified_name, OuputFieldPtr& res
 // Structure
 
 types::size_type FieldTree::GetRootChildCount() const {
-    return _obj->GetSize();
+    ACCESS_LOCK_GUARD(m_cache_lock);
+
+    EnsureCacheBuilt();
+    return m_root_children.size();
 }
 
 FieldPtr FieldTree::GetRootChild(types::size_type index) const {
-    if (index >= _obj->GetSize()) {
+    ACCESS_LOCK_GUARD(m_cache_lock);
+
+    EnsureCacheBuilt();
+
+    if (index >= m_root_children.size()) {
         LOG_ERROR_AND_THROW(syntax::ObjectMissingException, "Root child index out of range: {}", index);
     }
 
-    auto child_reference = _obj->GetValue(index);
-    auto child = child_reference->GetReferencedObjectAs<syntax::DictionaryObjectPtr>();
-    return Field::Create(child);
+    return Field::Create(m_root_children[index]);
 }
 
 void FieldTree::AddRootChild(FieldPtr child) {
@@ -204,6 +209,7 @@ void FieldTree::RemoveChild(FieldPtr field) {
 void FieldTree::Invalidate() {
     ACCESS_LOCK_GUARD(m_cache_lock);
 
+    m_root_children.clear();
     m_field_cache.clear();
     m_nodes.clear();
     m_terminal_index.clear();
@@ -233,6 +239,26 @@ void FieldTree::BuildFieldCache() const {
     syntax::OutputDictionaryObjectPtr root_level;
 
     for (auto field_reference : _obj) {
+        auto root_child = field_reference->GetReferencedObjectAs<syntax::DictionaryObjectPtr>();
+
+        // The root array holds fields only (Table 218) - widget
+        // annotations belong to a field's /Kids. A dictionary here that is
+        // not a field is a stray entry, classified the same way a /Kids
+        // entry is and skipped the same way
+        if (!Field::IsFieldDictionary(root_child)) {
+            spdlog::warn("Root /Fields entry {} {} R is not a field dictionary and is skipped", field_reference->GetReferencedObjectNumber(), field_reference->GetReferencedGenerationNumber());
+            continue;
+        }
+
+        // A node listed twice - or already reached through some /Kids - is
+        // enumerated where it was first reached; the root view shows what
+        // the walk shows
+        if (m_nodes.find(root_child) != m_nodes.end()) {
+            spdlog::warn("Root /Fields entry {} {} R was already reached - only the first path is enumerated", field_reference->GetReferencedObjectNumber(), field_reference->GetReferencedGenerationNumber());
+            continue;
+        }
+
+        m_root_children.push_back(root_child);
         BuildFieldCacheInternal(field_reference, root_level, visited);
     }
 

--- a/src/vanillapdf/semantics/objects/field_tree.cpp
+++ b/src/vanillapdf/semantics/objects/field_tree.cpp
@@ -60,14 +60,14 @@ FieldTreePtr FieldTree::Create(syntax::FilePtr file) {
 types::size_type FieldTree::GetFieldCount() const {
     ACCESS_LOCK_GUARD(m_cache_lock);
 
-    EnsureCacheBuilt();
+    EnsureViewsBuilt();
     return m_field_cache.size();
 }
 
 FieldPtr FieldTree::GetField(types::size_type index) const {
     ACCESS_LOCK_GUARD(m_cache_lock);
 
-    EnsureCacheBuilt();
+    EnsureViewsBuilt();
 
     if (index >= m_field_cache.size()) {
         LOG_ERROR_AND_THROW(syntax::ObjectMissingException, "Field index out of range: {}", index);
@@ -79,7 +79,7 @@ FieldPtr FieldTree::GetField(types::size_type index) const {
 bool FieldTree::TryFindField(std::string_view qualified_name, OuputFieldPtr& result) const {
     ACCESS_LOCK_GUARD(m_cache_lock);
 
-    EnsureCacheBuilt();
+    EnsureViewsBuilt();
 
     auto found = m_terminal_index.find(std::string(qualified_name));
     if (found == m_terminal_index.end()) {
@@ -95,14 +95,14 @@ bool FieldTree::TryFindField(std::string_view qualified_name, OuputFieldPtr& res
 types::size_type FieldTree::GetRootChildCount() const {
     ACCESS_LOCK_GUARD(m_cache_lock);
 
-    EnsureCacheBuilt();
+    EnsureViewsBuilt();
     return m_root_children.size();
 }
 
 FieldPtr FieldTree::GetRootChild(types::size_type index) const {
     ACCESS_LOCK_GUARD(m_cache_lock);
 
-    EnsureCacheBuilt();
+    EnsureViewsBuilt();
 
     if (index >= m_root_children.size()) {
         LOG_ERROR_AND_THROW(syntax::ObjectMissingException, "Root child index out of range: {}", index);
@@ -115,21 +115,25 @@ void FieldTree::AddRootChild(FieldPtr child) {
     ACCESS_LOCK_GUARD(m_cache_lock);
 
     syntax::OutputDictionaryObjectPtr root_level;
-    ValidateInsertion(root_level, child);
+    NodeMap subtree_nodes;
+    std::set<std::string> subtree_names;
+    ValidateInsertion(root_level, child, subtree_nodes, subtree_names);
 
     auto child_dictionary = child->GetObject();
     auto child_reference = make_deferred<syntax::IndirectReferenceObject>(child_dictionary);
     _obj->Append(child_reference);
 
     LinkChild(root_level, child_dictionary);
-    Invalidate();
+    ExtendIndex(subtree_nodes, subtree_names);
 }
 
 void FieldTree::InsertRootChild(types::size_type index, FieldPtr child) {
     ACCESS_LOCK_GUARD(m_cache_lock);
 
     syntax::OutputDictionaryObjectPtr root_level;
-    ValidateInsertion(root_level, child);
+    NodeMap subtree_nodes;
+    std::set<std::string> subtree_names;
+    ValidateInsertion(root_level, child, subtree_nodes, subtree_names);
 
     // An index equal to the size appends, the array refuses anything beyond
     if (index > _obj->GetSize()) {
@@ -141,14 +145,16 @@ void FieldTree::InsertRootChild(types::size_type index, FieldPtr child) {
     _obj->Insert(index, child_reference);
 
     LinkChild(root_level, child_dictionary);
-    Invalidate();
+    ExtendIndex(subtree_nodes, subtree_names);
 }
 
 void FieldTree::AddChild(FieldPtr parent, FieldPtr child) {
     ACCESS_LOCK_GUARD(m_cache_lock);
 
     syntax::OutputDictionaryObjectPtr parent_dictionary(parent->GetObject());
-    ValidateInsertion(parent_dictionary, child);
+    NodeMap subtree_nodes;
+    std::set<std::string> subtree_names;
+    ValidateInsertion(parent_dictionary, child, subtree_nodes, subtree_names);
 
     auto child_dictionary = child->GetObject();
     auto child_reference = make_deferred<syntax::IndirectReferenceObject>(child_dictionary);
@@ -157,14 +163,16 @@ void FieldTree::AddChild(FieldPtr parent, FieldPtr child) {
     kids->Append(child_reference);
 
     LinkChild(parent_dictionary, child_dictionary);
-    Invalidate();
+    ExtendIndex(subtree_nodes, subtree_names);
 }
 
 void FieldTree::InsertChild(FieldPtr parent, types::size_type index, FieldPtr child) {
     ACCESS_LOCK_GUARD(m_cache_lock);
 
     syntax::OutputDictionaryObjectPtr parent_dictionary(parent->GetObject());
-    ValidateInsertion(parent_dictionary, child);
+    NodeMap subtree_nodes;
+    std::set<std::string> subtree_names;
+    ValidateInsertion(parent_dictionary, child, subtree_nodes, subtree_names);
 
     auto kids = CreateKids(*parent_dictionary);
 
@@ -178,13 +186,13 @@ void FieldTree::InsertChild(FieldPtr parent, types::size_type index, FieldPtr ch
     kids->Insert(index, child_reference);
 
     LinkChild(parent_dictionary, child_dictionary);
-    Invalidate();
+    ExtendIndex(subtree_nodes, subtree_names);
 }
 
 void FieldTree::RemoveChild(FieldPtr field) {
     ACCESS_LOCK_GUARD(m_cache_lock);
 
-    EnsureCacheBuilt();
+    EnsureIndexBuilt();
 
     auto field_dictionary = field->GetObject();
     auto node = m_nodes.find(field_dictionary);
@@ -245,18 +253,30 @@ void FieldTree::Invalidate() {
     m_nodes.clear();
     m_terminal_index.clear();
     m_names.clear();
-    m_cache_built = false;
+    m_index_built = false;
+    m_views_built = false;
 }
 
 // Cache
 
-void FieldTree::EnsureCacheBuilt() const {
-    if (!m_cache_built) {
+void FieldTree::EnsureIndexBuilt() const {
+    if (!m_index_built) {
+        BuildFieldCache();
+    }
+}
+
+void FieldTree::EnsureViewsBuilt() const {
+    if (!m_views_built) {
         BuildFieldCache();
     }
 }
 
 void FieldTree::BuildFieldCache() const {
+    m_nodes.clear();
+    m_names.clear();
+    m_root_children.clear();
+    m_field_cache.clear();
+    m_terminal_index.clear();
 
     // Both /Fields and /Kids shall contain indirect references (Table 218,
     // Table 220). The arrays are walked untyped and every entry classified
@@ -300,7 +320,8 @@ void FieldTree::BuildFieldCache() const {
         BuildFieldCacheInternal(field_reference, root_level, std::string(), visited);
     }
 
-    m_cache_built = true;
+    m_index_built = true;
+    m_views_built = true;
 }
 
 void FieldTree::BuildFieldCacheInternal(
@@ -386,7 +407,7 @@ void FieldTree::BuildFieldCacheInternal(
 // Helpers
 
 bool FieldTree::IsMember(const syntax::DictionaryObjectPtr& dictionary) const {
-    EnsureCacheBuilt();
+    EnsureIndexBuilt();
     return m_nodes.find(dictionary) != m_nodes.end();
 }
 
@@ -416,7 +437,11 @@ syntax::ArrayObjectPtr<syntax::IndirectReferenceObjectPtr> FieldTree::CreateKids
     return parent->FindAs<syntax::ArrayObjectPtr<syntax::IndirectReferenceObjectPtr>>(constant::Name::Kids);
 }
 
-void FieldTree::ValidateInsertion(const syntax::OutputDictionaryObjectPtr& parent, const FieldPtr& child) const {
+void FieldTree::ValidateInsertion(
+    const syntax::OutputDictionaryObjectPtr& parent,
+    const FieldPtr& child,
+    NodeMap& subtree_nodes,
+    std::set<std::string>& subtree_names) const {
     auto child_dictionary = child->GetObject();
 
     // The container arrays hold indirect references (Table 218, Table 220)
@@ -426,7 +451,7 @@ void FieldTree::ValidateInsertion(const syntax::OutputDictionaryObjectPtr& paren
         LOG_ERROR_AND_THROW(InvalidParameterException, "The field dictionary shall be an indirect object - allocate a cross-reference entry for it first");
     }
 
-    EnsureCacheBuilt();
+    EnsureIndexBuilt();
 
     std::string parent_name;
 
@@ -460,21 +485,21 @@ void FieldTree::ValidateInsertion(const syntax::OutputDictionaryObjectPtr& paren
 
     // The child may bring a subtree of its own - every node of it becomes
     // a node of this tree and is held to the same rules, under the name
-    // the walk will give it once the child is in place
-    std::set<std::string> subtree_names;
-    std::unordered_set<syntax::DictionaryObjectPtr, DeferredIdentityHash<syntax::DictionaryObject>, DeferredIdentityEqual<syntax::DictionaryObject>> subtree_nodes;
-    ValidateSubtree(child_dictionary, parent_name, subtree_names, subtree_nodes);
+    // the walk will give it once the child is in place. What the walk
+    // collects is exactly what the index needs once the child is in place.
+    ValidateSubtree(child_dictionary, parent, parent_name, subtree_nodes, subtree_names);
 }
 
 void FieldTree::ValidateSubtree(
     const syntax::DictionaryObjectPtr& node,
+    const syntax::OutputDictionaryObjectPtr& traversal_parent,
     const std::string& parent_name,
-    std::set<std::string>& subtree_names,
-    std::unordered_set<syntax::DictionaryObjectPtr, DeferredIdentityHash<syntax::DictionaryObject>, DeferredIdentityEqual<syntax::DictionaryObject>>& subtree_nodes) const {
+    NodeMap& subtree_nodes,
+    std::set<std::string>& subtree_names) const {
 
     // A node reached twice within the subtree is enumerated once by the
     // walk, so it is judged once here
-    if (!subtree_nodes.insert(node).second) {
+    if (!subtree_nodes.emplace(node, traversal_parent).second) {
         return;
     }
 
@@ -507,8 +532,20 @@ void FieldTree::ValidateSubtree(
             continue;
         }
 
-        ValidateSubtree(*kid, qualified_name, subtree_names, subtree_nodes);
+        ValidateSubtree(*kid, syntax::OutputDictionaryObjectPtr(node), qualified_name, subtree_nodes, subtree_names);
     }
+}
+
+void FieldTree::ExtendIndex(const NodeMap& subtree_nodes, const std::set<std::string>& subtree_names) const {
+    m_nodes.insert(subtree_nodes.begin(), subtree_nodes.end());
+    m_names.insert(subtree_names.begin(), subtree_names.end());
+
+    // The ordered views are rebuilt by the next read - one walk for a whole
+    // batch of insertions instead of one per insertion
+    m_root_children.clear();
+    m_field_cache.clear();
+    m_terminal_index.clear();
+    m_views_built = false;
 }
 
 void FieldTree::LinkChild(const syntax::OutputDictionaryObjectPtr& parent, syntax::DictionaryObjectPtr child) const {

--- a/src/vanillapdf/semantics/objects/field_tree.cpp
+++ b/src/vanillapdf/semantics/objects/field_tree.cpp
@@ -413,23 +413,21 @@ void FieldTree::BuildFieldCacheInternal(
 
 // Helpers
 
-bool FieldTree::IsMember(const syntax::DictionaryObjectPtr& dictionary) const {
-    EnsureIndexBuilt();
-    return m_nodes.find(dictionary) != m_nodes.end();
-}
-
-std::string FieldTree::GetMemberQualifiedName(const syntax::DictionaryObjectPtr& dictionary) const {
-    auto node = m_nodes.find(dictionary);
-    assert(node != m_nodes.end() && "The caller checks membership first");
+std::string FieldTree::GetMemberQualifiedName(NodeMap::const_iterator node) const {
 
     // The chain of traversal parents ends at the root level, which has no
     // name; it cannot cycle, since the walk visits every node once
     std::string parent_name;
     if (!node->second.empty()) {
-        parent_name = GetMemberQualifiedName(*node->second);
+        auto parent_node = m_nodes.find(*node->second);
+        if (parent_node == m_nodes.end()) {
+            LOG_ERROR_AND_THROW(InvalidParameterException, "The traversal parent of field {} {} R is missing from the node index", node->first->GetObjectNumber(), node->first->GetGenerationNumber());
+        }
+
+        parent_name = GetMemberQualifiedName(parent_node);
     }
 
-    return QualifiedNameOf(parent_name, dictionary);
+    return QualifiedNameOf(parent_name, node->first);
 }
 
 syntax::ArrayObjectPtr<syntax::IndirectReferenceObjectPtr> FieldTree::CreateKids(syntax::DictionaryObjectPtr parent) {
@@ -467,7 +465,8 @@ void FieldTree::ValidateInsertion(
 
         // Nothing but the node index tells a parent of this tree from a
         // field of another document - a field is a plain dictionary view
-        if (!IsMember(parent_dictionary)) {
+        auto parent_node = m_nodes.find(parent_dictionary);
+        if (parent_node == m_nodes.end()) {
             LOG_ERROR_AND_THROW(InvalidParameterException, "The parent field does not belong to this field hierarchy");
         }
 
@@ -487,7 +486,7 @@ void FieldTree::ValidateInsertion(
             LOG_ERROR_AND_THROW(InvalidParameterException, "A field merged with its widget annotation cannot take child fields");
         }
 
-        parent_name = GetMemberQualifiedName(parent_dictionary);
+        parent_name = GetMemberQualifiedName(parent_node);
     }
 
     // The child may bring a subtree of its own - every node of it becomes

--- a/src/vanillapdf/semantics/objects/field_tree.cpp
+++ b/src/vanillapdf/semantics/objects/field_tree.cpp
@@ -186,8 +186,11 @@ void FieldTree::RemoveChild(FieldPtr field) {
         break;
     }
 
+    // The index knows the field but the container does not hold it: the
+    // hierarchy was edited underneath the tree, and the index describes a
+    // structure that no longer exists
     if (!removed) {
-        LOG_ERROR_AND_THROW_GENERAL("Could not remove the field from its container array");
+        LOG_ERROR_AND_THROW(InvalidParameterException, "The field is no longer held by the container the hierarchy walk reached it through - the hierarchy was edited underneath the tree, call Invalidate first");
     }
 
     if (field_dictionary->Contains(constant::Name::Parent)) {
@@ -245,9 +248,12 @@ void FieldTree::BuildFieldCacheInternal(
     auto generation_number = node_reference->GetReferencedGenerationNumber();
     syntax::IndirectReferenceId node_id(object_number, generation_number);
 
+    // A node reached a second time is a cycle when it is an ancestor and a
+    // node shared by two parents otherwise; either way it is one node and
+    // is enumerated where it was first reached
     auto found = visited.find(node_id);
     if (found != visited.end() && found->second) {
-        spdlog::warn("Cyclic /Kids entry while enumerating form fields");
+        spdlog::warn("Field {} {} R is reached by more than one /Fields or /Kids entry - a cycle or a node shared by two parents; only the first path is enumerated", object_number, generation_number);
         return;
     }
 

--- a/src/vanillapdf/semantics/objects/field_tree.cpp
+++ b/src/vanillapdf/semantics/objects/field_tree.cpp
@@ -1,0 +1,416 @@
+#include "precompiled.h"
+
+#include "semantics/objects/field_tree.h"
+#include "semantics/objects/fields.h"
+#include "semantics/objects/document.h"
+
+#include "syntax/exceptions/syntax_exceptions.h"
+#include "syntax/objects/array_object.h"
+#include "syntax/utils/name_constants.h"
+
+#include "utils/buffer.h"
+#include "utils/text_string_encoding.h"
+
+namespace vanillapdf {
+namespace semantics {
+
+FieldTree::FieldTree(syntax::ArrayObjectPtr<syntax::IndirectReferenceObjectPtr> fields) : HighLevelObject(fields) {
+    m_cache_lock = std::unique_ptr<std::recursive_mutex>(pdf_new std::recursive_mutex());
+}
+
+FieldTreePtr FieldTree::Create(DocumentPtr document) {
+    auto file = document->GetFile();
+
+    // The array itself is a direct object of the form dictionary, but it
+    // belongs to the file, so that the references it will hold resolve
+    syntax::ArrayObjectPtr<syntax::IndirectReferenceObjectPtr> fields;
+    auto fields_data = fields->Data();
+    fields_data->SetFile(file);
+    fields_data->SetInitialized();
+
+    return make_deferred<FieldTree>(fields);
+}
+
+// Flat view
+
+types::size_type FieldTree::GetFieldCount() const {
+    ACCESS_LOCK_GUARD(m_cache_lock);
+
+    EnsureCacheBuilt();
+    return m_field_cache.size();
+}
+
+FieldPtr FieldTree::GetField(types::size_type index) const {
+    ACCESS_LOCK_GUARD(m_cache_lock);
+
+    EnsureCacheBuilt();
+
+    if (index >= m_field_cache.size()) {
+        LOG_ERROR_AND_THROW(syntax::ObjectMissingException, "Field index out of range: {}", index);
+    }
+
+    return Field::Create(m_field_cache[index]);
+}
+
+bool FieldTree::TryFindField(std::string_view qualified_name, OuputFieldPtr& result) const {
+    ACCESS_LOCK_GUARD(m_cache_lock);
+
+    EnsureCacheBuilt();
+
+    auto found = m_terminal_index.find(std::string(qualified_name));
+    if (found == m_terminal_index.end()) {
+        return false;
+    }
+
+    result = Field::Create(found->second);
+    return true;
+}
+
+// Structure
+
+types::size_type FieldTree::GetRootChildCount() const {
+    return _obj->GetSize();
+}
+
+FieldPtr FieldTree::GetRootChild(types::size_type index) const {
+    if (index >= _obj->GetSize()) {
+        LOG_ERROR_AND_THROW(syntax::ObjectMissingException, "Root child index out of range: {}", index);
+    }
+
+    auto child_reference = _obj->GetValue(index);
+    auto child = child_reference->GetReferencedObjectAs<syntax::DictionaryObjectPtr>();
+    return Field::Create(child);
+}
+
+void FieldTree::AddRootChild(FieldPtr child) {
+    ACCESS_LOCK_GUARD(m_cache_lock);
+
+    syntax::OutputDictionaryObjectPtr root_level;
+    ValidateInsertion(root_level, child);
+
+    auto child_dictionary = child->GetObject();
+    auto child_reference = make_deferred<syntax::IndirectReferenceObject>(child_dictionary);
+    _obj->Append(child_reference);
+
+    LinkChild(root_level, child_dictionary);
+    Invalidate();
+}
+
+void FieldTree::InsertRootChild(types::size_type index, FieldPtr child) {
+    ACCESS_LOCK_GUARD(m_cache_lock);
+
+    syntax::OutputDictionaryObjectPtr root_level;
+    ValidateInsertion(root_level, child);
+
+    // An index equal to the size appends, the array refuses anything beyond
+    if (index > _obj->GetSize()) {
+        LOG_ERROR_AND_THROW(syntax::ObjectMissingException, "Root child index out of range: {}", index);
+    }
+
+    auto child_dictionary = child->GetObject();
+    auto child_reference = make_deferred<syntax::IndirectReferenceObject>(child_dictionary);
+    _obj->Insert(index, child_reference);
+
+    LinkChild(root_level, child_dictionary);
+    Invalidate();
+}
+
+void FieldTree::AddChild(FieldPtr parent, FieldPtr child) {
+    ACCESS_LOCK_GUARD(m_cache_lock);
+
+    syntax::OutputDictionaryObjectPtr parent_dictionary(parent->GetObject());
+    ValidateInsertion(parent_dictionary, child);
+
+    auto child_dictionary = child->GetObject();
+    auto child_reference = make_deferred<syntax::IndirectReferenceObject>(child_dictionary);
+
+    auto kids = CreateKids(*parent_dictionary);
+    kids->Append(child_reference);
+
+    LinkChild(parent_dictionary, child_dictionary);
+    Invalidate();
+}
+
+void FieldTree::InsertChild(FieldPtr parent, types::size_type index, FieldPtr child) {
+    ACCESS_LOCK_GUARD(m_cache_lock);
+
+    syntax::OutputDictionaryObjectPtr parent_dictionary(parent->GetObject());
+    ValidateInsertion(parent_dictionary, child);
+
+    auto kids = CreateKids(*parent_dictionary);
+
+    // An index equal to the size appends, the array refuses anything beyond
+    if (index > kids->GetSize()) {
+        LOG_ERROR_AND_THROW(syntax::ObjectMissingException, "Child index out of range: {}", index);
+    }
+
+    auto child_dictionary = child->GetObject();
+    auto child_reference = make_deferred<syntax::IndirectReferenceObject>(child_dictionary);
+    kids->Insert(index, child_reference);
+
+    LinkChild(parent_dictionary, child_dictionary);
+    Invalidate();
+}
+
+void FieldTree::RemoveChild(FieldPtr field) {
+    ACCESS_LOCK_GUARD(m_cache_lock);
+
+    EnsureCacheBuilt();
+
+    auto field_dictionary = field->GetObject();
+    auto node = m_nodes.find(field_dictionary);
+    if (node == m_nodes.end()) {
+        LOG_ERROR_AND_THROW(InvalidParameterException, "The field does not belong to this field hierarchy");
+    }
+
+    // The container is the one the hierarchy walk reached the field
+    // through - the root /Fields array, or the /Kids of the traversal
+    // parent. /Parent is not consulted: a missing one would send a nested
+    // field to the root array, a wrong one to another node's /Kids.
+    auto traversal_parent = node->second;
+
+    syntax::ArrayObjectPtr<syntax::IndirectReferenceObjectPtr> container = _obj;
+    if (!traversal_parent.empty()) {
+        container = traversal_parent->FindAs<syntax::ArrayObjectPtr<syntax::IndirectReferenceObjectPtr>>(constant::Name::Kids);
+    }
+
+    bool removed = false;
+    auto container_size = container->GetSize();
+    for (decltype(container_size) i = 0; i < container_size; ++i) {
+        auto entry_reference = container->GetValue(i);
+        if (!entry_reference->GetReferencedObject()->Identity(field_dictionary)) {
+            continue;
+        }
+
+        removed = container->Remove(i);
+        break;
+    }
+
+    if (!removed) {
+        LOG_ERROR_AND_THROW_GENERAL("Could not remove the field from its container array");
+    }
+
+    if (field_dictionary->Contains(constant::Name::Parent)) {
+        bool parent_removed = field_dictionary->Remove(constant::Name::Parent);
+        assert(parent_removed && "Unable to remove existing item"); UNUSED(parent_removed);
+    }
+
+    Invalidate();
+}
+
+void FieldTree::Invalidate() {
+    ACCESS_LOCK_GUARD(m_cache_lock);
+
+    m_field_cache.clear();
+    m_nodes.clear();
+    m_terminal_index.clear();
+    m_names.clear();
+    m_cache_built = false;
+}
+
+// Cache
+
+void FieldTree::EnsureCacheBuilt() const {
+    if (!m_cache_built) {
+        BuildFieldCache();
+    }
+}
+
+void FieldTree::BuildFieldCache() const {
+
+    // Both /Fields and /Kids shall contain indirect references (Table 218,
+    // Table 220), so the tree is walked as references and every node is
+    // dereferenced only after the cycle check - the same way PageTree types
+    // its kids array.
+    //
+    // Malformed documents can link /Kids in a cycle. Visited nodes are
+    // tracked by their object identity, the same way Field guards its
+    // /Parent chain walk.
+    std::map<syntax::IndirectReferenceId, bool> visited;
+    syntax::OutputDictionaryObjectPtr root_level;
+
+    for (auto field_reference : _obj) {
+        BuildFieldCacheInternal(field_reference, root_level, visited);
+    }
+
+    m_cache_built = true;
+}
+
+void FieldTree::BuildFieldCacheInternal(
+    syntax::IndirectReferenceObjectPtr node_reference,
+    const syntax::OutputDictionaryObjectPtr& traversal_parent,
+    std::map<syntax::IndirectReferenceId, bool>& visited) const {
+
+    auto object_number = node_reference->GetReferencedObjectNumber();
+    auto generation_number = node_reference->GetReferencedGenerationNumber();
+    syntax::IndirectReferenceId node_id(object_number, generation_number);
+
+    auto found = visited.find(node_id);
+    if (found != visited.end() && found->second) {
+        spdlog::warn("Cyclic /Kids entry while enumerating form fields");
+        return;
+    }
+
+    visited[node_id] = true;
+
+    auto node = node_reference->GetReferencedObjectAs<syntax::DictionaryObjectPtr>();
+    m_nodes.emplace(node, traversal_parent);
+
+    // A /Parent that disagrees with the /Kids entry that reached the node
+    // is the other common way a file is already dirty - the fully qualified
+    // name follows /Parent, the enumeration follows /Kids, and the two
+    // diverge from here on. Reported, not repaired.
+    bool parent_is_root = traversal_parent.empty();
+    if (node->Contains(constant::Name::Parent)) {
+        auto parent_obj = node->Find(constant::Name::Parent);
+        bool parent_matches = false;
+        if (!parent_is_root && syntax::ObjectUtils::IsType<syntax::IndirectReferenceObjectPtr>(parent_obj)) {
+            auto parent_reference = syntax::ObjectUtils::ConvertTo<syntax::IndirectReferenceObjectPtr>(parent_obj);
+            parent_matches = traversal_parent->Identity(parent_reference->GetReferencedObject());
+        }
+
+        if (!parent_matches) {
+            spdlog::warn("Field {} {} R has a /Parent entry that does not reference the node whose /Kids contains it", object_number, generation_number);
+        }
+    } else if (!parent_is_root) {
+        spdlog::warn("Field {} {} R is a /Kids entry without the /Parent entry required by Table 220", object_number, generation_number);
+    }
+
+    // Names are indexed for the nodes that carry a /T of their own - a node
+    // without one shares its parent's fully qualified name (12.7.3.2) and
+    // would only ever report a false duplicate
+    bool terminal = Field::IsTerminalDictionary(node);
+    if (node->Contains(constant::Name::T)) {
+        auto field = Field::Create(node);
+        auto name = field->GetQualifiedName()->ToString();
+
+        auto inserted = m_names.insert(name);
+        if (!inserted.second) {
+            spdlog::warn("Duplicate fully qualified field name \"{}\" - lookups resolve to the first field in document order", name);
+        }
+
+        if (terminal) {
+            m_terminal_index.emplace(name, node);
+        }
+    }
+
+    if (terminal) {
+        m_field_cache.push_back(node);
+        return;
+    }
+
+    // Only field dictionaries are hierarchy nodes - widget annotations stay
+    // attached to their field (12.7.3.2)
+    auto kids = node->FindAs<syntax::ArrayObjectPtr<syntax::IndirectReferenceObjectPtr>>(constant::Name::Kids);
+    for (auto kid_reference : kids) {
+        auto kid = kid_reference->GetReferencedObjectAs<syntax::DictionaryObjectPtr>();
+        if (!Field::IsFieldDictionary(kid)) {
+            continue;
+        }
+
+        BuildFieldCacheInternal(kid_reference, syntax::OutputDictionaryObjectPtr(node), visited);
+    }
+}
+
+// Helpers
+
+bool FieldTree::IsMember(const syntax::DictionaryObjectPtr& dictionary) const {
+    EnsureCacheBuilt();
+    return m_nodes.find(dictionary) != m_nodes.end();
+}
+
+syntax::ArrayObjectPtr<syntax::IndirectReferenceObjectPtr> FieldTree::CreateKids(syntax::DictionaryObjectPtr parent) {
+    if (!parent->Contains(constant::Name::Kids)) {
+        syntax::MixedArrayObjectPtr mixed_array;
+        mixed_array->SetFile(parent->GetFile());
+        mixed_array->SetInitialized();
+
+        parent->Insert(constant::Name::Kids, mixed_array);
+    }
+
+    return parent->FindAs<syntax::ArrayObjectPtr<syntax::IndirectReferenceObjectPtr>>(constant::Name::Kids);
+}
+
+void FieldTree::ValidateInsertion(const syntax::OutputDictionaryObjectPtr& parent, const FieldPtr& child) const {
+    auto child_dictionary = child->GetObject();
+
+    // The container arrays hold indirect references (Table 218, Table 220)
+    // - a direct dictionary cannot be referenced and would serialize as a
+    // dangling 0 0 R
+    if (!child_dictionary->IsIndirect()) {
+        LOG_ERROR_AND_THROW(InvalidParameterException, "The field dictionary shall be an indirect object - allocate a cross-reference entry for it first");
+    }
+
+    if (IsMember(child_dictionary)) {
+        LOG_ERROR_AND_THROW(InvalidParameterException, "The field already belongs to this field hierarchy");
+    }
+
+    std::string qualified_name;
+
+    if (!parent.empty()) {
+        auto parent_dictionary = *parent;
+
+        // Nothing but the node index tells a parent of this tree from a
+        // field of another document - a field is a plain dictionary view
+        if (!IsMember(parent_dictionary)) {
+            LOG_ERROR_AND_THROW(InvalidParameterException, "The parent field does not belong to this field hierarchy");
+        }
+
+        // A field's /Kids holds either child fields or widget annotations,
+        // never both (12.7.3.1)
+        if (parent_dictionary->Contains(constant::Name::Kids) && Field::IsTerminalDictionary(parent_dictionary)) {
+            auto parent_kids = parent_dictionary->FindAs<syntax::MixedArrayObjectPtr>(constant::Name::Kids);
+            if (parent_kids->GetSize() > 0) {
+                LOG_ERROR_AND_THROW(InvalidParameterException, "A terminal field carrying widget annotations cannot take child fields");
+            }
+        }
+
+        // A field merged with its widget annotation is a leaf of the page
+        // as well as of the hierarchy - giving it children would make the
+        // widget dictionary a grouping node
+        if (parent_dictionary->Contains(constant::Name::Subtype)) {
+            LOG_ERROR_AND_THROW(InvalidParameterException, "A field merged with its widget annotation cannot take child fields");
+        }
+
+        auto parent_field = Field::Create(parent_dictionary);
+        qualified_name = parent_field->GetQualifiedName()->ToString();
+    }
+
+    // Fully qualified names shall be unique (12.7.3.2). The name the child
+    // would take is the parent's name extended by the child's partial name;
+    // a child without a /T has no name of its own to collide with.
+    if (child_dictionary->Contains(constant::Name::T)) {
+        auto child_partial_name = child_dictionary->FindAs<syntax::StringObjectPtr>(constant::Name::T);
+        auto child_partial_name_utf8 = TextStringEncoding::ToUtf8(child_partial_name->GetValue()->ToStringView());
+
+        if (!qualified_name.empty()) {
+            qualified_name += ".";
+        }
+
+        qualified_name += child_partial_name_utf8;
+
+        if (m_names.find(qualified_name) != m_names.end()) {
+            LOG_ERROR_AND_THROW(InvalidParameterException, "A field with the fully qualified name \"{}\" already exists in this field hierarchy", qualified_name);
+        }
+    }
+}
+
+void FieldTree::LinkChild(const syntax::OutputDictionaryObjectPtr& parent, syntax::DictionaryObjectPtr child) const {
+
+    // Root-level fields have no /Parent (Table 220 requires it for kids
+    // only); anything below the root references its parent
+    if (parent.empty()) {
+        if (child->Contains(constant::Name::Parent)) {
+            bool removed = child->Remove(constant::Name::Parent);
+            assert(removed && "Unable to remove existing item"); UNUSED(removed);
+        }
+
+        return;
+    }
+
+    auto parent_reference = make_deferred<syntax::IndirectReferenceObject>(*parent);
+    child->Insert(constant::Name::Parent, parent_reference, true);
+}
+
+} // semantics
+} // vanillapdf

--- a/src/vanillapdf/semantics/objects/field_tree.cpp
+++ b/src/vanillapdf/semantics/objects/field_tree.cpp
@@ -40,7 +40,10 @@ FieldTree::FieldTree(syntax::ArrayObjectPtr<syntax::IndirectReferenceObjectPtr> 
 }
 
 FieldTreePtr FieldTree::Create(DocumentPtr document) {
-    auto file = document->GetFile();
+    return Create(document->GetFile());
+}
+
+FieldTreePtr FieldTree::Create(syntax::FilePtr file) {
 
     // The array itself is a direct object of the form dictionary, but it
     // belongs to the file, so that the references it will hold resolve

--- a/src/vanillapdf/semantics/objects/field_tree.h
+++ b/src/vanillapdf/semantics/objects/field_tree.h
@@ -178,12 +178,11 @@ private:
         const std::string& parent_name,
         std::map<syntax::IndirectReferenceId, bool>& visited) const;
 
-    bool IsMember(const syntax::DictionaryObjectPtr& dictionary) const;
-
     // The walk's fully qualified name of a member node, derived from the
     // chain of traversal parents in the node index - the same chain the
-    // mutators navigate by, not /Parent
-    std::string GetMemberQualifiedName(const syntax::DictionaryObjectPtr& dictionary) const;
+    // mutators navigate by, not /Parent. Takes the index entry the caller
+    // looked up, so membership is established by construction.
+    std::string GetMemberQualifiedName(NodeMap::const_iterator node) const;
 
     // The /Kids array of a node, created when the node has none yet
     static syntax::ArrayObjectPtr<syntax::IndirectReferenceObjectPtr> CreateKids(syntax::DictionaryObjectPtr parent);

--- a/src/vanillapdf/semantics/objects/field_tree.h
+++ b/src/vanillapdf/semantics/objects/field_tree.h
@@ -57,8 +57,11 @@ public:
     // resolve to the first terminal field in document order.
     bool TryFindField(std::string_view qualified_name, OuputFieldPtr& result) const;
 
-    // Structural view, level 0 - the root /Fields entries in array order,
-    // groups included. Field::GetChildCount / GetChild continue below.
+    // Structural view, level 0 - the root /Fields entries that are field
+    // dictionaries, in array order, groups included; a stray dictionary is
+    // skipped with a warning, the same way a widget among /Kids is. Served
+    // from the cache under the lock, like the flat view.
+    // Field::GetChildCount / GetChild continue below.
     types::size_type GetRootChildCount() const;
     FieldPtr GetRootChild(types::size_type index) const;
 
@@ -106,9 +109,9 @@ public:
     void Invalidate();
 
 private:
-    // Flat cache in document order plus the node index over every node the
-    // walk visited - root children, groups and terminals - keyed by object
-    // identity. Each node maps to its traversal parent: the node whose /Kids
+    // The root children and the flat cache in document order, plus the node
+    // index over every node the walk visited - root children, groups and
+    // terminals - keyed by object identity. Each node maps to its traversal parent: the node whose /Kids
     // reached it, empty for a root-level entry. That is what the mutators
     // navigate by; /Parent is validated and warned about during the walk,
     // never trusted, since a missing or mismatched entry is the common way
@@ -124,6 +127,7 @@ private:
     // the same array each carry their own cache and lock (canonicalization
     // is issue #524).
     mutable std::unique_ptr<std::recursive_mutex> m_cache_lock;
+    mutable std::vector<syntax::DictionaryObjectPtr> m_root_children;
     mutable std::vector<syntax::DictionaryObjectPtr> m_field_cache;
     mutable std::unordered_map<syntax::DictionaryObjectPtr, syntax::OutputDictionaryObjectPtr, DeferredIdentityHash<syntax::DictionaryObject>, DeferredIdentityEqual<syntax::DictionaryObject>> m_nodes;
     mutable std::map<std::string, syntax::DictionaryObjectPtr> m_terminal_index;

--- a/src/vanillapdf/semantics/objects/field_tree.h
+++ b/src/vanillapdf/semantics/objects/field_tree.h
@@ -12,6 +12,7 @@
 #include <string>
 #include <string_view>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 namespace vanillapdf {
@@ -76,10 +77,15 @@ public:
     // index equal to the count appends, a larger one is an
     // ObjectMissingException.
     //
+    // The child may bring a subtree of its own; every node of it is held
+    // to the same rules as the child, under the names the walk will give
+    // them once the child is in place.
+    //
     // InvalidParameterException when: the child dictionary is a direct
     // object (the arrays hold indirect references, Table 218 and Table 220),
-    // the child is already in this tree, or the resulting fully qualified
-    // name is already taken.
+    // the child or a node of its subtree is already in this tree, or a
+    // fully qualified name the subtree would take is already taken - by
+    // this tree or by another node of the same subtree.
     void AddRootChild(FieldPtr child);
     void InsertRootChild(types::size_type index, FieldPtr child);
 
@@ -166,6 +172,16 @@ private:
     // The insertion rules shared by every level; an empty parent stands for
     // the root level
     void ValidateInsertion(const syntax::OutputDictionaryObjectPtr& parent, const FieldPtr& child) const;
+
+    // The rules every node of an inserted subtree is held to, under the
+    // name the walk will give it: not a member yet, and its name - when it
+    // has a /T - taken neither by this tree nor by another node of the
+    // subtree. Recurses through the /Kids fields the way the walk does.
+    void ValidateSubtree(
+        const syntax::DictionaryObjectPtr& node,
+        const std::string& parent_name,
+        std::set<std::string>& subtree_names,
+        std::unordered_set<syntax::DictionaryObjectPtr, DeferredIdentityHash<syntax::DictionaryObject>, DeferredIdentityEqual<syntax::DictionaryObject>>& subtree_nodes) const;
     void LinkChild(const syntax::OutputDictionaryObjectPtr& parent, syntax::DictionaryObjectPtr child) const;
 };
 

--- a/src/vanillapdf/semantics/objects/field_tree.h
+++ b/src/vanillapdf/semantics/objects/field_tree.h
@@ -44,8 +44,11 @@ public:
     explicit FieldTree(syntax::ArrayObjectPtr<syntax::IndirectReferenceObjectPtr> fields);
 
     // Creates an empty hierarchy belonging to the document. It takes effect
-    // once attached to a form with InteractiveForm::SetFieldTree.
+    // once attached to a form with InteractiveForm::SetFieldTree. The
+    // document is the public form, mirrored by the C API; the file overload
+    // is for the library's own use, where Document holds its file directly.
     static FieldTreePtr Create(DocumentPtr document);
+    static FieldTreePtr Create(syntax::FilePtr file);
 
     // Flat view - terminal fields in document order, grouping nodes hidden.
     // A radio button group is a single terminal field with one value,

--- a/src/vanillapdf/semantics/objects/field_tree.h
+++ b/src/vanillapdf/semantics/objects/field_tree.h
@@ -65,6 +65,12 @@ public:
     // order.
     bool TryFindField(std::string_view qualified_name, OuputFieldPtr& result) const;
 
+    // Whether any node of the hierarchy - terminal or group - carries this
+    // fully qualified name. This is the authority the mutators reject
+    // duplicates against, so a name absent here is one they accept;
+    // TryFindField sees terminals only.
+    bool ContainsName(std::string_view qualified_name) const;
+
     // Structural view, level 0 - the root /Fields entries that are field
     // dictionaries, in array order, groups included; a stray dictionary is
     // skipped with a warning, the same way a widget among /Kids is. Served

--- a/src/vanillapdf/semantics/objects/field_tree.h
+++ b/src/vanillapdf/semantics/objects/field_tree.h
@@ -12,7 +12,6 @@
 #include <string>
 #include <string_view>
 #include <unordered_map>
-#include <unordered_set>
 #include <vector>
 
 namespace vanillapdf {
@@ -117,24 +116,30 @@ public:
     // edited underneath the tree without Invalidate.
     void RemoveChild(FieldPtr field);
 
-    // Drops the cached flat view, so the next access rebuilds it from the
+    // Drops the cache, so the next access rebuilds it from the
     // dictionaries. Required after editing /Fields, /Kids or /Parent through
-    // the raw dictionary API; the tree's own mutators invalidate themselves.
+    // the raw dictionary API; the tree's own mutators maintain themselves.
     void Invalidate();
 
 private:
-    // The root children and the flat cache in document order, plus the node
-    // index over every node the walk visited - root children, groups and
-    // terminals - keyed by object identity. Each node maps to its traversal
-    // parent: the node whose /Kids reached it, empty for a root-level entry.
-    // That is what the mutators navigate and name by; /Parent is validated
-    // and warned about during the walk, never trusted, since a missing or
-    // mismatched entry is the common way a file is already dirty. The walk
-    // threads the name prefix down with it, so the name index agrees with
-    // the enumeration by construction. The index holds the nodes alive, so an
-    // address can never be recycled by an unrelated dictionary while it is
-    // a key. Built in full on first access and cleared by every mutator, so
-    // structural changes are reflected on the next access.
+    // The cache has two tiers, so that authoring many fields stays linear:
+    //  - the index - every node the walk visited, keyed by object identity
+    //    and mapped to its traversal parent (the node whose /Kids reached
+    //    it, empty for a root-level entry), plus the qualified names of the
+    //    nodes carrying a /T - answers membership and uniqueness. The insert
+    //    mutators extend it with the subtree they validated, no rebuild.
+    //  - the views - the root children, the terminal fields in document
+    //    order and the name lookup - are ordered, so an insert only marks
+    //    them stale; the next read rebuilds everything in one walk.
+    // Removal and Invalidate drop both tiers.
+    //
+    // The traversal parent is what the mutators navigate and name by;
+    // /Parent is validated and warned about during the walk, never trusted,
+    // since a missing or mismatched entry is the common way a file is
+    // already dirty. The walk threads the name prefix down with it, so the
+    // name index agrees with the enumeration by construction. The index
+    // holds the nodes alive, so an address can never be recycled by an
+    // unrelated dictionary while it is a key.
     //
     // The mutators hold the cache lock across the whole mutation, so the
     // membership check, the create-if-missing /Kids insert and the
@@ -142,15 +147,20 @@ private:
     // cache builds on this tree instance. Distinct FieldTree wrappers over
     // the same array each carry their own cache and lock (canonicalization
     // is issue #524).
+    using NodeMap = std::unordered_map<syntax::DictionaryObjectPtr, syntax::OutputDictionaryObjectPtr, DeferredIdentityHash<syntax::DictionaryObject>, DeferredIdentityEqual<syntax::DictionaryObject>>;
+
     mutable std::unique_ptr<std::recursive_mutex> m_cache_lock;
+    mutable NodeMap m_nodes;
+    mutable std::set<std::string> m_names;
+    mutable bool m_index_built = false;
+
     mutable std::vector<syntax::DictionaryObjectPtr> m_root_children;
     mutable std::vector<syntax::DictionaryObjectPtr> m_field_cache;
-    mutable std::unordered_map<syntax::DictionaryObjectPtr, syntax::OutputDictionaryObjectPtr, DeferredIdentityHash<syntax::DictionaryObject>, DeferredIdentityEqual<syntax::DictionaryObject>> m_nodes;
     mutable std::map<std::string, syntax::DictionaryObjectPtr> m_terminal_index;
-    mutable std::set<std::string> m_names;
-    mutable bool m_cache_built = false;
+    mutable bool m_views_built = false;
 
-    void EnsureCacheBuilt() const;
+    void EnsureIndexBuilt() const;
+    void EnsureViewsBuilt() const;
     void BuildFieldCache() const;
 
     // The traversal parent is the node whose /Kids reached this one; empty
@@ -173,8 +183,15 @@ private:
     static syntax::ArrayObjectPtr<syntax::IndirectReferenceObjectPtr> CreateKids(syntax::DictionaryObjectPtr parent);
 
     // The insertion rules shared by every level; an empty parent stands for
-    // the root level
-    void ValidateInsertion(const syntax::OutputDictionaryObjectPtr& parent, const FieldPtr& child) const;
+    // the root level. Collects the child's subtree as the walk will see it
+    // under that parent - the nodes with their traversal parents and the
+    // names they take - ready to extend the index once the child is in
+    // place.
+    void ValidateInsertion(
+        const syntax::OutputDictionaryObjectPtr& parent,
+        const FieldPtr& child,
+        NodeMap& subtree_nodes,
+        std::set<std::string>& subtree_names) const;
 
     // The rules every node of an inserted subtree is held to, under the
     // name the walk will give it: not a member yet, and its name - when it
@@ -182,9 +199,13 @@ private:
     // subtree. Recurses through the /Kids fields the way the walk does.
     void ValidateSubtree(
         const syntax::DictionaryObjectPtr& node,
+        const syntax::OutputDictionaryObjectPtr& traversal_parent,
         const std::string& parent_name,
-        std::set<std::string>& subtree_names,
-        std::unordered_set<syntax::DictionaryObjectPtr, DeferredIdentityHash<syntax::DictionaryObject>, DeferredIdentityEqual<syntax::DictionaryObject>>& subtree_nodes) const;
+        NodeMap& subtree_nodes,
+        std::set<std::string>& subtree_names) const;
+
+    // Adds a validated subtree to the index and marks the views stale
+    void ExtendIndex(const NodeMap& subtree_nodes, const std::set<std::string>& subtree_names) const;
     void LinkChild(const syntax::OutputDictionaryObjectPtr& parent, syntax::DictionaryObjectPtr child) const;
 };
 

--- a/src/vanillapdf/semantics/objects/field_tree.h
+++ b/src/vanillapdf/semantics/objects/field_tree.h
@@ -53,8 +53,13 @@ public:
     FieldPtr GetField(types::size_type index) const;
 
     // Finds a terminal field by its fully qualified name - the /T partial
-    // names joined with '.' (12.7.3.2), UTF-8 encoded. Duplicate names
-    // resolve to the first terminal field in document order.
+    // names joined with '.' (12.7.3.2), UTF-8 encoded - as the hierarchy
+    // walk produces it: the traversal parent's name extended by the node's
+    // own /T, so the name index agrees with the enumeration by
+    // construction. Field::GetQualifiedName has nothing but /Parent to
+    // follow and can disagree on a file whose /Parent entries are wrong.
+    // Duplicate names resolve to the first terminal field in document
+    // order.
     bool TryFindField(std::string_view qualified_name, OuputFieldPtr& result) const;
 
     // Structural view, level 0 - the root /Fields entries that are field
@@ -111,11 +116,13 @@ public:
 private:
     // The root children and the flat cache in document order, plus the node
     // index over every node the walk visited - root children, groups and
-    // terminals - keyed by object identity. Each node maps to its traversal parent: the node whose /Kids
-    // reached it, empty for a root-level entry. That is what the mutators
-    // navigate by; /Parent is validated and warned about during the walk,
-    // never trusted, since a missing or mismatched entry is the common way
-    // a file is already dirty. The index holds the nodes alive, so an
+    // terminals - keyed by object identity. Each node maps to its traversal
+    // parent: the node whose /Kids reached it, empty for a root-level entry.
+    // That is what the mutators navigate and name by; /Parent is validated
+    // and warned about during the walk, never trusted, since a missing or
+    // mismatched entry is the common way a file is already dirty. The walk
+    // threads the name prefix down with it, so the name index agrees with
+    // the enumeration by construction. The index holds the nodes alive, so an
     // address can never be recycled by an unrelated dictionary while it is
     // a key. Built in full on first access and cleared by every mutator, so
     // structural changes are reflected on the next access.
@@ -138,13 +145,20 @@ private:
     void BuildFieldCache() const;
 
     // The traversal parent is the node whose /Kids reached this one; empty
-    // for a root entry, which the /Fields array reached
+    // for a root entry, which the /Fields array reached. Its qualified name
+    // is the prefix of every name below it - the root level has none.
     void BuildFieldCacheInternal(
         syntax::IndirectReferenceObjectPtr node_reference,
         const syntax::OutputDictionaryObjectPtr& traversal_parent,
+        const std::string& parent_name,
         std::map<syntax::IndirectReferenceId, bool>& visited) const;
 
     bool IsMember(const syntax::DictionaryObjectPtr& dictionary) const;
+
+    // The walk's fully qualified name of a member node, derived from the
+    // chain of traversal parents in the node index - the same chain the
+    // mutators navigate by, not /Parent
+    std::string GetMemberQualifiedName(const syntax::DictionaryObjectPtr& dictionary) const;
 
     // The /Kids array of a node, created when the node has none yet
     static syntax::ArrayObjectPtr<syntax::IndirectReferenceObjectPtr> CreateKids(syntax::DictionaryObjectPtr parent);

--- a/src/vanillapdf/semantics/objects/field_tree.h
+++ b/src/vanillapdf/semantics/objects/field_tree.h
@@ -1,0 +1,153 @@
+#ifndef _FIELD_TREE_H
+#define _FIELD_TREE_H
+
+#include "semantics/utils/semantics_fwd.h"
+
+#include "semantics/objects/high_level_object.h"
+#include "semantics/objects/fields.h"
+
+#include <map>
+#include <mutex>
+#include <set>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <vector>
+
+namespace vanillapdf {
+namespace semantics {
+
+// The field hierarchy of an interactive form (12.7.3) - a view over the
+// root /Fields array, the same way PageTree is a view over the page tree
+// root. The array is the top of the hierarchy: its entries are the
+// root-level fields, and every field below is reached through /Kids. The
+// tree knows nothing about the form holding the array; Create builds the
+// array that InteractiveForm::SetFieldTree installs as the form's /Fields
+// entry, so a read never creates anything and a tree is never a view over
+// an object the document does not hold.
+//
+// Two views over one structure:
+//  - the flat view (GetFieldCount / GetField / TryFindField) enumerates the
+//    resolved terminal fields in document order, which is what form filling
+//    consumers work with
+//  - the structural view starts at the root level (GetRootChildCount /
+//    GetRootChild) and continues down through Field::GetChildCount /
+//    GetChild; Field::GetParent walks back up and stops at a root-level
+//    field, which has no /Parent
+//
+// Every mutation goes through the tree, because the tree owns the cache.
+// The raw dictionary API can still edit /Fields, /Kids or /Parent underneath;
+// Invalidate is the documented contract for that path.
+class FieldTree : public HighLevelObject<syntax::ArrayObjectPtr<syntax::IndirectReferenceObjectPtr>> {
+public:
+    explicit FieldTree(syntax::ArrayObjectPtr<syntax::IndirectReferenceObjectPtr> fields);
+
+    // Creates an empty hierarchy belonging to the document. It takes effect
+    // once attached to a form with InteractiveForm::SetFieldTree.
+    static FieldTreePtr Create(DocumentPtr document);
+
+    // Flat view - terminal fields in document order, grouping nodes hidden.
+    // A radio button group is a single terminal field with one value,
+    // regardless of how many widget annotations represent it on the page.
+    types::size_type GetFieldCount() const;
+    FieldPtr GetField(types::size_type index) const;
+
+    // Finds a terminal field by its fully qualified name - the /T partial
+    // names joined with '.' (12.7.3.2), UTF-8 encoded. Duplicate names
+    // resolve to the first terminal field in document order.
+    bool TryFindField(std::string_view qualified_name, OuputFieldPtr& result) const;
+
+    // Structural view, level 0 - the root /Fields entries in array order,
+    // groups included. Field::GetChildCount / GetChild continue below.
+    types::size_type GetRootChildCount() const;
+    FieldPtr GetRootChild(types::size_type index) const;
+
+    // Adds a root-level field: appends its reference to /Fields and removes
+    // any /Parent it carries, since Table 220 requires /Parent for kids
+    // only. InsertRootChild places it among the /Fields entries instead; an
+    // index equal to the count appends, a larger one is an
+    // ObjectMissingException.
+    //
+    // InvalidParameterException when: the child dictionary is a direct
+    // object (the arrays hold indirect references, Table 218 and Table 220),
+    // the child is already in this tree, or the resulting fully qualified
+    // name is already taken.
+    void AddRootChild(FieldPtr child);
+    void InsertRootChild(types::size_type index, FieldPtr child);
+
+    // Adds a child field under a parent of this tree: appends its reference
+    // to the parent's /Kids, created when the parent has none yet, and sets
+    // /Parent. InsertChild places it among the /Kids entries instead, with
+    // the same index rules as InsertRootChild.
+    //
+    // Refused as for AddRootChild, and in addition when the parent does not
+    // belong to this tree, or is a terminal field carrying widget
+    // annotations or merged with its own widget annotation.
+    //
+    // The order of /Fields and /Kids affects enumeration order only - tab
+    // order comes from the page /Annots.
+    void AddChild(FieldPtr parent, FieldPtr child);
+    void InsertChild(FieldPtr parent, types::size_type index, FieldPtr child);
+
+    // Removes a field of this tree - root-level or nested, subtree included
+    // - from the container the hierarchy walk reached it through, and clears
+    // its /Parent. Emptied groups are left in place, and widget annotations
+    // stay in the page /Annots. A field that does not belong to this tree
+    // is an InvalidParameterException.
+    void RemoveChild(FieldPtr field);
+
+    // Drops the cached flat view, so the next access rebuilds it from the
+    // dictionaries. Required after editing /Fields, /Kids or /Parent through
+    // the raw dictionary API; the tree's own mutators invalidate themselves.
+    void Invalidate();
+
+private:
+    // Flat cache in document order plus the node index over every node the
+    // walk visited - root children, groups and terminals - keyed by object
+    // identity. Each node maps to its traversal parent: the node whose /Kids
+    // reached it, empty for a root-level entry. That is what the mutators
+    // navigate by; /Parent is validated and warned about during the walk,
+    // never trusted, since a missing or mismatched entry is the common way
+    // a file is already dirty. The index holds the nodes alive, so an
+    // address can never be recycled by an unrelated dictionary while it is
+    // a key. Built in full on first access and cleared by every mutator, so
+    // structural changes are reflected on the next access.
+    //
+    // The mutators hold the cache lock across the whole mutation, so the
+    // membership check, the create-if-missing /Kids insert and the
+    // reference append are atomic with respect to concurrent mutators and
+    // cache builds on this tree instance. Distinct FieldTree wrappers over
+    // the same array each carry their own cache and lock (canonicalization
+    // is issue #524).
+    mutable std::unique_ptr<std::recursive_mutex> m_cache_lock;
+    mutable std::vector<syntax::DictionaryObjectPtr> m_field_cache;
+    mutable std::unordered_map<syntax::DictionaryObjectPtr, syntax::OutputDictionaryObjectPtr, DeferredIdentityHash<syntax::DictionaryObject>, DeferredIdentityEqual<syntax::DictionaryObject>> m_nodes;
+    mutable std::map<std::string, syntax::DictionaryObjectPtr> m_terminal_index;
+    mutable std::set<std::string> m_names;
+    mutable bool m_cache_built = false;
+
+    void EnsureCacheBuilt() const;
+    void BuildFieldCache() const;
+
+    // The traversal parent is the node whose /Kids reached this one; empty
+    // for a root entry, which the /Fields array reached
+    void BuildFieldCacheInternal(
+        syntax::IndirectReferenceObjectPtr node_reference,
+        const syntax::OutputDictionaryObjectPtr& traversal_parent,
+        std::map<syntax::IndirectReferenceId, bool>& visited) const;
+
+    bool IsMember(const syntax::DictionaryObjectPtr& dictionary) const;
+
+    // The /Kids array of a node, created when the node has none yet
+    static syntax::ArrayObjectPtr<syntax::IndirectReferenceObjectPtr> CreateKids(syntax::DictionaryObjectPtr parent);
+
+    // The insertion rules shared by every level; an empty parent stands for
+    // the root level
+    void ValidateInsertion(const syntax::OutputDictionaryObjectPtr& parent, const FieldPtr& child) const;
+    void LinkChild(const syntax::OutputDictionaryObjectPtr& parent, syntax::DictionaryObjectPtr child) const;
+};
+
+} // semantics
+} // vanillapdf
+
+#endif /* _FIELD_TREE_H */

--- a/src/vanillapdf/semantics/objects/field_tree.h
+++ b/src/vanillapdf/semantics/objects/field_tree.h
@@ -92,8 +92,12 @@ public:
     // Removes a field of this tree - root-level or nested, subtree included
     // - from the container the hierarchy walk reached it through, and clears
     // its /Parent. Emptied groups are left in place, and widget annotations
-    // stay in the page /Annots. A field that does not belong to this tree
-    // is an InvalidParameterException.
+    // stay in the page /Annots. A container listing the same node twice
+    // loses the first entry only.
+    //
+    // InvalidParameterException when the field does not belong to this
+    // tree, or when the container no longer holds it - the hierarchy was
+    // edited underneath the tree without Invalidate.
     void RemoveChild(FieldPtr field);
 
     // Drops the cached flat view, so the next access rebuilds it from the

--- a/src/vanillapdf/semantics/objects/fields.cpp
+++ b/src/vanillapdf/semantics/objects/fields.cpp
@@ -84,16 +84,30 @@ bool Field::IsFieldDictionary(const syntax::DictionaryObjectPtr& dictionary) {
         || dictionary->Contains(constant::Name::FT);
 }
 
+Field::ChildEntryType Field::ClassifyChildEntry(const syntax::ObjectPtr& entry, syntax::OutputDictionaryObjectPtr& dictionary) {
+
+    // The reference is required, not just the dictionary behind it: a
+    // direct dictionary has no object number for its kids to name in
+    // /Parent, and the mutators could never address it
+    if (!syntax::ObjectUtils::IsType<syntax::IndirectReferenceObjectPtr>(entry)
+        || !syntax::ObjectUtils::IsType<syntax::DictionaryObjectPtr>(entry)) {
+        spdlog::warn("Field hierarchy entry of type {} is not an indirect reference to a dictionary and is skipped", static_cast<int32_t>(entry->GetObjectType()));
+        return ChildEntryType::Malformed;
+    }
+
+    dictionary = syntax::ObjectUtils::ConvertTo<syntax::DictionaryObjectPtr>(entry);
+    return IsFieldDictionary(dictionary) ? ChildEntryType::Field : ChildEntryType::Widget;
+}
+
 bool Field::IsTerminalDictionary(const syntax::DictionaryObjectPtr& dictionary) {
     if (!dictionary->Contains(constant::Name::Kids)) {
         return true;
     }
 
-    auto kids = dictionary->FindAs<syntax::ArrayObjectPtr<syntax::DictionaryObjectPtr>>(constant::Name::Kids);
-    auto kids_size = kids->GetSize();
-    for (decltype(kids_size) i = 0; i < kids_size; ++i) {
-        auto kid = kids->GetValue(i);
-        if (IsFieldDictionary(kid)) {
+    auto kids = dictionary->FindAs<syntax::MixedArrayObjectPtr>(constant::Name::Kids);
+    for (auto entry : kids) {
+        syntax::OutputDictionaryObjectPtr kid;
+        if (ClassifyChildEntry(entry, kid) == ChildEntryType::Field) {
             return false;
         }
     }
@@ -112,11 +126,10 @@ types::size_type Field::GetChildCount() const {
 
     types::size_type count = 0;
 
-    auto kids = _obj->FindAs<syntax::ArrayObjectPtr<syntax::DictionaryObjectPtr>>(constant::Name::Kids);
-    auto kids_size = kids->GetSize();
-    for (decltype(kids_size) i = 0; i < kids_size; ++i) {
-        auto kid = kids->GetValue(i);
-        if (IsFieldDictionary(kid)) {
+    auto kids = _obj->FindAs<syntax::MixedArrayObjectPtr>(constant::Name::Kids);
+    for (auto entry : kids) {
+        syntax::OutputDictionaryObjectPtr kid;
+        if (ClassifyChildEntry(entry, kid) == ChildEntryType::Field) {
             count += 1;
         }
     }
@@ -128,11 +141,10 @@ FieldPtr Field::GetChild(types::size_type index) const {
     if (_obj->Contains(constant::Name::Kids)) {
         types::size_type current = 0;
 
-        auto kids = _obj->FindAs<syntax::ArrayObjectPtr<syntax::DictionaryObjectPtr>>(constant::Name::Kids);
-        auto kids_size = kids->GetSize();
-        for (decltype(kids_size) i = 0; i < kids_size; ++i) {
-            auto kid = kids->GetValue(i);
-            if (!IsFieldDictionary(kid)) {
+        auto kids = _obj->FindAs<syntax::MixedArrayObjectPtr>(constant::Name::Kids);
+        for (auto entry : kids) {
+            syntax::OutputDictionaryObjectPtr kid;
+            if (ClassifyChildEntry(entry, kid) != ChildEntryType::Field) {
                 continue;
             }
 

--- a/src/vanillapdf/semantics/objects/fields.cpp
+++ b/src/vanillapdf/semantics/objects/fields.cpp
@@ -78,6 +78,12 @@ bool Field::GetInheritedEntry(const syntax::NameObject& key, syntax::OutputObjec
     return FindInheritedEntry(_obj, key, result);
 }
 
+bool Field::IsFieldDictionary(const syntax::DictionaryObjectPtr& dictionary) {
+    return dictionary->Contains(constant::Name::T)
+        || dictionary->Contains(constant::Name::Kids)
+        || dictionary->Contains(constant::Name::FT);
+}
+
 bool Field::IsTerminalDictionary(const syntax::DictionaryObjectPtr& dictionary) {
     if (!dictionary->Contains(constant::Name::Kids)) {
         return true;
@@ -87,7 +93,7 @@ bool Field::IsTerminalDictionary(const syntax::DictionaryObjectPtr& dictionary) 
     auto kids_size = kids->GetSize();
     for (decltype(kids_size) i = 0; i < kids_size; ++i) {
         auto kid = kids->GetValue(i);
-        if (kid->Contains(constant::Name::T)) {
+        if (IsFieldDictionary(kid)) {
             return false;
         }
     }
@@ -97,6 +103,60 @@ bool Field::IsTerminalDictionary(const syntax::DictionaryObjectPtr& dictionary) 
 
 bool Field::IsTerminal() const {
     return IsTerminalDictionary(_obj);
+}
+
+types::size_type Field::GetChildCount() const {
+    if (!_obj->Contains(constant::Name::Kids)) {
+        return 0;
+    }
+
+    types::size_type count = 0;
+
+    auto kids = _obj->FindAs<syntax::ArrayObjectPtr<syntax::DictionaryObjectPtr>>(constant::Name::Kids);
+    auto kids_size = kids->GetSize();
+    for (decltype(kids_size) i = 0; i < kids_size; ++i) {
+        auto kid = kids->GetValue(i);
+        if (IsFieldDictionary(kid)) {
+            count += 1;
+        }
+    }
+
+    return count;
+}
+
+FieldPtr Field::GetChild(types::size_type index) const {
+    if (_obj->Contains(constant::Name::Kids)) {
+        types::size_type current = 0;
+
+        auto kids = _obj->FindAs<syntax::ArrayObjectPtr<syntax::DictionaryObjectPtr>>(constant::Name::Kids);
+        auto kids_size = kids->GetSize();
+        for (decltype(kids_size) i = 0; i < kids_size; ++i) {
+            auto kid = kids->GetValue(i);
+            if (!IsFieldDictionary(kid)) {
+                continue;
+            }
+
+            if (current == index) {
+                return Create(kid);
+            }
+
+            current += 1;
+        }
+    }
+
+    LOG_ERROR_AND_THROW(syntax::ObjectMissingException, "Child field index out of range: {}", index);
+}
+
+bool Field::GetParent(OuputFieldPtr& result) const {
+    std::map<syntax::IndirectReferenceId, bool> visited;
+
+    syntax::DictionaryObjectPtr parent_dictionary;
+    if (!TryGetParentDictionary(_obj, visited, parent_dictionary)) {
+        return false;
+    }
+
+    result = Create(parent_dictionary);
+    return true;
 }
 
 BufferPtr Field::GetQualifiedName() const {
@@ -225,6 +285,18 @@ void Field::SetFieldFlags(types::big_int value) {
     }
     auto flags = make_deferred<syntax::IntegerObject>(value);
     _obj->Insert(constant::Name::Ff, flags);
+}
+
+bool Field::GetValueObject(syntax::OutputObjectPtr& result) const {
+
+    // /V is inheritable (Table 220)
+    return GetInheritedEntry(constant::Name::V, result);
+}
+
+bool Field::GetDefaultValueObject(syntax::OutputObjectPtr& result) const {
+
+    // /DV is inheritable (Table 220)
+    return GetInheritedEntry(constant::Name::DV, result);
 }
 
 bool Field::GetDefaultAppearance(syntax::OutputStringObjectPtr& result) const {
@@ -417,11 +489,6 @@ bool SignatureField::Value(OuputDigitalSignaturePtr& result) const {
     auto digital_signature = make_deferred<DigitalSignature>(value_dictionary);
     result = digital_signature;
     return true;
-}
-
-FieldCollectionPtr FieldCollection::Create() {
-    syntax::ArrayObjectPtr<syntax::DictionaryObjectPtr> fields;
-    return make_deferred<FieldCollection>(fields);
 }
 
 types::size_type FieldCollection::GetSize() const {

--- a/src/vanillapdf/semantics/objects/fields.h
+++ b/src/vanillapdf/semantics/objects/fields.h
@@ -51,13 +51,35 @@ public:
     // /Kids, the same way QPDF classifies the entries.
     static bool IsFieldDictionary(const syntax::DictionaryObjectPtr& dictionary);
 
+    // The kinds of entry a /Fields or /Kids array holds. Both arrays shall
+    // hold indirect references (Table 218, Table 220): a reference to a
+    // field dictionary is a child field, a reference to any other
+    // dictionary is a widget annotation. Anything else - a direct
+    // dictionary, a reference to something other than a dictionary - is
+    // malformed. It does occur in existing files and is skipped with a
+    // warning rather than failing the enumeration, the same policy every
+    // hierarchy walker applies to a cyclic /Kids link.
+    enum class ChildEntryType {
+        Undefined = 0,
+        Field,
+        Widget,
+        Malformed
+    };
+
+    // Classifies one entry of a /Fields or /Kids array, resolving the
+    // dictionary for a field or a widget. The tree and the field's own
+    // child walk share this one classification, so the flat view stays a
+    // projection of the structural one.
+    static ChildEntryType ClassifyChildEntry(const syntax::ObjectPtr& entry, syntax::OutputDictionaryObjectPtr& dictionary);
+
     // A terminal field has no children other than widget annotations (12.7.3.2).
     static bool IsTerminalDictionary(const syntax::DictionaryObjectPtr& dictionary);
     bool IsTerminal() const;
 
-    // Child fields in /Kids order - widget annotations are not children.
-    // Zero for a terminal field. The level above the root-level fields is
-    // the /Fields array, enumerated by FieldTree::GetRootChild.
+    // Child fields in /Kids order - widget annotations are not children,
+    // malformed entries are skipped as ClassifyChildEntry describes. Zero
+    // for a terminal field. The level above the root-level fields is the
+    // /Fields array, enumerated by FieldTree::GetRootChild.
     types::size_type GetChildCount() const;
     FieldPtr GetChild(types::size_type index) const;
 

--- a/src/vanillapdf/semantics/objects/fields.h
+++ b/src/vanillapdf/semantics/objects/fields.h
@@ -12,14 +12,14 @@ class FieldCollection : public HighLevelObject<syntax::ArrayObjectPtr<syntax::Di
 public:
     explicit FieldCollection(syntax::ArrayObjectPtr<syntax::DictionaryObjectPtr> root) : HighLevelObject(root) {}
 
-    // Creates an empty field collection. The array is attached as a direct
-    // object through InteractiveForm::SetFields.
-    static FieldCollectionPtr Create();
-
     types::size_type GetSize() const;
     FieldPtr At(types::size_type index) const;
 };
 
+// A view over one field dictionary (12.7.3.1). The hierarchy it belongs to
+// is the concern of FieldTree: the root /Fields array is the top of the
+// hierarchy and the tree enumerates that level, a field enumerates its own
+// /Kids below it. A field knows its ancestors through /Parent only.
 class Field : public HighLevelObject<syntax::DictionaryObjectPtr> {
 public:
     enum Type {
@@ -44,11 +44,26 @@ public:
 
     virtual Field::Type GetFieldType() const noexcept = 0;
 
+    // A /Kids entry is a child field when it carries /T, /Kids or /FT;
+    // otherwise it is a widget annotation. A merged field carries both /T
+    // and /Subtype /Widget and is a child field. Widgets never have /T; a
+    // nameless intermediate node is legal (12.7.3.2) and recognized by its
+    // /Kids, the same way QPDF classifies the entries.
+    static bool IsFieldDictionary(const syntax::DictionaryObjectPtr& dictionary);
+
     // A terminal field has no children other than widget annotations (12.7.3.2).
-    // Child fields are recognized by their /T partial name, which widget
-    // annotations do not carry.
     static bool IsTerminalDictionary(const syntax::DictionaryObjectPtr& dictionary);
     bool IsTerminal() const;
+
+    // Child fields in /Kids order - widget annotations are not children.
+    // Zero for a terminal field. The level above the root-level fields is
+    // the /Fields array, enumerated by FieldTree::GetRootChild.
+    types::size_type GetChildCount() const;
+    FieldPtr GetChild(types::size_type index) const;
+
+    // The parent field through /Parent. A root-level field has none -
+    // Table 220 requires /Parent for kids only - and reports false.
+    bool GetParent(OuputFieldPtr& result) const;
 
     // Fully qualified field name: the /T partial names joined with '.' from
     // the root of the hierarchy down to this field (12.7.3.2). Levels without
@@ -70,12 +85,21 @@ public:
     bool GetFieldFlags(types::big_int& result) const;
     void SetFieldFlags(types::big_int value);
 
+    // The field value (/V) and default value (/DV) as raw objects, resolved
+    // through the /Parent chain (Table 220). Their type depends on the
+    // field type - a name for buttons, a text string for text fields, a
+    // text string or an array for choice fields, a dictionary for signature
+    // fields - which the typed subclasses expose directly.
+    bool GetValueObject(syntax::OutputObjectPtr& result) const;
+    bool GetDefaultValueObject(syntax::OutputObjectPtr& result) const;
+
     // Default appearance string (/DA) and quadding (/Q) for variable text
-    // fields, resolved through the /Parent chain. The document-wide default
-    // lives in the AcroForm dictionary (12.7.3.3) and is exposed by
-    // InteractiveForm::GetDefaultAppearance / GetQuadding - when the entry is
-    // missing here, the caller applies that fallback. The setters write this
-    // field's own dictionary, overriding any inherited value.
+    // fields, resolved through the /Parent chain - this field and its
+    // ancestors, nothing else. The document-wide default lives in the
+    // AcroForm dictionary (12.7.3.3), which owns the last step of the
+    // lookup: InteractiveForm::ResolveDefaultAppearance / ResolveQuadding.
+    // The setters write this field's own dictionary, overriding any
+    // inherited value.
     bool GetDefaultAppearance(syntax::OutputStringObjectPtr& result) const;
     void SetDefaultAppearance(syntax::StringObjectPtr value);
     bool GetQuadding(Quadding& result) const;

--- a/src/vanillapdf/semantics/objects/fields.h
+++ b/src/vanillapdf/semantics/objects/fields.h
@@ -40,6 +40,13 @@ public:
 
 public:
     explicit Field(syntax::DictionaryObjectPtr root) : HighLevelObject(root) {}
+
+    // The typed view over a dictionary, chosen by /FT resolved through the
+    // /Parent chain - it is inheritable, and a field merged with its widget
+    // annotation usually carries it on the parent only. The type says
+    // nothing about the position in the hierarchy: a group under a typed
+    // ancestor is a TextField / ButtonField / ... too, and IsTerminal is
+    // the question to ask about the position.
     static FieldPtr Create(syntax::DictionaryObjectPtr root);
 
     virtual Field::Type GetFieldType() const noexcept = 0;

--- a/src/vanillapdf/semantics/objects/interactive_forms.cpp
+++ b/src/vanillapdf/semantics/objects/interactive_forms.cpp
@@ -42,6 +42,30 @@ void InteractiveForm::SetFields(FieldCollectionPtr value) {
     InvalidateFieldCache();
 }
 
+void InteractiveForm::AddField(FieldPtr value) {
+    auto field_dictionary = value->GetObject();
+
+    // The /Fields array holds indirect references (Table 218) - a direct
+    // dictionary cannot be referenced and would serialize as a dangling 0 0 R
+    if (!field_dictionary->IsIndirect()) {
+        LOG_ERROR_AND_THROW(InvalidParameterException, "The field dictionary shall be an indirect object - allocate a cross-reference entry for it first");
+    }
+
+    if (!_obj->Contains(constant::Name::Fields)) {
+        syntax::MixedArrayObjectPtr mixed_array;
+        mixed_array->SetFile(_obj->GetFile());
+        mixed_array->SetInitialized();
+
+        _obj->Insert(constant::Name::Fields, mixed_array);
+    }
+
+    auto root_fields = _obj->FindAs<syntax::ArrayObjectPtr<syntax::IndirectReferenceObjectPtr>>(constant::Name::Fields);
+    auto field_reference = make_deferred<syntax::IndirectReferenceObject>(field_dictionary);
+    root_fields->Append(field_reference);
+
+    InvalidateFieldCache();
+}
+
 void InteractiveForm::BuildFieldCache() const {
     if (!_obj->Contains(constant::Name::Fields)) {
         m_cache_built = true;

--- a/src/vanillapdf/semantics/objects/interactive_forms.cpp
+++ b/src/vanillapdf/semantics/objects/interactive_forms.cpp
@@ -2,23 +2,19 @@
 
 #include "semantics/objects/signature_flags.h"
 #include "semantics/objects/interactive_forms.h"
+#include "semantics/objects/field_tree.h"
 #include "semantics/objects/fields.h"
 #include "semantics/objects/document.h"
 
-#include "syntax/exceptions/syntax_exceptions.h"
 #include "syntax/files/file.h"
 #include "syntax/objects/array_object.h"
 #include "syntax/utils/name_constants.h"
-
-#include "utils/buffer.h"
-
-#include <map>
 
 namespace vanillapdf {
 namespace semantics {
 
 InteractiveForm::InteractiveForm(syntax::DictionaryObjectPtr root) : HighLevelObject(root) {
-    m_cache_lock = std::unique_ptr<std::recursive_mutex>(pdf_new std::recursive_mutex());
+    m_access_lock = std::unique_ptr<std::recursive_mutex>(pdf_new std::recursive_mutex());
 }
 
 InteractiveFormPtr InteractiveForm::Create(DocumentPtr document) {
@@ -37,157 +33,45 @@ InteractiveFormPtr InteractiveForm::Create(DocumentPtr document) {
     return make_deferred<InteractiveForm>(raw_dictionary);
 }
 
-void InteractiveForm::SetFields(FieldCollectionPtr value) {
-    ACCESS_LOCK_GUARD(m_cache_lock);
+bool InteractiveForm::GetFieldTree(OutputFieldTreePtr& result) const {
+    ACCESS_LOCK_GUARD(m_access_lock);
 
-    _obj->Insert(constant::Name::Fields, value->GetObject(), true);
-    InvalidateFieldCache();
-}
-
-void InteractiveForm::AddField(FieldPtr value) {
-    auto field_dictionary = value->GetObject();
-
-    // The /Fields array holds indirect references (Table 218) - a direct
-    // dictionary cannot be referenced and would serialize as a dangling 0 0 R
-    if (!field_dictionary->IsIndirect()) {
-        LOG_ERROR_AND_THROW(InvalidParameterException, "The field dictionary shall be an indirect object - allocate a cross-reference entry for it first");
+    if (!m_field_tree.empty()) {
+        result = m_field_tree;
+        return true;
     }
-
-    // The cache lock spans the whole mutation, so the create-if-missing
-    // check and the append are atomic with respect to concurrent mutators
-    // and cache builds on this form
-    ACCESS_LOCK_GUARD(m_cache_lock);
 
     if (!_obj->Contains(constant::Name::Fields)) {
-        syntax::MixedArrayObjectPtr mixed_array;
-        mixed_array->SetFile(_obj->GetFile());
-        mixed_array->SetInitialized();
-
-        _obj->Insert(constant::Name::Fields, mixed_array);
+        return false;
     }
 
-    auto root_fields = _obj->FindAs<syntax::ArrayObjectPtr<syntax::IndirectReferenceObjectPtr>>(constant::Name::Fields);
-    auto field_reference = make_deferred<syntax::IndirectReferenceObject>(field_dictionary);
-    root_fields->Append(field_reference);
+    auto fields = _obj->FindAs<syntax::ArrayObjectPtr<syntax::IndirectReferenceObjectPtr>>(constant::Name::Fields);
+    m_field_tree = make_deferred<FieldTree>(fields);
 
-    InvalidateFieldCache();
+    result = m_field_tree;
+    return true;
 }
 
-void InteractiveForm::BuildFieldCache() const {
-    if (!_obj->Contains(constant::Name::Fields)) {
-        m_cache_built = true;
-        return;
-    }
+void InteractiveForm::SetFieldTree(FieldTreePtr value) {
+    ACCESS_LOCK_GUARD(m_access_lock);
 
-    // Both /Fields and /Kids shall contain indirect references (Table 218,
-    // Table 220), so the tree is walked as references and every node is
-    // dereferenced only after the cycle check - the same way PageTree types
-    // its kids array.
-    auto root_fields = _obj->FindAs<syntax::ArrayObjectPtr<syntax::IndirectReferenceObjectPtr>>(constant::Name::Fields);
+    auto fields = value->GetObject();
+    _obj->Insert(constant::Name::Fields, fields->Data(), true);
 
-    // Malformed documents can link /Kids in a cycle. Visited nodes are
-    // tracked by their object identity, the same way Field guards its
-    // /Parent chain walk.
-    std::map<syntax::IndirectReferenceId, bool> visited;
-
-    for (auto field_reference : root_fields) {
-        BuildFieldCacheInternal(field_reference, visited);
-    }
-
-    m_cache_built = true;
-}
-
-void InteractiveForm::BuildFieldCacheInternal(
-    syntax::IndirectReferenceObjectPtr node_reference,
-    std::map<syntax::IndirectReferenceId, bool>& visited) const {
-
-    auto object_number = node_reference->GetReferencedObjectNumber();
-    auto generation_number = node_reference->GetReferencedGenerationNumber();
-    syntax::IndirectReferenceId node_id(object_number, generation_number);
-
-    auto found = visited.find(node_id);
-    if (found != visited.end() && found->second) {
-        spdlog::warn("Cyclic /Kids entry while enumerating form fields");
-        return;
-    }
-
-    visited[node_id] = true;
-
-    auto node = node_reference->GetReferencedObjectAs<syntax::DictionaryObjectPtr>();
-
-    if (Field::IsTerminalDictionary(node)) {
-        m_field_cache.push_back(node);
-        return;
-    }
-
-    // Only field dictionaries are hierarchy nodes - sibling widget
-    // annotations stay attached to their field (12.7.3.2)
-    auto kids = node->FindAs<syntax::ArrayObjectPtr<syntax::IndirectReferenceObjectPtr>>(constant::Name::Kids);
-    for (auto kid_reference : kids) {
-        auto kid = kid_reference->GetReferencedObjectAs<syntax::DictionaryObjectPtr>();
-        if (!kid->Contains(constant::Name::T)) {
-            continue;
-        }
-
-        BuildFieldCacheInternal(kid_reference, visited);
-    }
-}
-
-void InteractiveForm::InvalidateFieldCache() {
-    ACCESS_LOCK_GUARD(m_cache_lock);
-
-    m_field_cache.clear();
-    m_cache_built = false;
-}
-
-types::size_type InteractiveForm::GetFieldCount() const {
-    ACCESS_LOCK_GUARD(m_cache_lock);
-
-    if (!m_cache_built) {
-        BuildFieldCache();
-    }
-
-    return m_field_cache.size();
-}
-
-FieldPtr InteractiveForm::GetField(types::size_type index) const {
-    ACCESS_LOCK_GUARD(m_cache_lock);
-
-    if (!m_cache_built) {
-        BuildFieldCache();
-    }
-
-    if (index >= m_field_cache.size()) {
-        LOG_ERROR_AND_THROW(syntax::ObjectMissingException, "Field index out of range: {}", index);
-    }
-
-    return Field::Create(m_field_cache[index]);
-}
-
-bool InteractiveForm::TryFindField(std::string_view qualified_name, OuputFieldPtr& result) const {
-    ACCESS_LOCK_GUARD(m_cache_lock);
-
-    if (!m_cache_built) {
-        BuildFieldCache();
-    }
-
-    for (const auto& field_dictionary : m_field_cache) {
-        auto field = Field::Create(field_dictionary);
-        auto field_qualified_name = field->GetQualifiedName();
-        if (field_qualified_name->ToString() == qualified_name) {
-            result = field;
-            return true;
-        }
-    }
-
-    return false;
+    // The installed instance is the one handed out from now on, so that the
+    // caller's handle and the form share a single cache
+    m_field_tree = value;
 }
 
 void InteractiveForm::SetSignatureFlags(SignatureFlagsPtr value) {
+    ACCESS_LOCK_GUARD(m_access_lock);
+
     _obj->Insert(constant::Name::SigFlags, value->GetObject(), true);
 }
 
 bool InteractiveForm::GetFields(OuputFieldCollectionPtr& result) const {
+    ACCESS_LOCK_GUARD(m_access_lock);
+
     if (!_obj->Contains(constant::Name::Fields)) {
         return false;
     }
@@ -198,6 +82,8 @@ bool InteractiveForm::GetFields(OuputFieldCollectionPtr& result) const {
 }
 
 bool InteractiveForm::GetSignatureFlags(OutputSignatureFlagsPtr& result) const {
+    ACCESS_LOCK_GUARD(m_access_lock);
+
     if (!_obj->Contains(constant::Name::SigFlags)) {
         return false;
     }
@@ -208,6 +94,8 @@ bool InteractiveForm::GetSignatureFlags(OutputSignatureFlagsPtr& result) const {
 }
 
 bool InteractiveForm::GetNeedAppearances(bool& result) const {
+    ACCESS_LOCK_GUARD(m_access_lock);
+
     if (!_obj->Contains(constant::Name::NeedAppearances)) {
         return false;
     }
@@ -218,6 +106,8 @@ bool InteractiveForm::GetNeedAppearances(bool& result) const {
 }
 
 bool InteractiveForm::GetDefaultAppearance(syntax::OutputStringObjectPtr& result) const {
+    ACCESS_LOCK_GUARD(m_access_lock);
+
     if (!_obj->Contains(constant::Name::DA)) {
         return false;
     }
@@ -227,10 +117,14 @@ bool InteractiveForm::GetDefaultAppearance(syntax::OutputStringObjectPtr& result
 }
 
 void InteractiveForm::SetDefaultAppearance(syntax::StringObjectPtr value) {
+    ACCESS_LOCK_GUARD(m_access_lock);
+
     _obj->Insert(constant::Name::DA, value, true);
 }
 
 bool InteractiveForm::GetQuadding(Field::Quadding& result) const {
+    ACCESS_LOCK_GUARD(m_access_lock);
+
     if (!_obj->Contains(constant::Name::Q)) {
         return false;
     }
@@ -241,11 +135,28 @@ bool InteractiveForm::GetQuadding(Field::Quadding& result) const {
 }
 
 void InteractiveForm::SetQuadding(Field::Quadding value) {
+    ACCESS_LOCK_GUARD(m_access_lock);
+
     auto quadding = make_deferred<syntax::IntegerObject>(Field::ConvertQuadding(value));
     _obj->Insert(constant::Name::Q, quadding, true);
 }
 
+bool InteractiveForm::ResolveDefaultAppearance(const FieldPtr& field, syntax::OutputStringObjectPtr& result) const {
+    return field->GetDefaultAppearance(result) || GetDefaultAppearance(result);
+}
+
+Field::Quadding InteractiveForm::ResolveQuadding(const FieldPtr& field) const {
+    Field::Quadding quadding = Field::Quadding::LeftJustified;
+    if (field->GetQuadding(quadding) || GetQuadding(quadding)) {
+        return quadding;
+    }
+
+    return Field::Quadding::LeftJustified;
+}
+
 void InteractiveForm::SetNeedAppearances(bool value) {
+    ACCESS_LOCK_GUARD(m_access_lock);
+
     if (_obj->Contains(constant::Name::NeedAppearances)) {
         bool removed = _obj->Remove(constant::Name::NeedAppearances);
         assert(removed && "Unable to remove existing item"); UNUSED(removed);
@@ -255,6 +166,8 @@ void InteractiveForm::SetNeedAppearances(bool value) {
 }
 
 FieldCollectionPtr InteractiveForm::CreateFields() {
+    ACCESS_LOCK_GUARD(m_access_lock);
+
     if (!_obj->Contains(constant::Name::Fields)) {
         syntax::MixedArrayObjectPtr mixed_array;
         mixed_array->SetFile(_obj->GetFile());
@@ -268,6 +181,8 @@ FieldCollectionPtr InteractiveForm::CreateFields() {
 }
 
 SignatureFlagsPtr InteractiveForm::CreateSignatureFlags() {
+    ACCESS_LOCK_GUARD(m_access_lock);
+
     if (!_obj->Contains(constant::Name::SigFlags)) {
         syntax::IntegerObjectPtr signature_flags;
         signature_flags->SetFile(_obj->GetFile());

--- a/src/vanillapdf/semantics/objects/interactive_forms.cpp
+++ b/src/vanillapdf/semantics/objects/interactive_forms.cpp
@@ -38,6 +38,8 @@ InteractiveFormPtr InteractiveForm::Create(DocumentPtr document) {
 }
 
 void InteractiveForm::SetFields(FieldCollectionPtr value) {
+    ACCESS_LOCK_GUARD(m_cache_lock);
+
     _obj->Insert(constant::Name::Fields, value->GetObject(), true);
     InvalidateFieldCache();
 }
@@ -50,6 +52,11 @@ void InteractiveForm::AddField(FieldPtr value) {
     if (!field_dictionary->IsIndirect()) {
         LOG_ERROR_AND_THROW(InvalidParameterException, "The field dictionary shall be an indirect object - allocate a cross-reference entry for it first");
     }
+
+    // The cache lock spans the whole mutation, so the create-if-missing
+    // check and the append are atomic with respect to concurrent mutators
+    // and cache builds on this form
+    ACCESS_LOCK_GUARD(m_cache_lock);
 
     if (!_obj->Contains(constant::Name::Fields)) {
         syntax::MixedArrayObjectPtr mixed_array;

--- a/src/vanillapdf/semantics/objects/interactive_forms.cpp
+++ b/src/vanillapdf/semantics/objects/interactive_forms.cpp
@@ -56,6 +56,19 @@ void InteractiveForm::SetFieldTree(FieldTreePtr value) {
     ACCESS_LOCK_GUARD(m_access_lock);
 
     auto fields = value->GetObject();
+
+    // The array carries the file it was created for (FieldTree::Create,
+    // or the parser), and Insert sets the owner only. A hierarchy of
+    // another document holds references to that document's objects;
+    // installed here they would serialize as this document's object
+    // numbers, dangling. A detached form dictionary has no file to compare
+    // against.
+    auto tree_file = fields->Data()->GetFile();
+    auto form_file = _obj->GetFile();
+    if (!tree_file.IsEmpty() && !form_file.IsEmpty() && !tree_file.Identity(form_file)) {
+        LOG_ERROR_AND_THROW(InvalidParameterException, "The field hierarchy belongs to a different document than the form");
+    }
+
     _obj->Insert(constant::Name::Fields, fields->Data(), true);
 
     // The installed instance is the one handed out from now on, so that the

--- a/src/vanillapdf/semantics/objects/interactive_forms.cpp
+++ b/src/vanillapdf/semantics/objects/interactive_forms.cpp
@@ -18,8 +18,10 @@ InteractiveForm::InteractiveForm(syntax::DictionaryObjectPtr root) : HighLevelOb
 }
 
 InteractiveFormPtr InteractiveForm::Create(DocumentPtr document) {
-    auto file = document->GetFile();
+    return Create(document->GetFile());
+}
 
+InteractiveFormPtr InteractiveForm::Create(syntax::FilePtr file) {
     syntax::DictionaryObjectPtr raw_dictionary;
 
     auto new_entry = file->AllocateNewEntry();

--- a/src/vanillapdf/semantics/objects/interactive_forms.cpp
+++ b/src/vanillapdf/semantics/objects/interactive_forms.cpp
@@ -178,21 +178,6 @@ void InteractiveForm::SetNeedAppearances(bool value) {
     _obj->Insert(constant::Name::NeedAppearances, bool_obj);
 }
 
-FieldCollectionPtr InteractiveForm::CreateFields() {
-    ACCESS_LOCK_GUARD(m_access_lock);
-
-    if (!_obj->Contains(constant::Name::Fields)) {
-        syntax::MixedArrayObjectPtr mixed_array;
-        mixed_array->SetFile(_obj->GetFile());
-        mixed_array->SetInitialized();
-
-        _obj->Insert(constant::Name::Fields, mixed_array);
-    }
-
-    auto fields = _obj->FindAs<syntax::ArrayObjectPtr<syntax::DictionaryObjectPtr>>(constant::Name::Fields);
-    return make_deferred<FieldCollection>(fields);
-}
-
 SignatureFlagsPtr InteractiveForm::CreateSignatureFlags() {
     ACCESS_LOCK_GUARD(m_access_lock);
 

--- a/src/vanillapdf/semantics/objects/interactive_forms.h
+++ b/src/vanillapdf/semantics/objects/interactive_forms.h
@@ -5,12 +5,10 @@
 
 #include "semantics/objects/high_level_object.h"
 #include "semantics/objects/fields.h"
+#include "semantics/objects/field_tree.h"
 #include "semantics/objects/signature_flags.h"
 
-#include <map>
 #include <mutex>
-#include <string_view>
-#include <vector>
 
 namespace vanillapdf {
 namespace semantics {
@@ -23,26 +21,16 @@ public:
     // document. Attach it through Catalog::SetAcroForm to take effect.
     static InteractiveFormPtr Create(DocumentPtr document);
 
-    // Resolved terminal fields in document order. The field hierarchy's
-    // grouping nodes exist only for naming and attribute inheritance and are
-    // hidden, the same way PageTree hides its interior nodes behind Page().
-    // A radio button group is a single terminal field with one value,
-    // regardless of how many widget annotations represent it on the page.
-    types::size_type GetFieldCount() const;
-    FieldPtr GetField(types::size_type index) const;
-
-    // Finds a terminal field by its fully qualified name - the /T partial
-    // names joined with '.' (12.7.3.2), UTF-8 encoded
-    bool TryFindField(std::string_view qualified_name, OuputFieldPtr& result) const;
+    // The field hierarchy over the /Fields entry - the flat terminal
+    // enumeration, the structural walk and every field mutation live there.
+    // Reading never creates the entry: a form without /Fields has no
+    // hierarchy, and one is attached with SetFieldTree. One instance per
+    // form, so that the cache it owns is shared by everyone holding this
+    // form; the instance installed by SetFieldTree is the one handed out.
+    bool GetFieldTree(OutputFieldTreePtr& result) const;
+    void SetFieldTree(FieldTreePtr value);
 
     bool GetFields(OuputFieldCollectionPtr& result) const;
-    void SetFields(FieldCollectionPtr value);
-
-    // Appends a field to the root /Fields array, creating the array when the
-    // form does not have one yet. The array holds indirect references
-    // (Table 218), so the field's dictionary shall be an indirect object -
-    // a direct dictionary is an InvalidParameterException.
-    void AddField(FieldPtr value);
 
     bool GetSignatureFlags(OutputSignatureFlagsPtr& result) const;
     void SetSignatureFlags(SignatureFlagsPtr value);
@@ -50,14 +38,23 @@ public:
     bool GetNeedAppearances(bool& result) const;
     void SetNeedAppearances(bool value);
 
-    // Document-wide defaults for /DA and /Q (12.7.3.3). Field getters resolve
-    // these through the /Parent chain only - when a field reports the entry
-    // missing, the caller applies these form-level defaults.
+    // Document-wide defaults for /DA and /Q (12.7.3.3). Field getters
+    // resolve these through the /Parent chain only - when a field reports
+    // the entry missing, the caller applies these form-level defaults.
     bool GetDefaultAppearance(syntax::OutputStringObjectPtr& result) const;
     void SetDefaultAppearance(syntax::StringObjectPtr value);
 
     bool GetQuadding(Field::Quadding& result) const;
     void SetQuadding(Field::Quadding value);
+
+    // The /DA and /Q a field is rendered with: the field's own entry, then
+    // its ancestors through /Parent, then this form's document default
+    // (12.7.3.3). The field getters stop at the hierarchy; the form owns
+    // the last step because it owns the entry. /DA has no further default
+    // and may be absent everywhere; /Q defaults to left justification
+    // (Table 222), so it always resolves.
+    bool ResolveDefaultAppearance(const FieldPtr& field, syntax::OutputStringObjectPtr& result) const;
+    Field::Quadding ResolveQuadding(const FieldPtr& field) const;
 
     // Create-if-missing helpers retained for Document::Sign, which builds the
     // signature field on a form it may have just created itself
@@ -65,27 +62,18 @@ public:
     SignatureFlagsPtr CreateSignatureFlags();
 
 private:
-    // Flat cache of terminal field dictionary pointers in document order.
-    // Built in full on first access and cleared by SetFields and AddField, so
-    // structural changes are reflected on the next access (same pattern as
-    // PageTree's page cache). GetField constructs a Field on demand from the cached
-    // dictionary pointer. Mutating the raw /Fields array through the
-    // dictionary API bypasses the invalidation.
-    //
-    // The mutators hold the cache lock across the whole mutation, so
-    // AddField's create-if-missing check is atomic with respect to concurrent
-    // mutators and cache builds on this form instance. Distinct
-    // InteractiveForm wrappers over the same dictionary each carry their own
-    // cache and lock (canonicalization is issue #524).
-    mutable std::unique_ptr<std::recursive_mutex> m_cache_lock;
-    mutable std::vector<syntax::DictionaryObjectPtr> m_field_cache;
-    mutable bool m_cache_built = false;
+    // One lock for every operation on the form. The dictionary guards its
+    // individual entries itself, but the form's check-then-act sequences -
+    // the create-if-missing helpers, the remove-then-insert setters and the
+    // resolve-once field tree - are only atomic when the whole sequence
+    // runs under this lock. Distinct InteractiveForm wrappers over the same
+    // dictionary each carry their own lock (canonicalization is issue #524).
+    mutable std::unique_ptr<std::recursive_mutex> m_access_lock;
 
-    void BuildFieldCache() const;
-    void BuildFieldCacheInternal(
-        syntax::IndirectReferenceObjectPtr node_reference,
-        std::map<syntax::IndirectReferenceId, bool>& visited) const;
-    void InvalidateFieldCache();
+    // The tree instance is resolved once from /Fields and then handed out
+    // unchanged, or installed by SetFieldTree. The setter can replace it,
+    // so the lock-free fast path of CachedValue does not apply.
+    mutable OutputFieldTreePtr m_field_tree;
 };
 
 } // semantics

--- a/src/vanillapdf/semantics/objects/interactive_forms.h
+++ b/src/vanillapdf/semantics/objects/interactive_forms.h
@@ -56,9 +56,10 @@ public:
     bool ResolveDefaultAppearance(const FieldPtr& field, syntax::OutputStringObjectPtr& result) const;
     Field::Quadding ResolveQuadding(const FieldPtr& field) const;
 
-    // Create-if-missing helpers retained for Document::Sign, which builds the
-    // signature field on a form it may have just created itself
-    FieldCollectionPtr CreateFields();
+    // Create-if-missing helper retained for Document::Sign, which sets the
+    // flags on a form it may have just created itself. Fields have no such
+    // path: Document::Sign attaches a FieldTree like any other caller, so
+    // the tree's cache is never bypassed from inside the library.
     SignatureFlagsPtr CreateSignatureFlags();
 
 private:

--- a/src/vanillapdf/semantics/objects/interactive_forms.h
+++ b/src/vanillapdf/semantics/objects/interactive_forms.h
@@ -38,6 +38,12 @@ public:
     bool GetFields(OuputFieldCollectionPtr& result) const;
     void SetFields(FieldCollectionPtr value);
 
+    // Appends a field to the root /Fields array, creating the array when the
+    // form does not have one yet. The array holds indirect references
+    // (Table 218), so the field's dictionary shall be an indirect object -
+    // a direct dictionary is an InvalidParameterException.
+    void AddField(FieldPtr value);
+
     bool GetSignatureFlags(OutputSignatureFlagsPtr& result) const;
     void SetSignatureFlags(SignatureFlagsPtr value);
 
@@ -60,9 +66,9 @@ public:
 
 private:
     // Flat cache of terminal field dictionary pointers in document order.
-    // Built in full on first access and cleared by SetFields, so structural
-    // changes are reflected on the next access (same pattern as PageTree's
-    // page cache). GetField constructs a Field on demand from the cached
+    // Built in full on first access and cleared by SetFields and AddField, so
+    // structural changes are reflected on the next access (same pattern as
+    // PageTree's page cache). GetField constructs a Field on demand from the cached
     // dictionary pointer. Mutating the raw /Fields array through the
     // dictionary API bypasses the invalidation.
     mutable std::unique_ptr<std::recursive_mutex> m_cache_lock;

--- a/src/vanillapdf/semantics/objects/interactive_forms.h
+++ b/src/vanillapdf/semantics/objects/interactive_forms.h
@@ -71,6 +71,12 @@ private:
     // PageTree's page cache). GetField constructs a Field on demand from the cached
     // dictionary pointer. Mutating the raw /Fields array through the
     // dictionary API bypasses the invalidation.
+    //
+    // The mutators hold the cache lock across the whole mutation, so
+    // AddField's create-if-missing check is atomic with respect to concurrent
+    // mutators and cache builds on this form instance. Distinct
+    // InteractiveForm wrappers over the same dictionary each carry their own
+    // cache and lock (canonicalization is issue #524).
     mutable std::unique_ptr<std::recursive_mutex> m_cache_lock;
     mutable std::vector<syntax::DictionaryObjectPtr> m_field_cache;
     mutable bool m_cache_built = false;

--- a/src/vanillapdf/semantics/objects/interactive_forms.h
+++ b/src/vanillapdf/semantics/objects/interactive_forms.h
@@ -18,8 +18,11 @@ public:
     explicit InteractiveForm(syntax::DictionaryObjectPtr root);
 
     // Creates an empty form registered as an indirect object within the
-    // document. Attach it through Catalog::SetAcroForm to take effect.
+    // document. Attach it through Catalog::SetAcroForm to take effect. The
+    // document is the public form, mirrored by the C API; the file overload
+    // is for the library's own use, where Document holds its file directly.
     static InteractiveFormPtr Create(DocumentPtr document);
+    static InteractiveFormPtr Create(syntax::FilePtr file);
 
     // The field hierarchy over the /Fields entry - the flat terminal
     // enumeration, the structural walk and every field mutation live there.

--- a/src/vanillapdf/semantics/utils/semantics_fwd.h
+++ b/src/vanillapdf/semantics/utils/semantics_fwd.h
@@ -113,6 +113,7 @@ class UnicodeCharacterMap; using UnicodeCharacterMapPtr = Deferred<UnicodeCharac
 // Fields
 class Field; using FieldPtr = Deferred<Field>; using OuputFieldPtr = OutputPointer<FieldPtr>;
 class FieldCollection; using FieldCollectionPtr = Deferred<FieldCollection>; using OuputFieldCollectionPtr = OutputPointer<FieldCollectionPtr>;
+class FieldTree; using FieldTreePtr = Deferred<FieldTree>; using OutputFieldTreePtr = OutputPointer<FieldTreePtr>;
 class ButtonField; using ButtonFieldPtr = Deferred<ButtonField>;
 class TextField; using TextFieldPtr = Deferred<TextField>;
 class ChoiceField; using ChoiceFieldPtr = Deferred<ChoiceField>;


### PR DESCRIPTION
## Summary

Second slice of #510. The interactive form gets a proper field hierarchy object, `FieldTreeHandle`, that replaces the earlier `InteractiveForm_AddField` / `SetFields` attempt and the dictionary-node-oriented `FieldCollection` API. The tree is a view over the root `/Fields` array, the way `PageTreeHandle` is a view over the page tree root, and it is the single owner of the cache behind the flat field enumeration - every field mutation goes through it.

## API

**Two views over one structure.** The flat view - `FieldTree_GetFieldCount` / `FieldTree_GetField` / `FieldTree_FindField` - enumerates the resolved terminal fields in document order, which is what form filling works with. The structural view starts at the root level with `FieldTree_GetRootChildCount` / `FieldTree_GetRootChild` and continues down through `Field_GetChildCount` / `Field_GetChild`; `Field_GetParent` walks back up. Both views classify the `/Fields` and `/Kids` entries through one shared classification, so the flat view is exactly the set of terminals the structural walk reaches.

**Mutators.** `FieldTree_AddRootChild` / `FieldTree_InsertRootChild` at the root level, `FieldTree_AddChild` / `FieldTree_InsertChild` below it, `FieldTree_RemoveChild` at either. They validate the whole subtree a child brings - membership and fully qualified name uniqueness, tree-wide and within the subtree - under the names the hierarchy will give it, write `/Parent`, and keep the cache consistent themselves. `FieldTree_Invalidate` remains the documented contract for edits made underneath through the dictionary API.

**Attachment.** `FieldTree_CreateFromDocument` builds an empty hierarchy, `InteractiveForm_SetFieldTree` installs it as the form's `/Fields`, `InteractiveForm_GetFieldTree` returns it. Reading never creates the entry. Attaching a tree created for another document is refused - its references would serialize as dangling object numbers. The form hands out one tree instance and the catalog hands out one form instance (`Catalog_SetAcroForm` keeps the handle it is given), so a caller's handles and everything reaching the form through the catalog - `Document_Sign` included - share a single cache.

**Field.** `Field_IsTerminal`, `Field_GetChildCount` / `Field_GetChild` / `Field_GetParent`, `Field_GetQualifiedName` (UTF-8, the form `FieldTree_FindField` accepts), `Field_GetValue` / `Field_GetDefaultValue` as raw objects resolved through `/Parent`, `Field_SetName` (rejects a PERIOD), `/DA` and `/Q` getters and setters. `Field_GetType` resolves the inheritable `/FT` through `/Parent`, which is what makes merged widget fields report their type; the type is independent of the position in the hierarchy and the header says so. `InteractiveForm_ResolveDefaultAppearance` / `InteractiveForm_ResolveQuadding` finish the `/DA` and `/Q` lookup with the document default the form owns.

**Deprecated.** `FieldCollection_*` and `InteractiveForm_GetFields`, with doc pointers to the tree; the C++ `FieldCollection` stays for the deprecated wrapper until the 3.0 removal. `InteractiveForm::CreateFields` is gone - `Document::Sign` attaches a tree and adds the signature field through it, picking the first free `SignatureN` name with the same authority the tree rejects duplicates with.

## Damaged files

The hierarchy walk is the authority, not the entries a file happens to carry. Names are the traversal parent's name extended by the node's own `/T`, so the name index agrees with the enumeration by construction; a missing or wrong `/Parent` is warned about, never trusted, and `Field_GetQualifiedName` - which has nothing but `/Parent` to follow - can disagree with the tree on such a file. A malformed container entry (a direct dictionary, a reference to a non-dictionary), a stray dictionary in the root array, a cyclic `/Kids` link and a node reached from two parents are all skipped with a warning rather than failing a read-only enumeration. `FieldTree_RemoveChild` removes from the container the walk reached the field through.

## Performance

Every mutator used to drop the cache, and the validation of the next insert rebuilt it, so authoring N fields was O(N²). The cache now has two tiers: the membership and name index, which the insert mutators extend with the subtree they just validated, and the ordered views, which an insert only marks stale and the next read rebuilds in one walk. New benchmark `BM_FieldTreeAppendRootChildren` (Release, MSVC 18): 1000 fields 5192 ms -> 16.3 ms, 5000 fields 148490 ms -> 93 ms.

## Thread safety

Every `FieldTree_*` call on one tree handle is serialized on the tree's lock, so the flat view, the root level and the mutators may be used concurrently on the same tree; a mutation is atomic and a concurrent enumeration observes it entirely or not at all. `Field_*` calls are plain dictionary views and run outside that lock, which the header states. `FieldTreeThreadSafety.ConcurrentAddRootChildKeepsEnumerationConsistent` races eight writers against four readers on one tree.

## Testing

- 22 `FieldTree` unit tests: the walk at both levels, the parent round trip, values and appearance defaults through the hierarchy, every mutator with its refusals (duplicate names, foreign parents, widget-carrying and merged terminals, subtree validation), positional inserts, removal by the walk rather than `/Parent`, names following the walk on a file with wrong `/Parent` entries, direct dictionary and stray root entries skipped by both views, invalidation after raw edits including the stale-index removal error, attachment and cross-document refusal, save/reload persistence, and signing a document that already holds a `Signature1` group.
- `InteractiveForm` tests reworked for the tree (28), the signature-verifier and thread-safety tests migrated, the `verify` tool and the integration corpus walker use the tree.
- Verified locally (Debug, windows-x64-msvc-18): library, unit tests, integration tests and tools build; 137/137 across the form, field, signing, catalog and thread-safety suites.

Part of #510.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
