### PR TITLE
fix: Release the handle a HandleGuard already owns when it is refilled

### DIFF
--- a/src/vanillapdf.benchmark/handle_guard.h
+++ b/src/vanillapdf.benchmark/handle_guard.h
@@ -26,9 +26,7 @@ public:
     explicit HandleGuard(Handle* h) : handle_(h) {}
 
     ~HandleGuard() {
-        if (handle_) {
-            ReleaseFn(handle_);
-        }
+        reset();
     }
 
     // Move-only semantics to prevent double-release
@@ -38,9 +36,7 @@ public:
 
     HandleGuard& operator=(HandleGuard&& other) noexcept {
         if (this != &other) {
-            if (handle_) {
-                ReleaseFn(handle_);
-            }
+            reset();
             handle_ = other.handle_;
             other.handle_ = nullptr;
         }
@@ -52,9 +48,14 @@ public:
 
     /**
      * Returns a pointer to the internal handle pointer.
-     * Used with C API Create functions: Create(guard.out())
+     * Used with C API Create/Get functions: Create(guard.out()).
+     * A handle already owned by the guard is released first, so a guard
+     * declared outside a loop can be refilled on every iteration.
      */
-    Handle** out() { return &handle_; }
+    Handle** out() {
+        reset();
+        return &handle_;
+    }
 
     /**
      * Returns the raw handle pointer.
@@ -72,6 +73,17 @@ public:
      * Explicit bool conversion for null checks.
      */
     explicit operator bool() const { return handle_ != nullptr; }
+
+    /**
+     * Releases the owned handle now. The release result is deliberately
+     * ignored, matching the cleanup blocks it replaces.
+     */
+    void reset() {
+        if (handle_) {
+            ReleaseFn(handle_);
+            handle_ = nullptr;
+        }
+    }
 };
 
 #endif /* _VANILLAPDF_BENCHMARK_HANDLE_GUARD_H */

--- a/src/vanillapdf.fuzzer/handle_guard.h
+++ b/src/vanillapdf.fuzzer/handle_guard.h
@@ -26,9 +26,7 @@ public:
     explicit HandleGuard(Handle* h) : handle_(h) {}
 
     ~HandleGuard() {
-        if (handle_) {
-            ReleaseFn(handle_);
-        }
+        reset();
     }
 
     // Move-only semantics to prevent double-release
@@ -38,9 +36,7 @@ public:
 
     HandleGuard& operator=(HandleGuard&& other) noexcept {
         if (this != &other) {
-            if (handle_) {
-                ReleaseFn(handle_);
-            }
+            reset();
             handle_ = other.handle_;
             other.handle_ = nullptr;
         }
@@ -52,9 +48,14 @@ public:
 
     /**
      * Returns a pointer to the internal handle pointer.
-     * Used with C API Create functions: Create(guard.out())
+     * Used with C API Create/Get functions: Create(guard.out()).
+     * A handle already owned by the guard is released first, so a guard
+     * declared outside a loop can be refilled on every iteration.
      */
-    Handle** out() { return &handle_; }
+    Handle** out() {
+        reset();
+        return &handle_;
+    }
 
     /**
      * Returns the raw handle pointer.
@@ -72,6 +73,17 @@ public:
      * Explicit bool conversion for null checks.
      */
     explicit operator bool() const { return handle_ != nullptr; }
+
+    /**
+     * Releases the owned handle now. The release result is deliberately
+     * ignored, matching the cleanup blocks it replaces.
+     */
+    void reset() {
+        if (handle_) {
+            ReleaseFn(handle_);
+            handle_ = nullptr;
+        }
+    }
 };
 
 #endif /* _VANILLAPDF_FUZZER_HANDLE_GUARD_H */

--- a/src/vanillapdf.unittest/handle_guard.h
+++ b/src/vanillapdf.unittest/handle_guard.h
@@ -26,9 +26,7 @@ public:
     explicit HandleGuard(Handle* h) : handle_(h) {}
 
     ~HandleGuard() {
-        if (handle_) {
-            ReleaseFn(handle_);
-        }
+        reset();
     }
 
     // Move-only semantics to prevent double-release
