### PR TITLE
fix: Release handles on remove_page error paths and route its tests via the emulator

### DIFF
--- a/src/vanillapdf.tools/CMakeLists.txt
+++ b/src/vanillapdf.tools/CMakeLists.txt
@@ -273,7 +273,7 @@ if(VANILLAPDF_ENABLE_TESTS)
     # page number used to be applied directly to the root Kids array.
     add_test(
         NAME "Tools.remove_page.nested-pages.subtree-boundary"
-        COMMAND $<TARGET_FILE:vanillapdf.tools> remove_page -s "${VANILLAPDF_SOLUTION_SOURCE_DIR}/fixtures/nested-pages.pdf" -d "${CMAKE_CURRENT_BINARY_DIR}/remove_page-nested-pages.pdf" -n 4
+        COMMAND vanillapdf.tools remove_page -s "${VANILLAPDF_SOLUTION_SOURCE_DIR}/fixtures/nested-pages.pdf" -d "${CMAKE_CURRENT_BINARY_DIR}/remove_page-nested-pages.pdf" -n 4
     )
     set_tests_properties("Tools.remove_page.nested-pages.subtree-boundary" PROPERTIES
         PASS_REGULAR_EXPRESSION "Removed page 4 \\(5 -> 4 pages\\)"
@@ -282,7 +282,7 @@ if(VANILLAPDF_ENABLE_TESTS)
     # Flat single-node tree, removal from the middle of the wide Kids array
     add_test(
         NAME "Tools.remove_page.flat-pages.middle"
-        COMMAND $<TARGET_FILE:vanillapdf.tools> remove_page -s "${VANILLAPDF_SOLUTION_SOURCE_DIR}/fixtures/flat-pages.pdf" -d "${CMAKE_CURRENT_BINARY_DIR}/remove_page-flat-pages.pdf" -n 725
+        COMMAND vanillapdf.tools remove_page -s "${VANILLAPDF_SOLUTION_SOURCE_DIR}/fixtures/flat-pages.pdf" -d "${CMAKE_CURRENT_BINARY_DIR}/remove_page-flat-pages.pdf" -n 725
     )
     set_tests_properties("Tools.remove_page.flat-pages.middle" PROPERTIES
         PASS_REGULAR_EXPRESSION "Removed page 725 \\(1451 -> 1450 pages\\)"
@@ -291,7 +291,7 @@ if(VANILLAPDF_ENABLE_TESTS)
     # First page of a document with real content
     add_test(
         NAME "Tools.remove_page.sample-document.first"
-        COMMAND $<TARGET_FILE:vanillapdf.tools> remove_page -s "${VANILLAPDF_SOLUTION_SOURCE_DIR}/fixtures/sample-document.pdf" -d "${CMAKE_CURRENT_BINARY_DIR}/remove_page-sample-document.pdf" -n 1
+        COMMAND vanillapdf.tools remove_page -s "${VANILLAPDF_SOLUTION_SOURCE_DIR}/fixtures/sample-document.pdf" -d "${CMAKE_CURRENT_BINARY_DIR}/remove_page-sample-document.pdf" -n 1
     )
     set_tests_properties("Tools.remove_page.sample-document.first" PROPERTIES
         PASS_REGULAR_EXPRESSION "Removed page 1 \\(2 -> 1 pages\\)"
@@ -300,7 +300,7 @@ if(VANILLAPDF_ENABLE_TESTS)
     # Removing the only page leaves a document with an empty page tree
     add_test(
         NAME "Tools.remove_page.chinese_names.only-page"
-        COMMAND $<TARGET_FILE:vanillapdf.tools> remove_page -s "${VANILLAPDF_SOLUTION_SOURCE_DIR}/fixtures/chinese_names_中文的名字-2.pdf" -d "${CMAKE_CURRENT_BINARY_DIR}/remove_page-chinese_names.pdf" -n 1
+        COMMAND vanillapdf.tools remove_page -s "${VANILLAPDF_SOLUTION_SOURCE_DIR}/fixtures/chinese_names_中文的名字-2.pdf" -d "${CMAKE_CURRENT_BINARY_DIR}/remove_page-chinese_names.pdf" -n 1
     )
     set_tests_properties("Tools.remove_page.chinese_names.only-page" PROPERTIES
         PASS_REGULAR_EXPRESSION "Removed page 1 \\(1 -> 0 pages\\)"
@@ -310,7 +310,7 @@ if(VANILLAPDF_ENABLE_TESTS)
     # instead of the historical silent success
     add_test(
         NAME "Tools.remove_page.minimalist.out-of-range"
-        COMMAND $<TARGET_FILE:vanillapdf.tools> remove_page -s "${VANILLAPDF_SOLUTION_SOURCE_DIR}/fixtures/minimalist.pdf" -d "${CMAKE_CURRENT_BINARY_DIR}/remove_page-minimalist.pdf" -n 1
+        COMMAND vanillapdf.tools remove_page -s "${VANILLAPDF_SOLUTION_SOURCE_DIR}/fixtures/minimalist.pdf" -d "${CMAKE_CURRENT_BINARY_DIR}/remove_page-minimalist.pdf" -n 1
     )
     set_tests_properties("Tools.remove_page.minimalist.out-of-range" PROPERTIES
         PASS_REGULAR_EXPRESSION "out of range, the document has 0 pages"

--- a/src/vanillapdf.tools/remove_page.c
+++ b/src/vanillapdf.tools/remove_page.c
@@ -76,6 +76,13 @@ int process_remove_page(int argc, char *argv[]) {
     if ((size_type) page_number > page_count_before) {
         printf("Page number %d is out of range, the document has %llu pages\n",
             page_number, page_count_before_converted);
+
+        // Release the handles on this expected error path - a leak here trips
+        // LeakSanitizer, whose abort also discards the buffered message above
+        PageTree_Release(page_tree);
+        Catalog_Release(catalog);
+        Document_Release(document);
+        File_Release(source_file);
         return VANILLAPDF_TOOLS_ERROR_INVALID_PARAMETERS;
     }
 
@@ -87,6 +94,11 @@ int process_remove_page(int argc, char *argv[]) {
     if (page_count_after != page_count_before - 1) {
         printf("Page count mismatch after removal: %llu -> %llu\n",
             page_count_before_converted, page_count_after_converted);
+
+        PageTree_Release(page_tree);
+        Catalog_Release(catalog);
+        Document_Release(document);
+        File_Release(source_file);
         return VANILLAPDF_TOOLS_ERROR_FAILURE;
     }
 


### PR DESCRIPTION
## Summary

Fixes two nightly regressions on `main` caused by the crossed merges of #508 (`remove_page` tool + tests) and #520 (Android emulator job):

- **Sanitizer checks / ASan** ([run](https://github.com/vanillapdf/vanillapdf/actions/runs/32687293773/job/97314828604)): `Tools.remove_page.minimalist.out-of-range` failed. LeakSanitizer (bundled into ASan) flagged that `remove_page.c` returned early on the out-of-range path without releasing the file, document, catalog and page tree handles. LSan aborts through `_exit`, which also discarded the buffered "out of range" message the test greps for, so ctest reported "regex not found" on top of the leak. Both custom error paths (out-of-range and page-count mismatch) now release the handles before returning, mirroring `verify.c`.
- **Nightly full scan / android.28 + android.36** ([run](https://github.com/vanillapdf/vanillapdf/actions/runs/32684498451/job/97306940784)): all five `Tools.remove_page.*` tests were `BAD_COMMAND`. They used `$<TARGET_FILE:vanillapdf.tools>`, while #520 switched every other tools test to the bare target name so CMake prepends `CMAKE_CROSSCOMPILING_EMULATOR` (the adb wrapper). The host path was executed directly and did not exist on the device. The five tests now reference the target by name.

## Testing

- Rebuilt `windows-x64-msvc-18` Debug and ran `ctest -R "Tools\.remove_page"`: 5/5 pass.
- LSan and the Android emulator are not available locally; the sanitizer and nightly workflows will confirm those paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