@@ -38,9 +36,7 @@ public:
 
     HandleGuard& operator=(HandleGuard&& other) noexcept {
         if (this != &other) {
-            if (handle_) {
-                ReleaseFn(handle_);
-            }
+            reset();
             handle_ = other.handle_;
             other.handle_ = nullptr;
         }
@@ -52,9 +48,14 @@ public:
 
     /**
      * Returns a pointer to the internal handle pointer.
-     * Used with C API Create functions: Create(guard.out())
+     * Used with C API Create/Get functions: Create(guard.out()).
+     * A handle already owned by the guard is released first, so a guard can be
+     * reused for a second lookup without leaking the first result.
      */
-    Handle** out() { return &handle_; }
+    Handle** out() {
+        reset();
+        return &handle_;
+    }
 
     /**
      * Returns the raw handle pointer.
@@ -72,6 +73,17 @@ public:
      * Explicit bool conversion for null checks.
      */
     explicit operator bool() const { return handle_ != nullptr; }
+
+    /**
+     * Releases the owned handle now. The release result is deliberately
+     * ignored, matching the cleanup blocks it replaces.
+     */
+    void reset() {
+        if (handle_) {
+            ReleaseFn(handle_);
+            handle_ = nullptr;
+        }
+    }
 };
 
 #endif /* _VANILLAPDF_UNITTEST_HANDLE_GUARD_H */

--- a/src/vanillapdf.unittest/objects_test.cpp
+++ b/src/vanillapdf.unittest/objects_test.cpp
@@ -511,7 +511,6 @@ TEST(NameObject, Equals) {
     ASSERT_EQ(NameObject_Equals(first_ptr, second_ptr, &are_equal), VANILLAPDF_ERROR_SUCCESS);
     EXPECT_EQ(are_equal, VANILLAPDF_RV_TRUE);
 
-    second_ptr = HandleGuard<NameObjectHandle, NameObject_Release>();
     ASSERT_EQ(NameObject_CreateFromDecodedString("Other", second_ptr.out()), VANILLAPDF_ERROR_SUCCESS);
 
     ASSERT_EQ(NameObject_Equals(first_ptr, second_ptr, &are_equal), VANILLAPDF_ERROR_SUCCESS);


### PR DESCRIPTION
## The failure

LeakSanitizer failed the ASan job on `FieldTree.NamesFollowTheWalkNotParent` with 1929 bytes in 25 allocations ([run 33375296579](https://github.com/vanillapdf/vanillapdf/actions/runs/33375296579/job/99435686474)). Only one of the 25 was a *direct* leak; the other 24 hung off it, which is what made the report look larger than the bug.

The direct one traces to `field_tree_test.cpp:1017`, where the test looks two names up into the same guard:

```cpp
HandleGuard<FieldHandle, Field_Release> found;
EXPECT_EQ(FindFieldByName(sample.tree, "email.city", found.out()), VANILLAPDF_ERROR_SUCCESS);  // leaked
EXPECT_EQ(FindFieldByName(sample.tree, "street",     found.out()), VANILLAPDF_ERROR_SUCCESS);  // overwrote it
```

`out()` returned the address of the stored pointer without touching what was already there, so the second lookup clobbered the first `FieldHandle` and leaked it. That field carried the dictionary, its `/Parent` reference and the rest of the sample hierarchy — hence one 40 byte direct leak dragging 24 indirect ones behind it.

## The fix

`vanillapdf.tools` already resets in `out()`. It was written that way in #535, after LeakSanitizer caught the same shape on the `remove_page` path (#534), and its comment states the contract: *"A handle already owned by the guard is released first, so a guard declared outside a loop can be refilled on every iteration."* The `unittest`, `benchmark` and `fuzzer` copies of the header never followed. All three now carry the tools implementation, so the four copies hold the same class again (verified byte-identical modulo the header guard and doc comment).

Naming follows the established wrappers rather than inventing one:

| Type | raw ptr | free + null | out-param address |
|---|---|---|---|
| `std::unique_ptr` / `std::shared_ptr` | `get()` | `reset()` | — |
| `WRL::ComPtr` (COM AddRef/Release — the same model as our handles) | `Get()` | `Reset()` | `ReleaseAndGetAddressOf()` — releases first |
| `wil::unique_any` | `get()` | `reset()` | `put()` — resets first |

So `reset()` as in `unique_ptr`/`ComPtr`, and `out()` releasing before it yields the address as in `ReleaseAndGetAddressOf`/`put`. Deliberately not `release()`: in `unique_ptr` that means relinquish *without* freeing, the opposite of what this does.

The test itself is unchanged — with `out()` fixed, lines 1017/1018 express exactly what they mean. The hand-written `second_ptr = HandleGuard<...>();` in `objects_test.cpp`, which existed only as a workaround for this gap, is dropped.

## Verification

Built `vanillapdf.unittest` and `vanillapdf.benchmark` (windows-x64-msvc-18, Debug) and ran `ctest -R "FieldTree|InteractiveForm|Objects|Name"` — 85/85 passed, including the failing test and the edited one. The ASan job itself is the real check, since LeakSanitizer does not run on Windows. The fuzzer copy is Clang-only and was not compiled locally; its diff is identical to the two that were.
