### PR TITLE
refactor: Log errors at the throw site and name the value that failed

### DIFF
--- a/src/vanillapdf/contents/content_stream_operations.cpp
+++ b/src/vanillapdf/contents/content_stream_operations.cpp
@@ -18,35 +18,35 @@ using namespace syntax;
 OperationBeginText::OperationBeginText(const std::vector<ObjectPtr>& operands) {
     assert(operands.size() == 0);
     if (operands.size() != 0) {
-        throw syntax::ParseException("Unexpected number of arguments");
+        LOG_ERROR_AND_THROW(syntax::ParseException, "Unexpected number of arguments");
     }
 }
 
 OperationEndText::OperationEndText(const std::vector<ObjectPtr>& operands) {
     assert(operands.size() == 0);
     if (operands.size() != 0) {
-        throw syntax::ParseException("Unexpected number of arguments");
+        LOG_ERROR_AND_THROW(syntax::ParseException, "Unexpected number of arguments");
     }
 }
 
 OperationSaveGraphicsState::OperationSaveGraphicsState(const std::vector<ObjectPtr>& operands) {
     assert(operands.size() == 0);
     if (operands.size() != 0) {
-        throw syntax::ParseException("Unexpected number of arguments");
+        LOG_ERROR_AND_THROW(syntax::ParseException, "Unexpected number of arguments");
     }
 }
 
 OperationRestoreGraphicsState::OperationRestoreGraphicsState(const std::vector<ObjectPtr>& operands) {
     assert(operands.size() == 0);
     if (operands.size() != 0) {
-        throw syntax::ParseException("Unexpected number of arguments");
+        LOG_ERROR_AND_THROW(syntax::ParseException, "Unexpected number of arguments");
     }
 }
 
 OperationSetStrokingColorSpaceRGB::OperationSetStrokingColorSpaceRGB(const std::vector<ObjectPtr>& operands) {
     assert(operands.size() == 3);
     if (operands.size() != 3) {
-        throw syntax::ParseException("Unexpected number of arguments");
+        LOG_ERROR_AND_THROW(syntax::ParseException, "Unexpected number of arguments");
     }
 
     auto red = operands.at(0);
@@ -54,15 +54,15 @@ OperationSetStrokingColorSpaceRGB::OperationSetStrokingColorSpaceRGB(const std::
     auto blue = operands.at(2);
 
     if (!ObjectUtils::IsType<RealObjectPtr>(red)) {
-        throw syntax::ParseException("Unexpected argument type");
+        LOG_ERROR_AND_THROW(syntax::ParseException, "Unexpected argument type");
     }
 
     if (!ObjectUtils::IsType<RealObjectPtr>(green)) {
-        throw syntax::ParseException("Unexpected argument type");
+        LOG_ERROR_AND_THROW(syntax::ParseException, "Unexpected argument type");
     }
 
     if (!ObjectUtils::IsType<RealObjectPtr>(blue)) {
-        throw syntax::ParseException("Unexpected argument type");
+        LOG_ERROR_AND_THROW(syntax::ParseException, "Unexpected argument type");
     }
 
     m_red = syntax::ObjectUtils::ConvertTo<RealObjectPtr>(red);
@@ -73,7 +73,7 @@ OperationSetStrokingColorSpaceRGB::OperationSetStrokingColorSpaceRGB(const std::
 OperationSetNonstrokingColorSpaceRGB::OperationSetNonstrokingColorSpaceRGB(const std::vector<ObjectPtr>& operands) {
     assert(operands.size() == 3);
     if (operands.size() != 3) {
-        throw syntax::ParseException("Unexpected number of arguments");
+        LOG_ERROR_AND_THROW(syntax::ParseException, "Unexpected number of arguments");
     }
 
     auto red = operands.at(0);
@@ -81,15 +81,15 @@ OperationSetNonstrokingColorSpaceRGB::OperationSetNonstrokingColorSpaceRGB(const
     auto blue = operands.at(2);
 
     if (!ObjectUtils::IsType<RealObjectPtr>(red)) {
-        throw syntax::ParseException("Unexpected argument type");
+        LOG_ERROR_AND_THROW(syntax::ParseException, "Unexpected argument type");
     }
 
     if (!ObjectUtils::IsType<RealObjectPtr>(green)) {
-        throw syntax::ParseException("Unexpected argument type");
+        LOG_ERROR_AND_THROW(syntax::ParseException, "Unexpected argument type");
     }
 
     if (!ObjectUtils::IsType<RealObjectPtr>(blue)) {
-        throw syntax::ParseException("Unexpected argument type");
+        LOG_ERROR_AND_THROW(syntax::ParseException, "Unexpected argument type");
     }
 
     m_red = syntax::ObjectUtils::ConvertTo<RealObjectPtr>(red);
@@ -100,19 +100,19 @@ OperationSetNonstrokingColorSpaceRGB::OperationSetNonstrokingColorSpaceRGB(const
 OperationTextFont::OperationTextFont(const std::vector<ObjectPtr>& operands) {
     assert(operands.size() == 2);
     if (operands.size() != 2) {
-        throw syntax::ParseException("Unexpected number of arguments");
+        LOG_ERROR_AND_THROW(syntax::ParseException, "Unexpected number of arguments");
     }
 
     auto name = operands.at(0);
     auto scale = operands.at(1);
     if (!ObjectUtils::IsType<NameObjectPtr>(name)) {
         assert(!"Text font operation has invalid arguments");
-        throw syntax::ParseException("Unexpected argument type");
+        LOG_ERROR_AND_THROW(syntax::ParseException, "Unexpected argument type");
     }
 
     if (!ObjectUtils::IsType<RealObjectPtr>(scale)) {
         assert(!"Text font operation has invalid arguments");
-        throw syntax::ParseException("Unexpected argument type");
+        LOG_ERROR_AND_THROW(syntax::ParseException, "Unexpected argument type");
     }
 
     m_font = syntax::ObjectUtils::ConvertTo<NameObjectPtr>(name);
@@ -122,19 +122,19 @@ OperationTextFont::OperationTextFont(const std::vector<ObjectPtr>& operands) {
 OperationTextTranslate::OperationTextTranslate(const std::vector<ObjectPtr>& operands) {
     assert(operands.size() == 2);
     if (operands.size() != 2) {
-        throw syntax::ParseException("Unexpected number of arguments");
+        LOG_ERROR_AND_THROW(syntax::ParseException, "Unexpected number of arguments");
     }
 
     auto x = operands.at(0);
     auto y = operands.at(1);
     if (!ObjectUtils::IsType<IntegerObjectPtr>(x)) {
         assert(!"Text font operation has invalid arguments");
-        throw syntax::ParseException("Unexpected argument type");
+        LOG_ERROR_AND_THROW(syntax::ParseException, "Unexpected argument type");
     }
 
     if (!ObjectUtils::IsType<IntegerObjectPtr>(y)) {
         assert(!"Text font operation has invalid arguments");
-        throw syntax::ParseException("Unexpected argument type");
+        LOG_ERROR_AND_THROW(syntax::ParseException, "Unexpected argument type");
     }
 
     m_x = syntax::ObjectUtils::ConvertTo<IntegerObjectPtr>(x);
@@ -144,34 +144,34 @@ OperationTextTranslate::OperationTextTranslate(const std::vector<ObjectPtr>& ope
 OperationBeginInlineImageObject::OperationBeginInlineImageObject(const std::vector<ObjectPtr>& operands) {
     assert(operands.size() == 0);
     if (operands.size() != 0) {
-        throw syntax::ParseException("Unexpected number of arguments");
+        LOG_ERROR_AND_THROW(syntax::ParseException, "Unexpected number of arguments");
     }
 }
 
 OperationBeginInlineImageData::OperationBeginInlineImageData(const std::vector<ObjectPtr>& operands) {
     assert(operands.size() == 0);
     if (operands.size() != 0) {
-        throw syntax::ParseException("Unexpected number of arguments");
+        LOG_ERROR_AND_THROW(syntax::ParseException, "Unexpected number of arguments");
     }
 }
 
 OperationEndInlineImageObject::OperationEndInlineImageObject(const std::vector<ObjectPtr>& operands) {
     assert(operands.size() == 0);
     if (operands.size() != 0) {
-        throw syntax::ParseException("Unexpected number of arguments");
+        LOG_ERROR_AND_THROW(syntax::ParseException, "Unexpected number of arguments");
     }
 }
 
 OperationTextShow::OperationTextShow(const std::vector<ObjectPtr>& operands) {
     if (1 != operands.size()) {
         assert(!"Text show operation has invalid arguments");
-        throw syntax::ParseException("Unexpected number of arguments");
+        LOG_ERROR_AND_THROW(syntax::ParseException, "Unexpected number of arguments");
     }
 
     auto item = operands.at(0);
     if (!ObjectUtils::IsType<StringObjectPtr>(item)) {
         assert(!"Text show operation has invalid arguments");
-        throw syntax::ParseException("Unexpected argument type");
+        LOG_ERROR_AND_THROW(syntax::ParseException, "Unexpected argument type");
     }
 
     _str = ObjectUtils::ConvertTo<StringObjectPtr>(item);
@@ -180,13 +180,13 @@ OperationTextShow::OperationTextShow(const std::vector<ObjectPtr>& operands) {
 OperationTextShowArray::OperationTextShowArray(const std::vector<ObjectPtr>& operands) {
     if (1 != operands.size()) {
         assert(!"Text show array operation has invalid arguments");
-        throw syntax::ParseException("Unexpected number of arguments");
+        LOG_ERROR_AND_THROW(syntax::ParseException, "Unexpected number of arguments");
     }
 
     auto item = operands.at(0);
     if (!ObjectUtils::IsType<MixedArrayObjectPtr>(item)) {
         assert(!"Text show array operation has invalid arguments");
-        throw syntax::ParseException("Unexpected argument type");
+        LOG_ERROR_AND_THROW(syntax::ParseException, "Unexpected argument type");
     }
 
     m_items = ObjectUtils::ConvertTo<MixedArrayObjectPtr>(item);
@@ -195,43 +195,43 @@ OperationTextShowArray::OperationTextShowArray(const std::vector<ObjectPtr>& ope
 OperationTransformationMatrix::OperationTransformationMatrix(const std::vector<ObjectPtr>& operands) {
     if (6 != operands.size()) {
         assert(!"Transformation matrix operation has invalid arguments");
-        throw syntax::ParseException("Unexpected number of arguments");
+        LOG_ERROR_AND_THROW(syntax::ParseException, "Unexpected number of arguments");
     }
 
     auto a = operands.at(0);
     if (!ObjectUtils::IsType<IntegerObjectPtr>(a)) {
         assert(!"Transformation matrix operation has invalid arguments");
-        throw syntax::ParseException("Unexpected argument type");
+        LOG_ERROR_AND_THROW(syntax::ParseException, "Unexpected argument type");
     }
 
     auto b = operands.at(1);
     if (!ObjectUtils::IsType<IntegerObjectPtr>(b)) {
         assert(!"Transformation matrix operation has invalid arguments");
-        throw syntax::ParseException("Unexpected argument type");
+        LOG_ERROR_AND_THROW(syntax::ParseException, "Unexpected argument type");
     }
 
     auto c = operands.at(2);
     if (!ObjectUtils::IsType<IntegerObjectPtr>(c)) {
         assert(!"Transformation matrix operation has invalid arguments");
-        throw syntax::ParseException("Unexpected argument type");
+        LOG_ERROR_AND_THROW(syntax::ParseException, "Unexpected argument type");
     }
 
     auto d = operands.at(3);
     if (!ObjectUtils::IsType<IntegerObjectPtr>(d)) {
         assert(!"Transformation matrix operation has invalid arguments");
-        throw syntax::ParseException("Unexpected argument type");
+        LOG_ERROR_AND_THROW(syntax::ParseException, "Unexpected argument type");
     }
 
     auto e = operands.at(4);
     if (!ObjectUtils::IsType<IntegerObjectPtr>(e)) {
         assert(!"Transformation matrix operation has invalid arguments");
-        throw syntax::ParseException("Unexpected argument type");
+        LOG_ERROR_AND_THROW(syntax::ParseException, "Unexpected argument type");
     }
 
     auto f = operands.at(5);
     if (!ObjectUtils::IsType<IntegerObjectPtr>(f)) {
         assert(!"Transformation matrix operation has invalid arguments");
-        throw syntax::ParseException("Unexpected argument type");
+        LOG_ERROR_AND_THROW(syntax::ParseException, "Unexpected argument type");
     }
 
     m_a = ObjectUtils::ConvertTo<IntegerObjectPtr>(a);

--- a/src/vanillapdf/contents/content_stream_operations.cpp
+++ b/src/vanillapdf/contents/content_stream_operations.cpp
@@ -18,35 +18,35 @@ using namespace syntax;
 OperationBeginText::OperationBeginText(const std::vector<ObjectPtr>& operands) {
     assert(operands.size() == 0);
     if (operands.size() != 0) {
-        LOG_ERROR_AND_THROW(syntax::ParseException, "Unexpected number of arguments");
+        LOG_ERROR_AND_THROW(syntax::ParseException, "Operator BT expects no operands, but {} were found", operands.size());
     }
 }
 
 OperationEndText::OperationEndText(const std::vector<ObjectPtr>& operands) {
     assert(operands.size() == 0);
     if (operands.size() != 0) {
-        LOG_ERROR_AND_THROW(syntax::ParseException, "Unexpected number of arguments");
+        LOG_ERROR_AND_THROW(syntax::ParseException, "Operator ET expects no operands, but {} were found", operands.size());
     }
 }
 
 OperationSaveGraphicsState::OperationSaveGraphicsState(const std::vector<ObjectPtr>& operands) {
     assert(operands.size() == 0);
     if (operands.size() != 0) {
-        LOG_ERROR_AND_THROW(syntax::ParseException, "Unexpected number of arguments");
+        LOG_ERROR_AND_THROW(syntax::ParseException, "Operator q expects no operands, but {} were found", operands.size());
     }
 }
 
 OperationRestoreGraphicsState::OperationRestoreGraphicsState(const std::vector<ObjectPtr>& operands) {
     assert(operands.size() == 0);
     if (operands.size() != 0) {
-        LOG_ERROR_AND_THROW(syntax::ParseException, "Unexpected number of arguments");
+        LOG_ERROR_AND_THROW(syntax::ParseException, "Operator Q expects no operands, but {} were found", operands.size());
     }
 }
 
 OperationSetStrokingColorSpaceRGB::OperationSetStrokingColorSpaceRGB(const std::vector<ObjectPtr>& operands) {
     assert(operands.size() == 3);
     if (operands.size() != 3) {
-        LOG_ERROR_AND_THROW(syntax::ParseException, "Unexpected number of arguments");
+        LOG_ERROR_AND_THROW(syntax::ParseException, "Operator RG expects 3 operands, but {} were found", operands.size());
     }
 
     auto red = operands.at(0);
@@ -54,15 +54,15 @@ OperationSetStrokingColorSpaceRGB::OperationSetStrokingColorSpaceRGB(const std::
     auto blue = operands.at(2);
 
     if (!ObjectUtils::IsType<RealObjectPtr>(red)) {
-        LOG_ERROR_AND_THROW(syntax::ParseException, "Unexpected argument type");
+        LOG_ERROR_AND_THROW(syntax::ParseException, "Operator RG expects a Real red component, but found {}", Object::TypeName(red->GetObjectType()));
     }
 
     if (!ObjectUtils::IsType<RealObjectPtr>(green)) {
-        LOG_ERROR_AND_THROW(syntax::ParseException, "Unexpected argument type");
+        LOG_ERROR_AND_THROW(syntax::ParseException, "Operator RG expects a Real green component, but found {}", Object::TypeName(green->GetObjectType()));
     }
 
     if (!ObjectUtils::IsType<RealObjectPtr>(blue)) {
-        LOG_ERROR_AND_THROW(syntax::ParseException, "Unexpected argument type");
+        LOG_ERROR_AND_THROW(syntax::ParseException, "Operator RG expects a Real blue component, but found {}", Object::TypeName(blue->GetObjectType()));
     }
 
     m_red = syntax::ObjectUtils::ConvertTo<RealObjectPtr>(red);
@@ -73,7 +73,7 @@ OperationSetStrokingColorSpaceRGB::OperationSetStrokingColorSpaceRGB(const std::
 OperationSetNonstrokingColorSpaceRGB::OperationSetNonstrokingColorSpaceRGB(const std::vector<ObjectPtr>& operands) {
     assert(operands.size() == 3);
     if (operands.size() != 3) {
-        LOG_ERROR_AND_THROW(syntax::ParseException, "Unexpected number of arguments");
+        LOG_ERROR_AND_THROW(syntax::ParseException, "Operator rg expects 3 operands, but {} were found", operands.size());
     }
 
     auto red = operands.at(0);
@@ -81,15 +81,15 @@ OperationSetNonstrokingColorSpaceRGB::OperationSetNonstrokingColorSpaceRGB(const
     auto blue = operands.at(2);
 
     if (!ObjectUtils::IsType<RealObjectPtr>(red)) {
-        LOG_ERROR_AND_THROW(syntax::ParseException, "Unexpected argument type");
+        LOG_ERROR_AND_THROW(syntax::ParseException, "Operator rg expects a Real red component, but found {}", Object::TypeName(red->GetObjectType()));
     }
 
     if (!ObjectUtils::IsType<RealObjectPtr>(green)) {
-        LOG_ERROR_AND_THROW(syntax::ParseException, "Unexpected argument type");
+        LOG_ERROR_AND_THROW(syntax::ParseException, "Operator rg expects a Real green component, but found {}", Object::TypeName(green->GetObjectType()));
     }
 
     if (!ObjectUtils::IsType<RealObjectPtr>(blue)) {
-        LOG_ERROR_AND_THROW(syntax::ParseException, "Unexpected argument type");
+        LOG_ERROR_AND_THROW(syntax::ParseException, "Operator rg expects a Real blue component, but found {}", Object::TypeName(blue->GetObjectType()));
     }
 
     m_red = syntax::ObjectUtils::ConvertTo<RealObjectPtr>(red);
@@ -100,19 +100,19 @@ OperationSetNonstrokingColorSpaceRGB::OperationSetNonstrokingColorSpaceRGB(const
 OperationTextFont::OperationTextFont(const std::vector<ObjectPtr>& operands) {
     assert(operands.size() == 2);
     if (operands.size() != 2) {
-        LOG_ERROR_AND_THROW(syntax::ParseException, "Unexpected number of arguments");
+        LOG_ERROR_AND_THROW(syntax::ParseException, "Operator Tf expects 2 operands, but {} were found", operands.size());
     }
 
     auto name = operands.at(0);
     auto scale = operands.at(1);
     if (!ObjectUtils::IsType<NameObjectPtr>(name)) {
         assert(!"Text font operation has invalid arguments");
-        LOG_ERROR_AND_THROW(syntax::ParseException, "Unexpected argument type");
+        LOG_ERROR_AND_THROW(syntax::ParseException, "Operator Tf expects a Name font, but found {}", Object::TypeName(name->GetObjectType()));
     }
 
     if (!ObjectUtils::IsType<RealObjectPtr>(scale)) {
         assert(!"Text font operation has invalid arguments");
-        LOG_ERROR_AND_THROW(syntax::ParseException, "Unexpected argument type");
+        LOG_ERROR_AND_THROW(syntax::ParseException, "Operator Tf expects a Real font size, but found {}", Object::TypeName(scale->GetObjectType()));
     }
 
     m_font = syntax::ObjectUtils::ConvertTo<NameObjectPtr>(name);
@@ -122,19 +122,19 @@ OperationTextFont::OperationTextFont(const std::vector<ObjectPtr>& operands) {
 OperationTextTranslate::OperationTextTranslate(const std::vector<ObjectPtr>& operands) {
     assert(operands.size() == 2);
     if (operands.size() != 2) {
-        LOG_ERROR_AND_THROW(syntax::ParseException, "Unexpected number of arguments");
+        LOG_ERROR_AND_THROW(syntax::ParseException, "Operator Td expects 2 operands, but {} were found", operands.size());
     }
 
     auto x = operands.at(0);
     auto y = operands.at(1);
     if (!ObjectUtils::IsType<IntegerObjectPtr>(x)) {
         assert(!"Text font operation has invalid arguments");
-        LOG_ERROR_AND_THROW(syntax::ParseException, "Unexpected argument type");
+        LOG_ERROR_AND_THROW(syntax::ParseException, "Operator Td expects an Integer x offset, but found {}", Object::TypeName(x->GetObjectType()));
     }
 
     if (!ObjectUtils::IsType<IntegerObjectPtr>(y)) {
         assert(!"Text font operation has invalid arguments");
-        LOG_ERROR_AND_THROW(syntax::ParseException, "Unexpected argument type");
+        LOG_ERROR_AND_THROW(syntax::ParseException, "Operator Td expects an Integer y offset, but found {}", Object::TypeName(y->GetObjectType()));
     }
 
     m_x = syntax::ObjectUtils::ConvertTo<IntegerObjectPtr>(x);
@@ -144,34 +144,34 @@ OperationTextTranslate::OperationTextTranslate(const std::vector<ObjectPtr>& ope
 OperationBeginInlineImageObject::OperationBeginInlineImageObject(const std::vector<ObjectPtr>& operands) {
     assert(operands.size() == 0);
     if (operands.size() != 0) {
-        LOG_ERROR_AND_THROW(syntax::ParseException, "Unexpected number of arguments");
+        LOG_ERROR_AND_THROW(syntax::ParseException, "Operator BI expects no operands, but {} were found", operands.size());
     }
 }
 
 OperationBeginInlineImageData::OperationBeginInlineImageData(const std::vector<ObjectPtr>& operands) {
     assert(operands.size() == 0);
     if (operands.size() != 0) {
-        LOG_ERROR_AND_THROW(syntax::ParseException, "Unexpected number of arguments");
+        LOG_ERROR_AND_THROW(syntax::ParseException, "Operator ID expects no operands, but {} were found", operands.size());
     }
 }
 
 OperationEndInlineImageObject::OperationEndInlineImageObject(const std::vector<ObjectPtr>& operands) {
     assert(operands.size() == 0);
     if (operands.size() != 0) {
-        LOG_ERROR_AND_THROW(syntax::ParseException, "Unexpected number of arguments");
+        LOG_ERROR_AND_THROW(syntax::ParseException, "Operator EI expects no operands, but {} were found", operands.size());
     }
 }
 
 OperationTextShow::OperationTextShow(const std::vector<ObjectPtr>& operands) {
     if (1 != operands.size()) {
         assert(!"Text show operation has invalid arguments");
-        LOG_ERROR_AND_THROW(syntax::ParseException, "Unexpected number of arguments");
+        LOG_ERROR_AND_THROW(syntax::ParseException, "Operator Tj expects 1 operand, but {} were found", operands.size());
     }
 
     auto item = operands.at(0);
     if (!ObjectUtils::IsType<StringObjectPtr>(item)) {
         assert(!"Text show operation has invalid arguments");
-        LOG_ERROR_AND_THROW(syntax::ParseException, "Unexpected argument type");
+        LOG_ERROR_AND_THROW(syntax::ParseException, "Operator Tj expects a String operand, but found {}", Object::TypeName(item->GetObjectType()));
     }
 
     _str = ObjectUtils::ConvertTo<StringObjectPtr>(item);
@@ -180,13 +180,13 @@ OperationTextShow::OperationTextShow(const std::vector<ObjectPtr>& operands) {
 OperationTextShowArray::OperationTextShowArray(const std::vector<ObjectPtr>& operands) {
     if (1 != operands.size()) {
         assert(!"Text show array operation has invalid arguments");
-        LOG_ERROR_AND_THROW(syntax::ParseException, "Unexpected number of arguments");
+        LOG_ERROR_AND_THROW(syntax::ParseException, "Operator TJ expects 1 operand, but {} were found", operands.size());
     }
 
     auto item = operands.at(0);
     if (!ObjectUtils::IsType<MixedArrayObjectPtr>(item)) {
         assert(!"Text show array operation has invalid arguments");
-        LOG_ERROR_AND_THROW(syntax::ParseException, "Unexpected argument type");
+        LOG_ERROR_AND_THROW(syntax::ParseException, "Operator TJ expects an Array operand, but found {}", Object::TypeName(item->GetObjectType()));
     }
 
     m_items = ObjectUtils::ConvertTo<MixedArrayObjectPtr>(item);
@@ -195,43 +195,43 @@ OperationTextShowArray::OperationTextShowArray(const std::vector<ObjectPtr>& ope
 OperationTransformationMatrix::OperationTransformationMatrix(const std::vector<ObjectPtr>& operands) {
     if (6 != operands.size()) {
         assert(!"Transformation matrix operation has invalid arguments");
-        LOG_ERROR_AND_THROW(syntax::ParseException, "Unexpected number of arguments");
+        LOG_ERROR_AND_THROW(syntax::ParseException, "Operator cm expects 6 operands, but {} were found", operands.size());
     }
 
     auto a = operands.at(0);
     if (!ObjectUtils::IsType<IntegerObjectPtr>(a)) {
         assert(!"Transformation matrix operation has invalid arguments");
-        LOG_ERROR_AND_THROW(syntax::ParseException, "Unexpected argument type");
+        LOG_ERROR_AND_THROW(syntax::ParseException, "Operator cm expects an Integer operand a, but found {}", Object::TypeName(a->GetObjectType()));
     }
 
     auto b = operands.at(1);
     if (!ObjectUtils::IsType<IntegerObjectPtr>(b)) {
         assert(!"Transformation matrix operation has invalid arguments");
-        LOG_ERROR_AND_THROW(syntax::ParseException, "Unexpected argument type");
+        LOG_ERROR_AND_THROW(syntax::ParseException, "Operator cm expects an Integer operand b, but found {}", Object::TypeName(b->GetObjectType()));
     }
 
     auto c = operands.at(2);
     if (!ObjectUtils::IsType<IntegerObjectPtr>(c)) {
         assert(!"Transformation matrix operation has invalid arguments");
-        LOG_ERROR_AND_THROW(syntax::ParseException, "Unexpected argument type");
+        LOG_ERROR_AND_THROW(syntax::ParseException, "Operator cm expects an Integer operand c, but found {}", Object::TypeName(c->GetObjectType()));
     }
 
     auto d = operands.at(3);
     if (!ObjectUtils::IsType<IntegerObjectPtr>(d)) {
         assert(!"Transformation matrix operation has invalid arguments");
-        LOG_ERROR_AND_THROW(syntax::ParseException, "Unexpected argument type");
+        LOG_ERROR_AND_THROW(syntax::ParseException, "Operator cm expects an Integer operand d, but found {}", Object::TypeName(d->GetObjectType()));
     }
 
     auto e = operands.at(4);
     if (!ObjectUtils::IsType<IntegerObjectPtr>(e)) {
         assert(!"Transformation matrix operation has invalid arguments");
-        LOG_ERROR_AND_THROW(syntax::ParseException, "Unexpected argument type");
+        LOG_ERROR_AND_THROW(syntax::ParseException, "Operator cm expects an Integer operand e, but found {}", Object::TypeName(e->GetObjectType()));
     }
 
     auto f = operands.at(5);
     if (!ObjectUtils::IsType<IntegerObjectPtr>(f)) {
         assert(!"Transformation matrix operation has invalid arguments");
-        LOG_ERROR_AND_THROW(syntax::ParseException, "Unexpected argument type");
+        LOG_ERROR_AND_THROW(syntax::ParseException, "Operator cm expects an Integer operand f, but found {}", Object::TypeName(f->GetObjectType()));
     }
 
     m_a = ObjectUtils::ConvertTo<IntegerObjectPtr>(a);

--- a/src/vanillapdf/contents/content_stream_parser.cpp
+++ b/src/vanillapdf/contents/content_stream_parser.cpp
@@ -73,14 +73,15 @@ InlineImageObjectPtr ContentStreamParser::ReadInlineImageObject(void) {
         }
 
         assert(!"Unknown data in inline image dictionary");
-        LOG_ERROR_AND_THROW(ParseException, "Unexpected token in inline image dictionary");
+        LOG_ERROR_AND_THROW(ParseException, "Unexpected token type {} in inline image dictionary", static_cast<int>(token_type));
     }
 
     // read operation begin image data
     auto inline_image_data_op = ReadOperation();
     if (inline_image_data_op->GetOperationType() != OperationBase::Type::BeginInlineImageData) {
         assert(!"Invalid operation after inline image dictionary");
-        LOG_ERROR_AND_THROW(ParseException, "Invalid operation after inline image dictionary");
+        LOG_ERROR_AND_THROW(ParseException, "Inline image dictionary shall be followed by the ID operator, but operation type {} was found",
+            static_cast<int>(inline_image_data_op->GetOperationType()));
     }
 
     // The ID operator shall be followed by a single white-space character,

--- a/src/vanillapdf/implementation/syntax/c_file_writer_observer.cpp
+++ b/src/vanillapdf/implementation/syntax/c_file_writer_observer.cpp
@@ -34,7 +34,7 @@ public:
 
         // File writer events are licensed feature
         if (!LicenseInfo::IsValid()) {
-            throw LicenseRequiredException("Custom file writer observer is a licensed feature");
+            LOG_ERROR_AND_THROW(LicenseRequiredException, "Custom file writer observer is a licensed feature");
         }
     }
 
@@ -47,8 +47,7 @@ public:
 
         error_type rv = m_on_initializing(m_user_data, output_ptr);
         if (rv != VANILLAPDF_ERROR_SUCCESS) {
-            throw UserCancelledException(
-                fmt::format("OnInitializing operation returned: {}", rv));
+            LOG_ERROR_AND_THROW(UserCancelledException, "OnInitializing operation returned: {}", rv);
         }
     }
 
@@ -61,8 +60,7 @@ public:
 
         error_type rv = m_on_finalizing(m_user_data, output_ptr);
         if (rv != VANILLAPDF_ERROR_SUCCESS) {
-            throw UserCancelledException(
-                fmt::format("OnFinalizing operation returned: {}", rv));
+            LOG_ERROR_AND_THROW(UserCancelledException, "OnFinalizing operation returned: {}", rv);
         }
     }
 
@@ -75,8 +73,7 @@ public:
 
         error_type rv = m_on_before_object_write(m_user_data, object_ptr);
         if (rv != VANILLAPDF_ERROR_SUCCESS) {
-            throw UserCancelledException(
-                fmt::format("OnBeforeObjectWrite operation returned: {}", rv));
+            LOG_ERROR_AND_THROW(UserCancelledException, "OnBeforeObjectWrite operation returned: {}", rv);
         }
     }
 
@@ -89,8 +86,7 @@ public:
 
         error_type rv = m_on_after_object_write(m_user_data, object_ptr);
         if (rv != VANILLAPDF_ERROR_SUCCESS) {
-            throw UserCancelledException(
-                fmt::format("OnAfterObjectWrite operation returned: {}", rv));
+            LOG_ERROR_AND_THROW(UserCancelledException, "OnAfterObjectWrite operation returned: {}", rv);
         }
     }
 
@@ -103,8 +99,7 @@ public:
 
         error_type rv = m_on_before_object_offset_recalculation(m_user_data, object_ptr);
         if (rv != VANILLAPDF_ERROR_SUCCESS) {
-            throw UserCancelledException(
-                fmt::format("OnBeforeObjectOffsetRecalculation operation returned: {}", rv));
+            LOG_ERROR_AND_THROW(UserCancelledException, "OnBeforeObjectOffsetRecalculation operation returned: {}", rv);
         }
     }
 
@@ -117,8 +112,7 @@ public:
 
         error_type rv = m_on_after_object_offset_recalculation(m_user_data, object_ptr);
         if (rv != VANILLAPDF_ERROR_SUCCESS) {
-            throw UserCancelledException(
-                fmt::format("OnAfterObjectOffsetRecalculation operation returned: {}", rv));
+            LOG_ERROR_AND_THROW(UserCancelledException, "OnAfterObjectOffsetRecalculation operation returned: {}", rv);
         }
     }
 
@@ -131,8 +125,7 @@ public:
 
         error_type rv = m_on_before_entry_offset_recalculation(m_user_data, entry_ptr);
         if (rv != VANILLAPDF_ERROR_SUCCESS) {
-            throw UserCancelledException(
-                fmt::format("OnBeforeEntryOffsetRecalculation operation returned: {}", rv));
+            LOG_ERROR_AND_THROW(UserCancelledException, "OnBeforeEntryOffsetRecalculation operation returned: {}", rv);
         }
     }
 
@@ -145,8 +138,7 @@ public:
 
         error_type rv = m_on_after_entry_offset_recalculation(m_user_data, entry_ptr);
         if (rv != VANILLAPDF_ERROR_SUCCESS) {
-            throw UserCancelledException(
-                fmt::format("OnAfterEntryOffsetRecalculation operation returned: {}", rv));
+            LOG_ERROR_AND_THROW(UserCancelledException, "OnAfterEntryOffsetRecalculation operation returned: {}", rv);
         }
     }
 
@@ -159,8 +151,7 @@ public:
 
         error_type rv = m_on_before_output_flush(m_user_data, output_ptr);
         if (rv != VANILLAPDF_ERROR_SUCCESS) {
-            throw UserCancelledException(
-                fmt::format("OnBeforeOutputFlush operation returned: {}", rv));
+            LOG_ERROR_AND_THROW(UserCancelledException, "OnBeforeOutputFlush operation returned: {}", rv);
         }
     }
 
@@ -173,8 +164,7 @@ public:
 
         error_type rv = m_on_after_output_flush(m_user_data, output_ptr);
         if (rv != VANILLAPDF_ERROR_SUCCESS) {
-            throw UserCancelledException(
-                fmt::format("OnAfterOutputFlush operation returned: {}", rv));
+            LOG_ERROR_AND_THROW(UserCancelledException, "OnAfterOutputFlush operation returned: {}", rv);
         }
     }
 

--- a/src/vanillapdf/implementation/utils/c_encryption.cpp
+++ b/src/vanillapdf/implementation/utils/c_encryption.cpp
@@ -37,7 +37,7 @@ public:
 
         // Decryption is a licensed feature
         if (!LicenseInfo::IsValid()) {
-            throw LicenseRequiredException("Custom file encryption is a licensed feature");
+            LOG_ERROR_AND_THROW(LicenseRequiredException, "Custom file encryption is a licensed feature");
         }
 
         m_init();
@@ -50,13 +50,11 @@ public:
 
         error_type rv = m_decrypt(input_ptr, &output_ptr);
         if (VANILLAPDF_ERROR_SUCCESS != rv) {
-            throw UserCancelledException(
-                fmt::format("Custom key decrypt operation returned: {}", rv));
+            LOG_ERROR_AND_THROW(UserCancelledException, "Custom key decrypt operation returned: {}", rv);
         }
 
         if (output_ptr == nullptr) {
-            throw UserCancelledException(
-                "Custom key decrypt operation succeeded, but did not fill the decrypted data pointer");
+            LOG_ERROR_AND_THROW(UserCancelledException, "Custom key decrypt operation succeeded, but did not fill the decrypted data pointer");
         }
 
         return reinterpret_cast<Buffer*>(output_ptr);
@@ -70,8 +68,7 @@ public:
 
         error_type rv = m_contains(input_issuer, input_serial, &result);
         if (VANILLAPDF_ERROR_SUCCESS != rv) {
-            throw UserCancelledException(
-                fmt::format("Custom key equals operation returned: {}", rv));
+            LOG_ERROR_AND_THROW(UserCancelledException, "Custom key equals operation returned: {}", rv);
         }
 
         return (result == VANILLAPDF_RV_TRUE);

--- a/src/vanillapdf/implementation/utils/c_signing_key.cpp
+++ b/src/vanillapdf/implementation/utils/c_signing_key.cpp
@@ -38,7 +38,7 @@ public:
 
         // Document signature is a licensed feature
         if (!LicenseInfo::IsValid()) {
-            throw LicenseRequiredException("Custom signing key is a licensed feature");
+            LOG_ERROR_AND_THROW(LicenseRequiredException, "Custom signing key is a licensed feature");
         }
     }
 
@@ -78,8 +78,7 @@ public:
 
         error_type rv = m_init(m_user_data, algorithm_type);
         if (VANILLAPDF_ERROR_SUCCESS != rv) {
-            throw UserCancelledException(
-                fmt::format("Custom key sign init operation returned: {}", rv));
+            LOG_ERROR_AND_THROW(UserCancelledException, "Custom key sign init operation returned: {}", rv);
         }
     }
 
@@ -87,8 +86,7 @@ public:
         auto input_handle = reinterpret_cast<const BufferHandle*>(&data);
         error_type rv = m_update(m_user_data, input_handle);
         if (VANILLAPDF_ERROR_SUCCESS != rv) {
-            throw UserCancelledException(
-                fmt::format("Custom key sign update operation returned: {}", rv));
+            LOG_ERROR_AND_THROW(UserCancelledException, "Custom key sign update operation returned: {}", rv);
         }
     }
 
@@ -103,13 +101,11 @@ public:
 
         error_type rv = m_final(m_user_data, &output_ptr);
         if (VANILLAPDF_ERROR_SUCCESS != rv) {
-            throw UserCancelledException(
-                fmt::format("Custom key sign final operation returned: {}", rv));
+            LOG_ERROR_AND_THROW(UserCancelledException, "Custom key sign final operation returned: {}", rv);
         }
 
         if (output_ptr == nullptr) {
-            throw UserCancelledException(
-                "Custom key sign final operation succeeded, but did not fill the signed data pointer");
+            LOG_ERROR_AND_THROW(UserCancelledException, "Custom key sign final operation succeeded, but did not fill the signed data pointer");
         }
 
         auto result = reinterpret_cast<Buffer*>(output_ptr);
@@ -119,8 +115,7 @@ public:
     void SignCleanup() override {
         error_type rv = m_cleanup(m_user_data);
         if (VANILLAPDF_ERROR_SUCCESS != rv) {
-            throw UserCancelledException(
-                fmt::format("Custom key sign cleanup operation returned: {}", rv));
+            LOG_ERROR_AND_THROW(UserCancelledException, "Custom key sign cleanup operation returned: {}", rv);
         }
     }
 

--- a/src/vanillapdf/semantics/objects/actions.cpp
+++ b/src/vanillapdf/semantics/objects/actions.cpp
@@ -19,13 +19,13 @@ LaunchAction::LaunchAction(syntax::DictionaryObjectPtr root) : ActionBase(root) 
 
 ActionPtr ActionBase::Create(syntax::DictionaryObjectPtr root) {
     if (!root->Contains(constant::Name::S)) {
-        throw syntax::ObjectMissingException("Action dictionary does not contain /S entry");
+        LOG_ERROR_AND_THROW(syntax::ObjectMissingException, "Action dictionary does not contain /S entry");
     }
 
     syntax::ObjectPtr s_obj = root->Find(constant::Name::S);
 
     if (!syntax::ObjectUtils::IsType<syntax::NameObjectPtr>(s_obj)) {
-        throw syntax::ObjectMissingException("Invalid action type");
+        LOG_ERROR_AND_THROW(syntax::ObjectMissingException, "Invalid action type");
     }
 
     syntax::NameObjectPtr s = syntax::ObjectUtils::ConvertTo<syntax::NameObjectPtr>(s_obj);
@@ -54,7 +54,7 @@ ActionPtr ActionBase::Create(syntax::DictionaryObjectPtr root) {
         return make_deferred<JavaScriptAction>(root);
     }
 
-    throw syntax::ObjectMissingException("Unknown action type: " + s->ToString());
+    LOG_ERROR_AND_THROW(syntax::ObjectMissingException, "Unknown action type: {}", s->ToString());
 }
 
 bool GoToAction::Destination(OutputDestinationPtr& result) const {

--- a/src/vanillapdf/semantics/objects/actions.cpp
+++ b/src/vanillapdf/semantics/objects/actions.cpp
@@ -25,7 +25,7 @@ ActionPtr ActionBase::Create(syntax::DictionaryObjectPtr root) {
     syntax::ObjectPtr s_obj = root->Find(constant::Name::S);
 
     if (!syntax::ObjectUtils::IsType<syntax::NameObjectPtr>(s_obj)) {
-        LOG_ERROR_AND_THROW(syntax::ObjectMissingException, "Invalid action type");
+        LOG_ERROR_AND_THROW(syntax::ObjectMissingException, "Action /S entry shall be a Name, but found {}", syntax::Object::TypeName(s_obj->GetObjectType()));
     }
 
     syntax::NameObjectPtr s = syntax::ObjectUtils::ConvertTo<syntax::NameObjectPtr>(s_obj);

--- a/src/vanillapdf/semantics/objects/annotations.cpp
+++ b/src/vanillapdf/semantics/objects/annotations.cpp
@@ -66,13 +66,13 @@ std::unique_ptr<AnnotationBase> AnnotationBase::Create(syntax::DictionaryObjectP
     if (root->Contains(constant::Name::Type)) {
         syntax::ObjectPtr type_obj = root->Find(constant::Name::Type);
         if (!syntax::ObjectUtils::IsType<syntax::NameObjectPtr>(type_obj)) {
-            LOG_ERROR_AND_THROW(syntax::ObjectMissingException, "Invalid annotation type");
+            LOG_ERROR_AND_THROW(syntax::ObjectMissingException, "Annotation /Type entry shall be a Name, but found {}", syntax::Object::TypeName(type_obj->GetObjectType()));
         }
 
         syntax::NameObjectPtr type = syntax::ObjectUtils::ConvertTo<syntax::NameObjectPtr>(type_obj);
 
         if (type != constant::Name::Annot) {
-            LOG_ERROR_AND_THROW(syntax::ObjectMissingException, "Invalid annotation type");
+            LOG_ERROR_AND_THROW(syntax::ObjectMissingException, "Annotation /Type entry shall be /Annot, but found {}", type->ToString());
         }
     }
 
@@ -83,7 +83,7 @@ std::unique_ptr<AnnotationBase> AnnotationBase::Create(syntax::DictionaryObjectP
     syntax::ObjectPtr subtype_obj = root->Find(constant::Name::Subtype);
 
     if (!syntax::ObjectUtils::IsType<syntax::NameObjectPtr>(subtype_obj)) {
-        LOG_ERROR_AND_THROW(syntax::ObjectMissingException, "Invalid annotation subtype");
+        LOG_ERROR_AND_THROW(syntax::ObjectMissingException, "Annotation /Subtype entry shall be a Name, but found {}", syntax::Object::TypeName(subtype_obj->GetObjectType()));
     }
 
     syntax::NameObjectPtr subtype = syntax::ObjectUtils::ConvertTo<syntax::NameObjectPtr>(subtype_obj);
@@ -191,7 +191,7 @@ std::unique_ptr<AnnotationBase> AnnotationBase::Create(syntax::DictionaryObjectP
         return make_unique<RedactionAnnotation>(root);
     }
 
-    LOG_ERROR_AND_THROW(syntax::ObjectMissingException, "Unknown annotation subtype");
+    LOG_ERROR_AND_THROW(syntax::ObjectMissingException, "Unknown annotation subtype: {}", subtype->ToString());
 }
 
 bool LinkAnnotation::Destination(OutputDestinationPtr& result) const {

--- a/src/vanillapdf/semantics/objects/annotations.cpp
+++ b/src/vanillapdf/semantics/objects/annotations.cpp
@@ -66,24 +66,24 @@ std::unique_ptr<AnnotationBase> AnnotationBase::Create(syntax::DictionaryObjectP
     if (root->Contains(constant::Name::Type)) {
         syntax::ObjectPtr type_obj = root->Find(constant::Name::Type);
         if (!syntax::ObjectUtils::IsType<syntax::NameObjectPtr>(type_obj)) {
-            throw syntax::ObjectMissingException("Invalid annotation type");
+            LOG_ERROR_AND_THROW(syntax::ObjectMissingException, "Invalid annotation type");
         }
 
         syntax::NameObjectPtr type = syntax::ObjectUtils::ConvertTo<syntax::NameObjectPtr>(type_obj);
 
         if (type != constant::Name::Annot) {
-            throw syntax::ObjectMissingException("Invalid annotation type");
+            LOG_ERROR_AND_THROW(syntax::ObjectMissingException, "Invalid annotation type");
         }
     }
 
     if (!root->Contains(constant::Name::Subtype)) {
-        throw syntax::ObjectMissingException("Dictionary does not contain subtype");
+        LOG_ERROR_AND_THROW(syntax::ObjectMissingException, "Dictionary does not contain subtype");
     }
 
     syntax::ObjectPtr subtype_obj = root->Find(constant::Name::Subtype);
 
     if (!syntax::ObjectUtils::IsType<syntax::NameObjectPtr>(subtype_obj)) {
-        throw syntax::ObjectMissingException("Invalid annotation subtype");
+        LOG_ERROR_AND_THROW(syntax::ObjectMissingException, "Invalid annotation subtype");
     }
 
     syntax::NameObjectPtr subtype = syntax::ObjectUtils::ConvertTo<syntax::NameObjectPtr>(subtype_obj);
@@ -191,7 +191,7 @@ std::unique_ptr<AnnotationBase> AnnotationBase::Create(syntax::DictionaryObjectP
         return make_unique<RedactionAnnotation>(root);
     }
 
-    throw syntax::ObjectMissingException("Unknown annotation subtype");
+    LOG_ERROR_AND_THROW(syntax::ObjectMissingException, "Unknown annotation subtype");
 }
 
 bool LinkAnnotation::Destination(OutputDestinationPtr& result) const {

--- a/src/vanillapdf/semantics/objects/catalog.cpp
+++ b/src/vanillapdf/semantics/objects/catalog.cpp
@@ -95,7 +95,7 @@ bool Catalog::PageLayout(Catalog::PageLayoutType& result) const {
     } else if (layout == constant::Name::TwoPageRight) {
         result = PageLayoutType::TwoPageRight;
     } else {
-        throw syntax::ParseException("Unknown value in PageLayout entry: " + layout->ToString());
+        LOG_ERROR_AND_THROW(syntax::ParseException, "Unknown value in PageLayout entry: {}", layout->ToString());
     }
 
     return true;
@@ -167,7 +167,7 @@ bool Catalog::PageMode(PageModeType& result) const {
     } else if (page_mode == constant::Name::UseAttachments) {
         result = PageModeType::UseAttachments;
     } else {
-        throw syntax::ParseException("Unknown page mode type: " + page_mode->ToString());
+        LOG_ERROR_AND_THROW(syntax::ParseException, "Unknown page mode type: {}", page_mode->ToString());
     }
 
     return true;

--- a/src/vanillapdf/semantics/objects/color.cpp
+++ b/src/vanillapdf/semantics/objects/color.cpp
@@ -15,7 +15,7 @@ Color::Color(syntax::MixedArrayObjectPtr root) : HighLevelObject(root) {
     case 4:
         break;
     default:
-        throw InvalidParameterException("Invalid color array size: " + std::to_string(size));
+        LOG_ERROR_AND_THROW(InvalidParameterException, "Invalid color array size: {}", size);
     }
 }
 
@@ -28,7 +28,7 @@ Color::ColorSpace Color::GetColorSpace() const {
     case 3: return ColorSpace::DeviceRGB;
     case 4: return ColorSpace::DeviceCMYK;
     default:
-        throw InvalidParameterException("Invalid color array size: " + std::to_string(size));
+        LOG_ERROR_AND_THROW(InvalidParameterException, "Invalid color array size: {}", size);
     }
 }
 
@@ -47,14 +47,14 @@ void Color::SetComponent(types::size_type index, double value) {
 
 double Color::GetGray() const {
     if (GetColorSpace() != ColorSpace::DeviceGray) {
-        throw NotSupportedException("Component not available for current color space");
+        LOG_ERROR_AND_THROW(NotSupportedException, "Component not available for current color space");
     }
     return GetComponent(0);
 }
 
 void Color::SetGray(double value) {
     if (GetColorSpace() != ColorSpace::DeviceGray) {
-        throw NotSupportedException("Component not available for current color space");
+        LOG_ERROR_AND_THROW(NotSupportedException, "Component not available for current color space");
     }
     SetComponent(0, value);
 }
@@ -63,42 +63,42 @@ void Color::SetGray(double value) {
 
 double Color::GetRed() const {
     if (GetColorSpace() != ColorSpace::DeviceRGB) {
-        throw NotSupportedException("Component not available for current color space");
+        LOG_ERROR_AND_THROW(NotSupportedException, "Component not available for current color space");
     }
     return GetComponent(0);
 }
 
 void Color::SetRed(double value) {
     if (GetColorSpace() != ColorSpace::DeviceRGB) {
-        throw NotSupportedException("Component not available for current color space");
+        LOG_ERROR_AND_THROW(NotSupportedException, "Component not available for current color space");
     }
     SetComponent(0, value);
 }
 
 double Color::GetGreen() const {
     if (GetColorSpace() != ColorSpace::DeviceRGB) {
-        throw NotSupportedException("Component not available for current color space");
+        LOG_ERROR_AND_THROW(NotSupportedException, "Component not available for current color space");
     }
     return GetComponent(1);
 }
 
 void Color::SetGreen(double value) {
     if (GetColorSpace() != ColorSpace::DeviceRGB) {
-        throw NotSupportedException("Component not available for current color space");
+        LOG_ERROR_AND_THROW(NotSupportedException, "Component not available for current color space");
     }
     SetComponent(1, value);
 }
 
 double Color::GetBlue() const {
     if (GetColorSpace() != ColorSpace::DeviceRGB) {
-        throw NotSupportedException("Component not available for current color space");
+        LOG_ERROR_AND_THROW(NotSupportedException, "Component not available for current color space");
     }
     return GetComponent(2);
 }
 
 void Color::SetBlue(double value) {
     if (GetColorSpace() != ColorSpace::DeviceRGB) {
-        throw NotSupportedException("Component not available for current color space");
+        LOG_ERROR_AND_THROW(NotSupportedException, "Component not available for current color space");
     }
     SetComponent(2, value);
 }
@@ -107,56 +107,56 @@ void Color::SetBlue(double value) {
 
 double Color::GetCyan() const {
     if (GetColorSpace() != ColorSpace::DeviceCMYK) {
-        throw NotSupportedException("Component not available for current color space");
+        LOG_ERROR_AND_THROW(NotSupportedException, "Component not available for current color space");
     }
     return GetComponent(0);
 }
 
 void Color::SetCyan(double value) {
     if (GetColorSpace() != ColorSpace::DeviceCMYK) {
-        throw NotSupportedException("Component not available for current color space");
+        LOG_ERROR_AND_THROW(NotSupportedException, "Component not available for current color space");
     }
     SetComponent(0, value);
 }
 
 double Color::GetMagenta() const {
     if (GetColorSpace() != ColorSpace::DeviceCMYK) {
-        throw NotSupportedException("Component not available for current color space");
+        LOG_ERROR_AND_THROW(NotSupportedException, "Component not available for current color space");
     }
     return GetComponent(1);
 }
 
 void Color::SetMagenta(double value) {
     if (GetColorSpace() != ColorSpace::DeviceCMYK) {
-        throw NotSupportedException("Component not available for current color space");
+        LOG_ERROR_AND_THROW(NotSupportedException, "Component not available for current color space");
     }
     SetComponent(1, value);
 }
 
 double Color::GetYellow() const {
     if (GetColorSpace() != ColorSpace::DeviceCMYK) {
-        throw NotSupportedException("Component not available for current color space");
+        LOG_ERROR_AND_THROW(NotSupportedException, "Component not available for current color space");
     }
     return GetComponent(2);
 }
 
 void Color::SetYellow(double value) {
     if (GetColorSpace() != ColorSpace::DeviceCMYK) {
-        throw NotSupportedException("Component not available for current color space");
+        LOG_ERROR_AND_THROW(NotSupportedException, "Component not available for current color space");
     }
     SetComponent(2, value);
 }
 
 double Color::GetBlack() const {
     if (GetColorSpace() != ColorSpace::DeviceCMYK) {
-        throw NotSupportedException("Component not available for current color space");
+        LOG_ERROR_AND_THROW(NotSupportedException, "Component not available for current color space");
     }
     return GetComponent(3);
 }
 
 void Color::SetBlack(double value) {
     if (GetColorSpace() != ColorSpace::DeviceCMYK) {
-        throw NotSupportedException("Component not available for current color space");
+        LOG_ERROR_AND_THROW(NotSupportedException, "Component not available for current color space");
     }
     SetComponent(3, value);
 }

--- a/src/vanillapdf/semantics/objects/color.cpp
+++ b/src/vanillapdf/semantics/objects/color.cpp
@@ -5,6 +5,25 @@
 namespace vanillapdf {
 namespace semantics {
 
+const char* Color::ColorSpaceName(ColorSpace color_space) {
+    switch (color_space) {
+        case ColorSpace::Transparent:
+            return "Transparent";
+        case ColorSpace::DeviceGray:
+            return "DeviceGray";
+        case ColorSpace::DeviceRGB:
+            return "DeviceRGB";
+        case ColorSpace::DeviceCMYK:
+            return "DeviceCMYK";
+        default:
+
+            // The name is used in log and exception messages, so it has to stay
+            // a printable string even for values outside of the enumeration.
+
+            return "Undefined";
+    }
+}
+
 Color::Color(syntax::MixedArrayObjectPtr root) : HighLevelObject(root) {
     auto size = root->GetSize();
 
@@ -47,14 +66,14 @@ void Color::SetComponent(types::size_type index, double value) {
 
 double Color::GetGray() const {
     if (GetColorSpace() != ColorSpace::DeviceGray) {
-        LOG_ERROR_AND_THROW(NotSupportedException, "The Gray component is only available in DeviceGray colors, but this color has {} component(s)", _obj->GetSize());
+        LOG_ERROR_AND_THROW(NotSupportedException, "The Gray component is only available in DeviceGray colors, but this color is {}", ColorSpaceName(GetColorSpace()));
     }
     return GetComponent(0);
 }
 
 void Color::SetGray(double value) {
     if (GetColorSpace() != ColorSpace::DeviceGray) {
-        LOG_ERROR_AND_THROW(NotSupportedException, "The Gray component is only available in DeviceGray colors, but this color has {} component(s)", _obj->GetSize());
+        LOG_ERROR_AND_THROW(NotSupportedException, "The Gray component is only available in DeviceGray colors, but this color is {}", ColorSpaceName(GetColorSpace()));
     }
     SetComponent(0, value);
 }
@@ -63,42 +82,42 @@ void Color::SetGray(double value) {
 
 double Color::GetRed() const {
     if (GetColorSpace() != ColorSpace::DeviceRGB) {
-        LOG_ERROR_AND_THROW(NotSupportedException, "The Red component is only available in DeviceRGB colors, but this color has {} component(s)", _obj->GetSize());
+        LOG_ERROR_AND_THROW(NotSupportedException, "The Red component is only available in DeviceRGB colors, but this color is {}", ColorSpaceName(GetColorSpace()));
     }
     return GetComponent(0);
 }
 
 void Color::SetRed(double value) {
     if (GetColorSpace() != ColorSpace::DeviceRGB) {
-        LOG_ERROR_AND_THROW(NotSupportedException, "The Red component is only available in DeviceRGB colors, but this color has {} component(s)", _obj->GetSize());
+        LOG_ERROR_AND_THROW(NotSupportedException, "The Red component is only available in DeviceRGB colors, but this color is {}", ColorSpaceName(GetColorSpace()));
     }
     SetComponent(0, value);
 }
 
 double Color::GetGreen() const {
     if (GetColorSpace() != ColorSpace::DeviceRGB) {
-        LOG_ERROR_AND_THROW(NotSupportedException, "The Green component is only available in DeviceRGB colors, but this color has {} component(s)", _obj->GetSize());
+        LOG_ERROR_AND_THROW(NotSupportedException, "The Green component is only available in DeviceRGB colors, but this color is {}", ColorSpaceName(GetColorSpace()));
     }
     return GetComponent(1);
 }
 
 void Color::SetGreen(double value) {
     if (GetColorSpace() != ColorSpace::DeviceRGB) {
-        LOG_ERROR_AND_THROW(NotSupportedException, "The Green component is only available in DeviceRGB colors, but this color has {} component(s)", _obj->GetSize());
+        LOG_ERROR_AND_THROW(NotSupportedException, "The Green component is only available in DeviceRGB colors, but this color is {}", ColorSpaceName(GetColorSpace()));
     }
     SetComponent(1, value);
 }
 
 double Color::GetBlue() const {
     if (GetColorSpace() != ColorSpace::DeviceRGB) {
-        LOG_ERROR_AND_THROW(NotSupportedException, "The Blue component is only available in DeviceRGB colors, but this color has {} component(s)", _obj->GetSize());
+        LOG_ERROR_AND_THROW(NotSupportedException, "The Blue component is only available in DeviceRGB colors, but this color is {}", ColorSpaceName(GetColorSpace()));
     }
     return GetComponent(2);
 }
 
 void Color::SetBlue(double value) {
     if (GetColorSpace() != ColorSpace::DeviceRGB) {
-        LOG_ERROR_AND_THROW(NotSupportedException, "The Blue component is only available in DeviceRGB colors, but this color has {} component(s)", _obj->GetSize());
+        LOG_ERROR_AND_THROW(NotSupportedException, "The Blue component is only available in DeviceRGB colors, but this color is {}", ColorSpaceName(GetColorSpace()));
     }
     SetComponent(2, value);
 }
@@ -107,56 +126,56 @@ void Color::SetBlue(double value) {
 
 double Color::GetCyan() const {
     if (GetColorSpace() != ColorSpace::DeviceCMYK) {
-        LOG_ERROR_AND_THROW(NotSupportedException, "The Cyan component is only available in DeviceCMYK colors, but this color has {} component(s)", _obj->GetSize());
+        LOG_ERROR_AND_THROW(NotSupportedException, "The Cyan component is only available in DeviceCMYK colors, but this color is {}", ColorSpaceName(GetColorSpace()));
     }
     return GetComponent(0);
 }
 
 void Color::SetCyan(double value) {
     if (GetColorSpace() != ColorSpace::DeviceCMYK) {
-        LOG_ERROR_AND_THROW(NotSupportedException, "The Cyan component is only available in DeviceCMYK colors, but this color has {} component(s)", _obj->GetSize());
+        LOG_ERROR_AND_THROW(NotSupportedException, "The Cyan component is only available in DeviceCMYK colors, but this color is {}", ColorSpaceName(GetColorSpace()));
     }
     SetComponent(0, value);
 }
 
 double Color::GetMagenta() const {
     if (GetColorSpace() != ColorSpace::DeviceCMYK) {
-        LOG_ERROR_AND_THROW(NotSupportedException, "The Magenta component is only available in DeviceCMYK colors, but this color has {} component(s)", _obj->GetSize());
+        LOG_ERROR_AND_THROW(NotSupportedException, "The Magenta component is only available in DeviceCMYK colors, but this color is {}", ColorSpaceName(GetColorSpace()));
     }
     return GetComponent(1);
 }
 
 void Color::SetMagenta(double value) {
     if (GetColorSpace() != ColorSpace::DeviceCMYK) {
-        LOG_ERROR_AND_THROW(NotSupportedException, "The Magenta component is only available in DeviceCMYK colors, but this color has {} component(s)", _obj->GetSize());
+        LOG_ERROR_AND_THROW(NotSupportedException, "The Magenta component is only available in DeviceCMYK colors, but this color is {}", ColorSpaceName(GetColorSpace()));
     }
     SetComponent(1, value);
 }
 
 double Color::GetYellow() const {
     if (GetColorSpace() != ColorSpace::DeviceCMYK) {
-        LOG_ERROR_AND_THROW(NotSupportedException, "The Yellow component is only available in DeviceCMYK colors, but this color has {} component(s)", _obj->GetSize());
+        LOG_ERROR_AND_THROW(NotSupportedException, "The Yellow component is only available in DeviceCMYK colors, but this color is {}", ColorSpaceName(GetColorSpace()));
     }
     return GetComponent(2);
 }
 
 void Color::SetYellow(double value) {
     if (GetColorSpace() != ColorSpace::DeviceCMYK) {
-        LOG_ERROR_AND_THROW(NotSupportedException, "The Yellow component is only available in DeviceCMYK colors, but this color has {} component(s)", _obj->GetSize());
+        LOG_ERROR_AND_THROW(NotSupportedException, "The Yellow component is only available in DeviceCMYK colors, but this color is {}", ColorSpaceName(GetColorSpace()));
     }
     SetComponent(2, value);
 }
 
 double Color::GetBlack() const {
     if (GetColorSpace() != ColorSpace::DeviceCMYK) {
-        LOG_ERROR_AND_THROW(NotSupportedException, "The Black component is only available in DeviceCMYK colors, but this color has {} component(s)", _obj->GetSize());
+        LOG_ERROR_AND_THROW(NotSupportedException, "The Black component is only available in DeviceCMYK colors, but this color is {}", ColorSpaceName(GetColorSpace()));
     }
     return GetComponent(3);
 }
 
 void Color::SetBlack(double value) {
     if (GetColorSpace() != ColorSpace::DeviceCMYK) {
-        LOG_ERROR_AND_THROW(NotSupportedException, "The Black component is only available in DeviceCMYK colors, but this color has {} component(s)", _obj->GetSize());
+        LOG_ERROR_AND_THROW(NotSupportedException, "The Black component is only available in DeviceCMYK colors, but this color is {}", ColorSpaceName(GetColorSpace()));
     }
     SetComponent(3, value);
 }

--- a/src/vanillapdf/semantics/objects/color.cpp
+++ b/src/vanillapdf/semantics/objects/color.cpp
@@ -47,14 +47,14 @@ void Color::SetComponent(types::size_type index, double value) {
 
 double Color::GetGray() const {
     if (GetColorSpace() != ColorSpace::DeviceGray) {
-        LOG_ERROR_AND_THROW(NotSupportedException, "Component not available for current color space");
+        LOG_ERROR_AND_THROW(NotSupportedException, "The Gray component is only available in DeviceGray colors, but this color has {} component(s)", _obj->GetSize());
     }
     return GetComponent(0);
 }
 
 void Color::SetGray(double value) {
     if (GetColorSpace() != ColorSpace::DeviceGray) {
-        LOG_ERROR_AND_THROW(NotSupportedException, "Component not available for current color space");
+        LOG_ERROR_AND_THROW(NotSupportedException, "The Gray component is only available in DeviceGray colors, but this color has {} component(s)", _obj->GetSize());
     }
     SetComponent(0, value);
 }
@@ -63,42 +63,42 @@ void Color::SetGray(double value) {
 
 double Color::GetRed() const {
     if (GetColorSpace() != ColorSpace::DeviceRGB) {
-        LOG_ERROR_AND_THROW(NotSupportedException, "Component not available for current color space");
+        LOG_ERROR_AND_THROW(NotSupportedException, "The Red component is only available in DeviceRGB colors, but this color has {} component(s)", _obj->GetSize());
     }
     return GetComponent(0);
 }
 
 void Color::SetRed(double value) {
     if (GetColorSpace() != ColorSpace::DeviceRGB) {
-        LOG_ERROR_AND_THROW(NotSupportedException, "Component not available for current color space");
+        LOG_ERROR_AND_THROW(NotSupportedException, "The Red component is only available in DeviceRGB colors, but this color has {} component(s)", _obj->GetSize());
     }
     SetComponent(0, value);
 }
 
 double Color::GetGreen() const {
     if (GetColorSpace() != ColorSpace::DeviceRGB) {
-        LOG_ERROR_AND_THROW(NotSupportedException, "Component not available for current color space");
+        LOG_ERROR_AND_THROW(NotSupportedException, "The Green component is only available in DeviceRGB colors, but this color has {} component(s)", _obj->GetSize());
     }
     return GetComponent(1);
 }
 
 void Color::SetGreen(double value) {
     if (GetColorSpace() != ColorSpace::DeviceRGB) {
-        LOG_ERROR_AND_THROW(NotSupportedException, "Component not available for current color space");
+        LOG_ERROR_AND_THROW(NotSupportedException, "The Green component is only available in DeviceRGB colors, but this color has {} component(s)", _obj->GetSize());
     }
     SetComponent(1, value);
 }
 
 double Color::GetBlue() const {
     if (GetColorSpace() != ColorSpace::DeviceRGB) {
-        LOG_ERROR_AND_THROW(NotSupportedException, "Component not available for current color space");
+        LOG_ERROR_AND_THROW(NotSupportedException, "The Blue component is only available in DeviceRGB colors, but this color has {} component(s)", _obj->GetSize());
     }
     return GetComponent(2);
 }
 
 void Color::SetBlue(double value) {
     if (GetColorSpace() != ColorSpace::DeviceRGB) {
-        LOG_ERROR_AND_THROW(NotSupportedException, "Component not available for current color space");
+        LOG_ERROR_AND_THROW(NotSupportedException, "The Blue component is only available in DeviceRGB colors, but this color has {} component(s)", _obj->GetSize());
     }
     SetComponent(2, value);
 }
@@ -107,56 +107,56 @@ void Color::SetBlue(double value) {
 
 double Color::GetCyan() const {
     if (GetColorSpace() != ColorSpace::DeviceCMYK) {
-        LOG_ERROR_AND_THROW(NotSupportedException, "Component not available for current color space");
+        LOG_ERROR_AND_THROW(NotSupportedException, "The Cyan component is only available in DeviceCMYK colors, but this color has {} component(s)", _obj->GetSize());
     }
     return GetComponent(0);
 }
 
 void Color::SetCyan(double value) {
     if (GetColorSpace() != ColorSpace::DeviceCMYK) {
-        LOG_ERROR_AND_THROW(NotSupportedException, "Component not available for current color space");
+        LOG_ERROR_AND_THROW(NotSupportedException, "The Cyan component is only available in DeviceCMYK colors, but this color has {} component(s)", _obj->GetSize());
     }
     SetComponent(0, value);
 }
 
 double Color::GetMagenta() const {
     if (GetColorSpace() != ColorSpace::DeviceCMYK) {
-        LOG_ERROR_AND_THROW(NotSupportedException, "Component not available for current color space");
+        LOG_ERROR_AND_THROW(NotSupportedException, "The Magenta component is only available in DeviceCMYK colors, but this color has {} component(s)", _obj->GetSize());
     }
     return GetComponent(1);
 }
 
 void Color::SetMagenta(double value) {
     if (GetColorSpace() != ColorSpace::DeviceCMYK) {
-        LOG_ERROR_AND_THROW(NotSupportedException, "Component not available for current color space");
+        LOG_ERROR_AND_THROW(NotSupportedException, "The Magenta component is only available in DeviceCMYK colors, but this color has {} component(s)", _obj->GetSize());
     }
     SetComponent(1, value);
 }
 
 double Color::GetYellow() const {
     if (GetColorSpace() != ColorSpace::DeviceCMYK) {
-        LOG_ERROR_AND_THROW(NotSupportedException, "Component not available for current color space");
+        LOG_ERROR_AND_THROW(NotSupportedException, "The Yellow component is only available in DeviceCMYK colors, but this color has {} component(s)", _obj->GetSize());
     }
     return GetComponent(2);
 }
 
 void Color::SetYellow(double value) {
     if (GetColorSpace() != ColorSpace::DeviceCMYK) {
-        LOG_ERROR_AND_THROW(NotSupportedException, "Component not available for current color space");
+        LOG_ERROR_AND_THROW(NotSupportedException, "The Yellow component is only available in DeviceCMYK colors, but this color has {} component(s)", _obj->GetSize());
     }
     SetComponent(2, value);
 }
 
 double Color::GetBlack() const {
     if (GetColorSpace() != ColorSpace::DeviceCMYK) {
-        LOG_ERROR_AND_THROW(NotSupportedException, "Component not available for current color space");
+        LOG_ERROR_AND_THROW(NotSupportedException, "The Black component is only available in DeviceCMYK colors, but this color has {} component(s)", _obj->GetSize());
     }
     return GetComponent(3);
 }
 
 void Color::SetBlack(double value) {
     if (GetColorSpace() != ColorSpace::DeviceCMYK) {
-        LOG_ERROR_AND_THROW(NotSupportedException, "Component not available for current color space");
+        LOG_ERROR_AND_THROW(NotSupportedException, "The Black component is only available in DeviceCMYK colors, but this color has {} component(s)", _obj->GetSize());
     }
     SetComponent(3, value);
 }

--- a/src/vanillapdf/semantics/objects/color.h
+++ b/src/vanillapdf/semantics/objects/color.h
@@ -21,6 +21,8 @@ public:
         DeviceCMYK    // 4 components
     };
 
+    static const char* ColorSpaceName(ColorSpace color_space);
+
 public:
     Color() = default;
     explicit Color(syntax::MixedArrayObjectPtr root);

--- a/src/vanillapdf/semantics/objects/date.cpp
+++ b/src/vanillapdf/semantics/objects/date.cpp
@@ -61,13 +61,27 @@ Date::Date(syntax::StringObjectPtr root) : HighLevelObject(root) {
         }
     }
 
-    if (m_month < 1 || m_month > 12) throw InvalidParameterException("Month is out of range: " + std::to_string(m_month));
-    if (m_day < 1 || m_day > 31) throw InvalidParameterException("Day is out of range: " + std::to_string(m_day));
-    if (m_hour < 0 || m_hour > 23) throw InvalidParameterException("Hour is out of range: " + std::to_string(m_hour));
-    if (m_minute < 0 || m_minute > 59) throw InvalidParameterException("Minute is out of range: " + std::to_string(m_minute));
-    if (m_second < 0 || m_second > 59) throw InvalidParameterException("Second is out of range: " + std::to_string(m_second));
-    if (m_hour_offset < 0 || m_hour_offset > 23) throw InvalidParameterException("Hour offset is out of range: " + std::to_string(m_hour_offset));
-    if (m_minute_offset < 0 || m_minute_offset > 59) throw InvalidParameterException("Minute offset is out of range: " + std::to_string(m_minute_offset));
+    if (m_month < 1 || m_month > 12) {
+        LOG_ERROR_AND_THROW(InvalidParameterException, "Month is out of range: {}", m_month);
+    }
+    if (m_day < 1 || m_day > 31) {
+        LOG_ERROR_AND_THROW(InvalidParameterException, "Day is out of range: {}", m_day);
+    }
+    if (m_hour < 0 || m_hour > 23) {
+        LOG_ERROR_AND_THROW(InvalidParameterException, "Hour is out of range: {}", m_hour);
+    }
+    if (m_minute < 0 || m_minute > 59) {
+        LOG_ERROR_AND_THROW(InvalidParameterException, "Minute is out of range: {}", m_minute);
+    }
+    if (m_second < 0 || m_second > 59) {
+        LOG_ERROR_AND_THROW(InvalidParameterException, "Second is out of range: {}", m_second);
+    }
+    if (m_hour_offset < 0 || m_hour_offset > 23) {
+        LOG_ERROR_AND_THROW(InvalidParameterException, "Hour offset is out of range: {}", m_hour_offset);
+    }
+    if (m_minute_offset < 0 || m_minute_offset > 59) {
+        LOG_ERROR_AND_THROW(InvalidParameterException, "Minute offset is out of range: {}", m_minute_offset);
+    }
 }
 
 DatePtr Date::GetCurrentDate() {
@@ -91,7 +105,7 @@ DatePtr Date::GetCurrentDate() {
             local_time.GetHour(), local_time.GetMinute(), local_time.GetSecond(),
             local_time.GetHourOffset(), local_time.GetMinuteOffset());
     } else {
-        throw InvalidParameterException("Unknown timezone type");
+        LOG_ERROR_AND_THROW(InvalidParameterException, "Unknown timezone type");
     }
 
     auto string_object = syntax::LiteralStringObject::CreateFromDecoded(formatted_time);
@@ -113,7 +127,7 @@ void Date::UpdateObject() {
             m_year, m_month, m_day, m_hour, m_minute, m_second,
             m_hour_offset, m_minute_offset);
     } else {
-        throw InvalidParameterException("Unknown timezone type");
+        LOG_ERROR_AND_THROW(InvalidParameterException, "Unknown timezone type");
     }
 
     SetObject(syntax::LiteralStringObject::CreateFromDecoded(formatted_time));

--- a/src/vanillapdf/semantics/objects/date.cpp
+++ b/src/vanillapdf/semantics/objects/date.cpp
@@ -105,7 +105,7 @@ DatePtr Date::GetCurrentDate() {
             local_time.GetHour(), local_time.GetMinute(), local_time.GetSecond(),
             local_time.GetHourOffset(), local_time.GetMinuteOffset());
     } else {
-        LOG_ERROR_AND_THROW(InvalidParameterException, "Unknown timezone type");
+        LOG_ERROR_AND_THROW(InvalidParameterException, "Unknown timezone type: {}", static_cast<int>(timezone));
     }
 
     auto string_object = syntax::LiteralStringObject::CreateFromDecoded(formatted_time);
@@ -127,7 +127,7 @@ void Date::UpdateObject() {
             m_year, m_month, m_day, m_hour, m_minute, m_second,
             m_hour_offset, m_minute_offset);
     } else {
-        LOG_ERROR_AND_THROW(InvalidParameterException, "Unknown timezone type");
+        LOG_ERROR_AND_THROW(InvalidParameterException, "Unknown timezone type: {}", static_cast<int>(m_timezone));
     }
 
     SetObject(syntax::LiteralStringObject::CreateFromDecoded(formatted_time));

--- a/src/vanillapdf/semantics/objects/destinations.cpp
+++ b/src/vanillapdf/semantics/objects/destinations.cpp
@@ -161,7 +161,7 @@ NamedDestinations::NamedDestinations(syntax::DictionaryObjectPtr root) : HighLev
 
 syntax::NameObjectPtr DestinationBase::ValidateAndGetDestinationType(syntax::MixedArrayObjectPtr array) {
     if (array->GetSize() < 2) {
-        throw syntax::ObjectMissingException("Invalid destination array");
+        LOG_ERROR_AND_THROW(syntax::ObjectMissingException, "Invalid destination array");
     }
 
     syntax::ObjectPtr page_number_obj = array->GetValue(0);
@@ -276,26 +276,26 @@ DestinationPtr DestinationBase::ResolveDestination(syntax::ObjectPtr dest_obj) {
         OutputCatalogPtr catalog_ptr;
         bool has_catalog = document->GetDocumentCatalog(catalog_ptr);
         if (!has_catalog) {
-            throw syntax::ObjectMissingException("Document does not have a catalog");
+            LOG_ERROR_AND_THROW(syntax::ObjectMissingException, "Document does not have a catalog");
         }
 
         OutputNameDictionaryPtr name_dictionary;
         bool has_dictionary = catalog_ptr->Names(name_dictionary);
         if (!has_dictionary) {
-            throw syntax::ObjectMissingException("Document does not have a name dictionary");
+            LOG_ERROR_AND_THROW(syntax::ObjectMissingException, "Document does not have a name dictionary");
         }
 
         OutputNameTreePtr<DestinationPtr> destinations;
         bool contains = name_dictionary->Dests(destinations);
         if (!contains) {
-            throw syntax::ObjectMissingException("Document does not have destinations in name dictionary");
+            LOG_ERROR_AND_THROW(syntax::ObjectMissingException, "Document does not have destinations in name dictionary");
         }
 
         auto destination_name = syntax::ObjectUtils::ConvertTo<syntax::StringObjectPtr>(dest_obj);
 
         assert(destinations->Contains(destination_name) && "Referenced destination does not exist");
         if (!destinations->Contains(destination_name)) {
-            throw syntax::ObjectMissingException("Referenced destination does not exist");
+            LOG_ERROR_AND_THROW(syntax::ObjectMissingException, "Referenced destination does not exist");
         }
 
         auto found_dest = destinations->Find(destination_name);
@@ -315,20 +315,20 @@ DestinationPtr DestinationBase::ResolveDestination(syntax::ObjectPtr dest_obj) {
         OutputCatalogPtr catalog;
         bool has_catalog = document->GetDocumentCatalog(catalog);
         if (!has_catalog) {
-            throw syntax::ObjectMissingException("Document does not have a catalog");
+            LOG_ERROR_AND_THROW(syntax::ObjectMissingException, "Document does not have a catalog");
         }
 
         OutputNamedDestinationsPtr destinations;
         bool has_destinations = catalog->Destinations(destinations);
         if (!has_destinations) {
-            throw syntax::ObjectMissingException("Document does not have named destinations");
+            LOG_ERROR_AND_THROW(syntax::ObjectMissingException, "Document does not have named destinations");
         }
 
         auto destination_name = syntax::ObjectUtils::ConvertTo<syntax::NameObjectPtr>(dest_obj);
 
         assert(destinations->Contains(destination_name) && "Referenced destination does not exist");
         if (!destinations->Contains(destination_name)) {
-            throw syntax::ObjectMissingException("Referenced destination does not exist");
+            LOG_ERROR_AND_THROW(syntax::ObjectMissingException, "Referenced destination does not exist");
         }
 
         return destinations->Find(destination_name);
@@ -339,7 +339,7 @@ DestinationPtr DestinationBase::ResolveDestination(syntax::ObjectPtr dest_obj) {
 
 DestinationPtr DestinationBase::CreateFromDictionary(syntax::DictionaryObjectPtr root) {
     if (!root->Contains(constant::Name::D)) {
-        throw syntax::ObjectMissingException("Invalid destination dictionary");
+        LOG_ERROR_AND_THROW(syntax::ObjectMissingException, "Invalid destination dictionary");
     }
 
     auto destination_array = root->FindAs<syntax::MixedArrayObjectPtr>(constant::Name::D);
@@ -393,7 +393,7 @@ syntax::MixedArrayObjectPtr DestinationBase::GetDestinationArray() const {
     }
 
     assert(false && "Destination was created but object is neither array nor dictionary");
-    throw syntax::ObjectMissingException("Destination was created but object is neither array nor dictionary");
+    LOG_ERROR_AND_THROW(syntax::ObjectMissingException, "Destination was created but object is neither array nor dictionary");
 }
 
 syntax::ObjectPtr DestinationBase::GetPage() const {

--- a/src/vanillapdf/semantics/objects/developer_extensions.cpp
+++ b/src/vanillapdf/semantics/objects/developer_extensions.cpp
@@ -13,7 +13,7 @@ namespace semantics {
 DeveloperExtensionPtr DeveloperExtensions::Iterator::Second() const {
     auto containable = BaseIterator<syntax::DictionaryObject::const_iterator>::m_current->second;
     if (!syntax::ObjectUtils::IsType<syntax::DictionaryObjectPtr>(containable)) {
-        throw syntax::ParseException("Developer extension value is not dictionary");
+        LOG_ERROR_AND_THROW(syntax::ParseException, "Developer extension value is not dictionary");
     }
 
     auto converted = syntax::ObjectUtils::ConvertTo<syntax::DictionaryObjectPtr>(containable);

--- a/src/vanillapdf/semantics/objects/document.cpp
+++ b/src/vanillapdf/semantics/objects/document.cpp
@@ -360,7 +360,7 @@ void Document::FixDestinationPage(ObjectPtr cloned_page, PageObjectPtr other_pag
         || ObjectUtils::IsType<IntegerObjectPtr>(cloned_page));
     if (!ObjectUtils::IsType<IndirectReferenceObjectPtr>(cloned_page)
         && !ObjectUtils::IsType<IntegerObjectPtr>(cloned_page)) {
-        throw InvalidParameterException("Unknown object type");
+        LOG_ERROR_AND_THROW(InvalidParameterException, "Unknown object type");
     }
 
     OutputCatalogPtr original_catalog;
@@ -440,7 +440,7 @@ bool Document::IsDestinationReferencingPage(DestinationPtr destination, PageObje
         || ObjectUtils::IsType<IntegerObjectPtr>(destination_page_object));
     if (!ObjectUtils::IsType<IndirectReferenceObjectPtr>(destination_page_object)
         && !ObjectUtils::IsType<IntegerObjectPtr>(destination_page_object)) {
-        throw InvalidParameterException("Unknown object type");
+        LOG_ERROR_AND_THROW(InvalidParameterException, "Unknown object type");
     }
 
     if (ObjectUtils::IsType<IndirectReferenceObjectPtr>(destination_page_object)) {
@@ -532,7 +532,7 @@ void Document::AppendStringDestination(StringObjectPtr key, DestinationPtr value
     // Check for name conflicts
     assert(!original_string_destinations->Contains(key) && "Name conflict");
     if (original_string_destinations->Contains(key)) {
-        throw NotSupportedException("Merge of conflicting names is not yet supported");
+        LOG_ERROR_AND_THROW(NotSupportedException, "Merge of conflicting names is not yet supported");
     }
 
     // Derefence destination in case it is indirect reference
@@ -572,7 +572,7 @@ void Document::AppendNameDestination(NameObjectPtr key, DestinationPtr value, Pa
     // Check for name conflicts
     assert(!original_destinations->Contains(key) && "Name conflict");
     if (original_destinations->Contains(key)) {
-        throw NotSupportedException("Merge of conflicting names is not yet supported");
+        LOG_ERROR_AND_THROW(NotSupportedException, "Merge of conflicting names is not yet supported");
     }
 
     // Derefence destination in case it is indirect reference
@@ -623,7 +623,7 @@ void Document::AppendPage(DocumentPtr other, PageObjectPtr other_page) {
 
     assert(ObjectUtils::IsType<DictionaryObjectPtr>(new_page_object) && "Page object is not dictionary");
     if (!ObjectUtils::IsType<DictionaryObjectPtr>(new_page_object)) {
-        throw syntax::ObjectMissingException("Cloned page object is not dictionary");
+        LOG_ERROR_AND_THROW(syntax::ObjectMissingException, "Cloned page object is not dictionary");
     }
 
     DictionaryObjectPtr new_dictionary = ObjectUtils::ConvertTo<DictionaryObjectPtr>(new_page_object);
@@ -681,7 +681,7 @@ void Document::Sign(FilePtr destination, DocumentSignatureSettingsPtr options) {
     auto digest = options->GetDigest();
 
     if (!has_key) {
-        throw InvalidParameterException("Signing key is not set");
+        LOG_ERROR_AND_THROW(InvalidParameterException, "Signing key is not set");
     }
 
     // Create new signature dictionary
@@ -745,12 +745,12 @@ void Document::Sign(FilePtr destination, DocumentSignatureSettingsPtr options) {
     OutputPageTreePtr page_tree;
     bool has_pages = catalog->Pages(page_tree);
     if (!has_pages) {
-        throw syntax::ObjectMissingException("Cannot sign document without pages");
+        LOG_ERROR_AND_THROW(syntax::ObjectMissingException, "Cannot sign document without pages");
     }
 
     auto page_count = page_tree->PageCount();
     if (page_count == 0) {
-        throw syntax::ObjectMissingException("Cannot sign document without pages");
+        LOG_ERROR_AND_THROW(syntax::ObjectMissingException, "Cannot sign document without pages");
     }
 
     auto first_page = page_tree->Page(1);
@@ -847,12 +847,12 @@ void Document::AddEncryption(DocumentEncryptionSettingsPtr settings) {
 
     // Document encryption is a licensed feature
     if (!LicenseInfo::IsValid()) {
-        throw LicenseRequiredException("Document encryption is a licensed feature");
+        LOG_ERROR_AND_THROW(LicenseRequiredException, "Document encryption is a licensed feature");
     }
 
     // Terminate in case the document is already encrypted
     if (m_holder->IsEncrypted()) {
-        throw CryptoErrorException("Cannot encrypt an encrypted document, please remove the encryption first");
+        LOG_ERROR_AND_THROW(CryptoErrorException, "Cannot encrypt an encrypted document, please remove the encryption first");
     }
 
     // Initialize all entries, to load them into cache
@@ -927,7 +927,7 @@ void Document::AddEncryption(DocumentEncryptionSettingsPtr settings) {
     bool password_set = m_holder->SetEncryptionPassword(settings->GetUserPassword());
 
     if (!password_set) {
-        throw CryptoErrorException("Could not verify the encryption password");
+        LOG_ERROR_AND_THROW(CryptoErrorException, "Could not verify the encryption password");
     }
 }
 
@@ -935,7 +935,7 @@ void Document::RemoveEncryption() {
 
     // Document encryption is a licensed feature
     if (!LicenseInfo::IsValid()) {
-        throw LicenseRequiredException("Document encryption is a licensed feature");
+        LOG_ERROR_AND_THROW(LicenseRequiredException, "Document encryption is a licensed feature");
     }
 
     // Terminate in case the document is not encrypted, treat as success

--- a/src/vanillapdf/semantics/objects/document.cpp
+++ b/src/vanillapdf/semantics/objects/document.cpp
@@ -360,7 +360,7 @@ void Document::FixDestinationPage(ObjectPtr cloned_page, PageObjectPtr other_pag
         || ObjectUtils::IsType<IntegerObjectPtr>(cloned_page));
     if (!ObjectUtils::IsType<IndirectReferenceObjectPtr>(cloned_page)
         && !ObjectUtils::IsType<IntegerObjectPtr>(cloned_page)) {
-        LOG_ERROR_AND_THROW(InvalidParameterException, "Unknown object type");
+        LOG_ERROR_AND_THROW(InvalidParameterException, "Cloned page shall be an IndirectReference or an Integer, but is {}", Object::TypeName(cloned_page->GetObjectType()));
     }
 
     OutputCatalogPtr original_catalog;
@@ -440,7 +440,7 @@ bool Document::IsDestinationReferencingPage(DestinationPtr destination, PageObje
         || ObjectUtils::IsType<IntegerObjectPtr>(destination_page_object));
     if (!ObjectUtils::IsType<IndirectReferenceObjectPtr>(destination_page_object)
         && !ObjectUtils::IsType<IntegerObjectPtr>(destination_page_object)) {
-        LOG_ERROR_AND_THROW(InvalidParameterException, "Unknown object type");
+        LOG_ERROR_AND_THROW(InvalidParameterException, "Destination page shall be an IndirectReference or an Integer, but is {}", Object::TypeName(destination_page_object->GetObjectType()));
     }
 
     if (ObjectUtils::IsType<IndirectReferenceObjectPtr>(destination_page_object)) {

--- a/src/vanillapdf/semantics/objects/document_info.cpp
+++ b/src/vanillapdf/semantics/objects/document_info.cpp
@@ -208,7 +208,7 @@ void DocumentInfo::SetTrapped(DocumentTrapped value) {
             name = syntax::ObjectUtils::Clone<syntax::NameObjectPtr>(constant::Name::False);
             break;
         default:
-            LOG_ERROR_AND_THROW(InvalidParameterException, "Unknown trapped type");
+            LOG_ERROR_AND_THROW(InvalidParameterException, "Unknown trapped type: {}", static_cast<int>(value));
     }
 
     _obj->Insert(constant::Name::Trapped, name, true);

--- a/src/vanillapdf/semantics/objects/document_info.cpp
+++ b/src/vanillapdf/semantics/objects/document_info.cpp
@@ -208,7 +208,7 @@ void DocumentInfo::SetTrapped(DocumentTrapped value) {
             name = syntax::ObjectUtils::Clone<syntax::NameObjectPtr>(constant::Name::False);
             break;
         default:
-            throw InvalidParameterException("Unknown trapped type");
+            LOG_ERROR_AND_THROW(InvalidParameterException, "Unknown trapped type");
     }
 
     _obj->Insert(constant::Name::Trapped, name, true);

--- a/src/vanillapdf/semantics/objects/font.cpp
+++ b/src/vanillapdf/semantics/objects/font.cpp
@@ -39,24 +39,24 @@ FontBase* FontBase::Create(syntax::DictionaryObjectPtr root) {
     if (root->Contains(constant::Name::Type)) {
         syntax::ObjectPtr type_obj = root->Find(constant::Name::Type);
         if (!syntax::ObjectUtils::IsType<syntax::NameObjectPtr>(type_obj)) {
-            throw syntax::ObjectMissingException("Invalid font type object");
+            LOG_ERROR_AND_THROW(syntax::ObjectMissingException, "Invalid font type object");
         }
 
         syntax::NameObjectPtr font_type = syntax::ObjectUtils::ConvertTo<syntax::NameObjectPtr>(type_obj);
 
         if (font_type != constant::Name::Font) {
-            throw syntax::ObjectMissingException("Invalid font type: " + font_type->ToString());
+            LOG_ERROR_AND_THROW(syntax::ObjectMissingException, "Invalid font type: {}", font_type->ToString());
         }
     }
 
     if (!root->Contains(constant::Name::Subtype)) {
-        throw syntax::ObjectMissingException("Dictionary does not contain subtype");
+        LOG_ERROR_AND_THROW(syntax::ObjectMissingException, "Dictionary does not contain subtype");
     }
 
     syntax::ObjectPtr subtype_obj = root->Find(constant::Name::Subtype);
 
     if (!syntax::ObjectUtils::IsType<syntax::NameObjectPtr>(subtype_obj)) {
-        throw syntax::ObjectMissingException("Invalid font subtype object");
+        LOG_ERROR_AND_THROW(syntax::ObjectMissingException, "Invalid font subtype object");
     }
 
     syntax::NameObjectPtr subtype = syntax::ObjectUtils::ConvertTo<syntax::NameObjectPtr>(subtype_obj);
@@ -96,7 +96,7 @@ FontBase* FontBase::Create(syntax::DictionaryObjectPtr root) {
         return result.release();
     }
 
-    throw syntax::ObjectMissingException("Unknown font subtype: " + subtype->ToString());
+    LOG_ERROR_AND_THROW(syntax::ObjectMissingException, "Unknown font subtype: {}", subtype->ToString());
 }
 
 bool FontBase::ToUnicode(OuputUnicodeCharacterMapPtr& result) const {

--- a/src/vanillapdf/semantics/objects/font.cpp
+++ b/src/vanillapdf/semantics/objects/font.cpp
@@ -39,7 +39,7 @@ FontBase* FontBase::Create(syntax::DictionaryObjectPtr root) {
     if (root->Contains(constant::Name::Type)) {
         syntax::ObjectPtr type_obj = root->Find(constant::Name::Type);
         if (!syntax::ObjectUtils::IsType<syntax::NameObjectPtr>(type_obj)) {
-            LOG_ERROR_AND_THROW(syntax::ObjectMissingException, "Invalid font type object");
+            LOG_ERROR_AND_THROW(syntax::ObjectMissingException, "Font /Type entry shall be a Name, but found {}", syntax::Object::TypeName(type_obj->GetObjectType()));
         }
 
         syntax::NameObjectPtr font_type = syntax::ObjectUtils::ConvertTo<syntax::NameObjectPtr>(type_obj);
@@ -56,7 +56,7 @@ FontBase* FontBase::Create(syntax::DictionaryObjectPtr root) {
     syntax::ObjectPtr subtype_obj = root->Find(constant::Name::Subtype);
 
     if (!syntax::ObjectUtils::IsType<syntax::NameObjectPtr>(subtype_obj)) {
-        LOG_ERROR_AND_THROW(syntax::ObjectMissingException, "Invalid font subtype object");
+        LOG_ERROR_AND_THROW(syntax::ObjectMissingException, "Font /Subtype entry shall be a Name, but found {}", syntax::Object::TypeName(subtype_obj->GetObjectType()));
     }
 
     syntax::NameObjectPtr subtype = syntax::ObjectUtils::ConvertTo<syntax::NameObjectPtr>(subtype_obj);

--- a/src/vanillapdf/semantics/objects/page_contents.cpp
+++ b/src/vanillapdf/semantics/objects/page_contents.cpp
@@ -84,7 +84,7 @@ bool PageContents::RecalculateStreamData() {
 
         assert(0 != stream_array_size && "Content stream array is empty");
         if (0 == stream_array_size) {
-            throw syntax::ObjectMissingException("Content stream array is empty");
+            LOG_ERROR_AND_THROW(syntax::ObjectMissingException, "Content stream array is empty");
         }
 
         for (decltype(stream_array_size) j = 0; j < stream_array_size; ++j) {
@@ -123,7 +123,7 @@ BaseInstructionCollectionPtr PageContents::Instructions(void) const {
             contents.push_back(content_stream);
         }
     } else {
-        throw syntax::ObjectMissingException("Contents was constructed from unrecognized element: " + _obj->ToString());
+        LOG_ERROR_AND_THROW(syntax::ObjectMissingException, "Contents was constructed from unrecognized element: {}", _obj->ToString());
     }
 
     // We are not using contents.Instructions, because objects can be separated

--- a/src/vanillapdf/semantics/objects/page_labels.cpp
+++ b/src/vanillapdf/semantics/objects/page_labels.cpp
@@ -46,7 +46,7 @@ bool PageLabel::Style(NumberingStyle& result) const {
     auto value = _obj->FindAs<syntax::NameObjectPtr>(constant::Name::S);
     auto buf = value->GetValue();
     if (buf->size() != 1) {
-        throw syntax::ParseException("Unknown numbering style" + buf->ToString());
+        LOG_ERROR_AND_THROW(syntax::ParseException, "Unknown numbering style{}", buf->ToString());
     }
 
     if (buf[0] != static_cast<char>(NumberingStyle::Decimal)
@@ -54,7 +54,7 @@ bool PageLabel::Style(NumberingStyle& result) const {
         && buf[0] != static_cast<char>(NumberingStyle::LowerRoman)
         && buf[0] != static_cast<char>(NumberingStyle::UpperLetters)
         && buf[0] != static_cast<char>(NumberingStyle::LowerLetters)) {
-        throw syntax::ParseException("Unknown numbering style" + buf->ToString());
+        LOG_ERROR_AND_THROW(syntax::ParseException, "Unknown numbering style{}", buf->ToString());
     }
 
     result = static_cast<NumberingStyle>(buf[0]);

--- a/src/vanillapdf/semantics/objects/page_labels.cpp
+++ b/src/vanillapdf/semantics/objects/page_labels.cpp
@@ -46,7 +46,7 @@ bool PageLabel::Style(NumberingStyle& result) const {
     auto value = _obj->FindAs<syntax::NameObjectPtr>(constant::Name::S);
     auto buf = value->GetValue();
     if (buf->size() != 1) {
-        LOG_ERROR_AND_THROW(syntax::ParseException, "Unknown numbering style{}", buf->ToString());
+        LOG_ERROR_AND_THROW(syntax::ParseException, "Unknown numbering style: {}", buf->ToString());
     }
 
     if (buf[0] != static_cast<char>(NumberingStyle::Decimal)
@@ -54,7 +54,7 @@ bool PageLabel::Style(NumberingStyle& result) const {
         && buf[0] != static_cast<char>(NumberingStyle::LowerRoman)
         && buf[0] != static_cast<char>(NumberingStyle::UpperLetters)
         && buf[0] != static_cast<char>(NumberingStyle::LowerLetters)) {
-        LOG_ERROR_AND_THROW(syntax::ParseException, "Unknown numbering style{}", buf->ToString());
+        LOG_ERROR_AND_THROW(syntax::ParseException, "Unknown numbering style: {}", buf->ToString());
     }
 
     result = static_cast<NumberingStyle>(buf[0]);

--- a/src/vanillapdf/semantics/objects/page_object.cpp
+++ b/src/vanillapdf/semantics/objects/page_object.cpp
@@ -129,7 +129,7 @@ bool PageObject::GetContents(OutputPageContentsPtr& result) const {
         assert(!(is_ref && is_array) && "Error in object utils, object is stream and array at the same time");
 
         auto base_type_str = Object::TypeName(content->GetObjectType());
-        throw syntax::ParseException("Invalid contents type: " + std::string(base_type_str));
+        LOG_ERROR_AND_THROW(syntax::ParseException, "Invalid contents type: {}", base_type_str);
     }
 
     if (is_ref) {
@@ -148,7 +148,7 @@ bool PageObject::GetContents(OutputPageContentsPtr& result) const {
         return true;
     }
 
-    throw InvalidParameterException("Unreachable code");
+    LOG_ERROR_AND_THROW(InvalidParameterException, "Unreachable code");
 }
 
 PageObjectPtr PageObject::Create(DocumentPtr document) {

--- a/src/vanillapdf/semantics/objects/page_tree.cpp
+++ b/src/vanillapdf/semantics/objects/page_tree.cpp
@@ -283,7 +283,7 @@ types::size_type PageTree::UpdateKidsCount(PageNodeBasePtr node) {
         return kid_count;
     }
 
-    LOG_ERROR_AND_THROW(syntax::ParseException, "Unknown page object type");
+    LOG_ERROR_AND_THROW(syntax::ParseException, "Unknown page node type: {}", static_cast<int>(node->GetNodeType()));
 }
 
 ArrayObjectPtr<IndirectReferenceObjectPtr> PageTree::GetKidsInternal(DictionaryObjectPtr node_dictionary) {

--- a/src/vanillapdf/semantics/objects/page_tree.cpp
+++ b/src/vanillapdf/semantics/objects/page_tree.cpp
@@ -56,7 +56,7 @@ void PageTree::BuildPageCache() const {
 
 PageObjectPtr PageTree::GetCachedPage(types::size_type page_number) const {
     if (page_number < 1) {
-        throw InvalidParameterException(fmt::format("Invalid page number: {}", page_number));
+        LOG_ERROR_AND_THROW(InvalidParameterException, "Invalid page number: {}", page_number);
     }
 
     ACCESS_LOCK_GUARD(m_cache_lock);
@@ -66,7 +66,7 @@ PageObjectPtr PageTree::GetCachedPage(types::size_type page_number) const {
     }
 
     if (page_number > m_page_cache.size()) {
-        throw ObjectMissingException("Page number was not found: " + std::to_string(page_number));
+        LOG_ERROR_AND_THROW(ObjectMissingException, "Page number was not found: {}", page_number);
     }
 
     spdlog::debug("Searching for page {}", page_number);
@@ -167,7 +167,7 @@ bool PageTree::FindPageParentInternal(PageTreeNodePtr node, types::size_type pag
 
 void PageTree::Insert(PageObjectPtr object, types::size_type page_index) {
     if (page_index < 1) {
-        throw InvalidParameterException(fmt::format("Invalid page index: {}. Page indices are 1-based", page_index));
+        LOG_ERROR_AND_THROW(InvalidParameterException, "Invalid page index: {}. Page indices are 1-based", page_index);
     }
 
     // Inserting after the current last page is an append
@@ -210,7 +210,7 @@ void PageTree::Append(PageObjectPtr object) {
 
 void PageTree::Remove(types::size_type page_index) {
     if (page_index < 1) {
-        throw InvalidParameterException(fmt::format("Invalid page index: {}. Page indices are 1-based", page_index));
+        LOG_ERROR_AND_THROW(InvalidParameterException, "Invalid page index: {}. Page indices are 1-based", page_index);
     }
 
     types::size_type kid_index = 0;
@@ -283,7 +283,7 @@ types::size_type PageTree::UpdateKidsCount(PageNodeBasePtr node) {
         return kid_count;
     }
 
-    throw syntax::ParseException("Unknown page object type");
+    LOG_ERROR_AND_THROW(syntax::ParseException, "Unknown page object type");
 }
 
 ArrayObjectPtr<IndirectReferenceObjectPtr> PageTree::GetKidsInternal(DictionaryObjectPtr node_dictionary) {

--- a/src/vanillapdf/semantics/objects/rectangle.cpp
+++ b/src/vanillapdf/semantics/objects/rectangle.cpp
@@ -14,7 +14,7 @@ Rectangle::Rectangle() {
 Rectangle::Rectangle(syntax::ArrayObjectPtr<syntax::RealObjectPtr> list) : HighLevelObject(list) {
     assert(list->GetSize() == 4 && "Only fully specified rectangles are yet supported");
     if (list->GetSize() != 4) {
-        throw InvalidParameterException("Invalid rectangle size: " + std::to_string(list->GetSize()));
+        LOG_ERROR_AND_THROW(InvalidParameterException, "Invalid rectangle size: {}", list->GetSize());
     }
 
     m_llx = list->GetValue(0);

--- a/src/vanillapdf/semantics/objects/tree.cpp
+++ b/src/vanillapdf/semantics/objects/tree.cpp
@@ -34,7 +34,7 @@ TreeNodeBasePtr TreeNodeBase::Create(
         return make_deferred<TreeNodeLeaf>(parent, obj);
     }
 
-    throw syntax::ObjectMissingException("Unknown tree node: " + obj->ToString());
+    LOG_ERROR_AND_THROW(syntax::ObjectMissingException, "Unknown tree node: {}", obj->ToString());
 }
 
 #pragma endregion

--- a/src/vanillapdf/semantics/objects/tree.h
+++ b/src/vanillapdf/semantics/objects/tree.h
@@ -13,6 +13,7 @@
 #include "syntax/utils/name_constants.h"
 
 #include "utils/util.h"
+#include "utils/log.h"
 
 namespace vanillapdf {
 namespace semantics {
@@ -376,7 +377,7 @@ syntax::ContainableObjectPtr TreeBase<KeyT, ValueT>::Find(const KeyT& key) const
 
     auto found = m_map.find(key);
     if (found == m_map.end()) {
-        throw syntax::ObjectMissingException("Item was not found");
+        LOG_ERROR_AND_THROW(syntax::ObjectMissingException, "Item was not found");
     }
 
     return found->second;
@@ -461,7 +462,7 @@ std::map<KeyT, syntax::ContainableObjectPtr> TreeBase<KeyT, ValueT>::GetAllKeys(
         return result_map;
     }
 
-    throw syntax::ObjectMissingException("Unknown node type");
+    LOG_ERROR_AND_THROW(syntax::ObjectMissingException, "Unknown node type");
 }
 
 template <typename KeyT, typename ValueT>
@@ -496,7 +497,7 @@ bool TreeBase<KeyT, ValueT>::ContainsInternal(const TreeNodeBasePtr node, const 
             return ContainsInternal(root->Values(), key);
         }
 
-        throw syntax::ObjectMissingException("Unknown tree root type");
+        LOG_ERROR_AND_THROW(syntax::ObjectMissingException, "Unknown tree root type");
     }
 
     if (node_type == TreeNodeBase::TreeNodeType::Intermediate) {
@@ -517,7 +518,7 @@ bool TreeBase<KeyT, ValueT>::ContainsInternal(const TreeNodeBasePtr node, const 
         return ContainsInternal(leaf->Values(), key);
     }
 
-    throw syntax::ObjectMissingException("Unknown node type");
+    LOG_ERROR_AND_THROW(syntax::ObjectMissingException, "Unknown node type");
 }
 
 template <typename KeyT, typename ValueT>
@@ -529,7 +530,7 @@ ValueT TreeBase<KeyT, ValueT>::FindInternal(const syntax::MixedArrayObjectPtr va
         }
     }
 
-    throw syntax::ObjectMissingException("Tree node does not contain required item");
+    LOG_ERROR_AND_THROW(syntax::ObjectMissingException, "Tree node does not contain required item");
 }
 
 template <typename KeyT, typename ValueT>
@@ -545,14 +546,14 @@ ValueT TreeBase<KeyT, ValueT>::FindInternal(const TreeNodeBasePtr node, const Ke
                 }
             }
 
-            throw syntax::ObjectMissingException("Tree node does not contain required item");
+            LOG_ERROR_AND_THROW(syntax::ObjectMissingException, "Tree node does not contain required item");
         }
 
         if (root->HasValues()) {
             return FindInternal(root->Values(), key);
         }
 
-        throw syntax::ObjectMissingException("Unknown tree root type");
+        LOG_ERROR_AND_THROW(syntax::ObjectMissingException, "Unknown tree root type");
     }
 
     if (node_type == TreeNodeBase::TreeNodeType::Intermediate) {
@@ -563,23 +564,25 @@ ValueT TreeBase<KeyT, ValueT>::FindInternal(const TreeNodeBasePtr node, const Ke
             }
         }
 
-        throw syntax::ObjectMissingException("Tree node does not contain required item");
+        LOG_ERROR_AND_THROW(syntax::ObjectMissingException, "Tree node does not contain required item");
     }
 
     if (node_type == TreeNodeBase::TreeNodeType::Leaf) {
         auto leaf = ConvertUtils<TreeNodeBasePtr>::ConvertTo<TreeNodeLeafPtr>(node);
         auto limits = leaf->Limits();
         assert(limits->GetSize() == 2);
-        if (limits->GetSize() != 2)
-            throw syntax::ObjectMissingException("Tree node has incorrect size");
+        if (limits->GetSize() != 2) {
+            LOG_ERROR_AND_THROW(syntax::ObjectMissingException, "Tree node has incorrect size");
+        }
 
-        if (key < limits->GetValue(0) || limits->GetValue(1) < key)
-            throw syntax::ObjectMissingException("Tree node does not contain required item");
+        if (key < limits->GetValue(0) || limits->GetValue(1) < key) {
+            LOG_ERROR_AND_THROW(syntax::ObjectMissingException, "Tree node does not contain required item");
+        }
 
         return FindInternal(leaf->Values(), key);
     }
 
-    throw syntax::ObjectMissingException("Unknown node type");
+    LOG_ERROR_AND_THROW(syntax::ObjectMissingException, "Unknown node type");
 }
 
 #pragma endregion

--- a/src/vanillapdf/semantics/objects/tree.h
+++ b/src/vanillapdf/semantics/objects/tree.h
@@ -377,7 +377,7 @@ syntax::ContainableObjectPtr TreeBase<KeyT, ValueT>::Find(const KeyT& key) const
 
     auto found = m_map.find(key);
     if (found == m_map.end()) {
-        LOG_ERROR_AND_THROW(syntax::ObjectMissingException, "Item was not found");
+        LOG_ERROR_AND_THROW(syntax::ObjectMissingException, "Item {} was not found in the tree", key->ToString());
     }
 
     return found->second;
@@ -462,7 +462,7 @@ std::map<KeyT, syntax::ContainableObjectPtr> TreeBase<KeyT, ValueT>::GetAllKeys(
         return result_map;
     }
 
-    LOG_ERROR_AND_THROW(syntax::ObjectMissingException, "Unknown node type");
+    LOG_ERROR_AND_THROW(syntax::ObjectMissingException, "Unknown tree node type: {}", static_cast<int>(node_type));
 }
 
 template <typename KeyT, typename ValueT>
@@ -497,7 +497,7 @@ bool TreeBase<KeyT, ValueT>::ContainsInternal(const TreeNodeBasePtr node, const 
             return ContainsInternal(root->Values(), key);
         }
 
-        LOG_ERROR_AND_THROW(syntax::ObjectMissingException, "Unknown tree root type");
+        LOG_ERROR_AND_THROW(syntax::ObjectMissingException, "Tree root node has neither kids nor values");
     }
 
     if (node_type == TreeNodeBase::TreeNodeType::Intermediate) {
@@ -518,7 +518,7 @@ bool TreeBase<KeyT, ValueT>::ContainsInternal(const TreeNodeBasePtr node, const 
         return ContainsInternal(leaf->Values(), key);
     }
 
-    LOG_ERROR_AND_THROW(syntax::ObjectMissingException, "Unknown node type");
+    LOG_ERROR_AND_THROW(syntax::ObjectMissingException, "Unknown tree node type: {}", static_cast<int>(node_type));
 }
 
 template <typename KeyT, typename ValueT>
@@ -530,7 +530,7 @@ ValueT TreeBase<KeyT, ValueT>::FindInternal(const syntax::MixedArrayObjectPtr va
         }
     }
 
-    LOG_ERROR_AND_THROW(syntax::ObjectMissingException, "Tree node does not contain required item");
+    LOG_ERROR_AND_THROW(syntax::ObjectMissingException, "Tree node does not contain item {}", key->ToString());
 }
 
 template <typename KeyT, typename ValueT>
@@ -546,14 +546,14 @@ ValueT TreeBase<KeyT, ValueT>::FindInternal(const TreeNodeBasePtr node, const Ke
                 }
             }
 
-            LOG_ERROR_AND_THROW(syntax::ObjectMissingException, "Tree node does not contain required item");
+            LOG_ERROR_AND_THROW(syntax::ObjectMissingException, "Tree node does not contain item {}", key->ToString());
         }
 
         if (root->HasValues()) {
             return FindInternal(root->Values(), key);
         }
 
-        LOG_ERROR_AND_THROW(syntax::ObjectMissingException, "Unknown tree root type");
+        LOG_ERROR_AND_THROW(syntax::ObjectMissingException, "Tree root node has neither kids nor values");
     }
 
     if (node_type == TreeNodeBase::TreeNodeType::Intermediate) {
@@ -564,7 +564,7 @@ ValueT TreeBase<KeyT, ValueT>::FindInternal(const TreeNodeBasePtr node, const Ke
             }
         }
 
-        LOG_ERROR_AND_THROW(syntax::ObjectMissingException, "Tree node does not contain required item");
+        LOG_ERROR_AND_THROW(syntax::ObjectMissingException, "Tree node does not contain item {}", key->ToString());
     }
 
     if (node_type == TreeNodeBase::TreeNodeType::Leaf) {
@@ -572,17 +572,17 @@ ValueT TreeBase<KeyT, ValueT>::FindInternal(const TreeNodeBasePtr node, const Ke
         auto limits = leaf->Limits();
         assert(limits->GetSize() == 2);
         if (limits->GetSize() != 2) {
-            LOG_ERROR_AND_THROW(syntax::ObjectMissingException, "Tree node has incorrect size");
+            LOG_ERROR_AND_THROW(syntax::ObjectMissingException, "Tree node limits shall contain two values, but contain {}", limits->GetSize());
         }
 
         if (key < limits->GetValue(0) || limits->GetValue(1) < key) {
-            LOG_ERROR_AND_THROW(syntax::ObjectMissingException, "Tree node does not contain required item");
+            LOG_ERROR_AND_THROW(syntax::ObjectMissingException, "Tree node does not contain item {}", key->ToString());
         }
 
         return FindInternal(leaf->Values(), key);
     }
 
-    LOG_ERROR_AND_THROW(syntax::ObjectMissingException, "Unknown node type");
+    LOG_ERROR_AND_THROW(syntax::ObjectMissingException, "Unknown tree node type: {}", static_cast<int>(node_type));
 }
 
 #pragma endregion

--- a/src/vanillapdf/semantics/objects/viewer_preferences.cpp
+++ b/src/vanillapdf/semantics/objects/viewer_preferences.cpp
@@ -106,7 +106,7 @@ bool ViewerPreferences::NonFullScreenPageMode(NonFullScreenPageModeType& result)
     } else if (name == constant::Name::UseOC) {
         result = NonFullScreenPageModeType::UseOC;
     } else {
-        throw syntax::ParseException("Unknown page mode type: " + name->ToString());
+        LOG_ERROR_AND_THROW(syntax::ParseException, "Unknown page mode type: {}", name->ToString());
     }
 
     return true;
@@ -123,7 +123,7 @@ bool ViewerPreferences::Direction(ReadingOrderType& result) const {
     } else if (name == constant::Name::R2L) {
         result = ReadingOrderType::RightToLeft;
     } else {
-        throw syntax::ParseException("Unknown reading order: " + name->ToString());
+        LOG_ERROR_AND_THROW(syntax::ParseException, "Unknown reading order: {}", name->ToString());
     }
 
     return true;
@@ -176,7 +176,7 @@ bool ViewerPreferences::PrintScaling(PrintScalingType& result) const {
     } else if (name == constant::Name::None) {
         result = PrintScalingType::None;
     } else {
-        throw syntax::ParseException("Unknown print scaling: " + name->ToString());
+        LOG_ERROR_AND_THROW(syntax::ParseException, "Unknown print scaling: {}", name->ToString());
     }
 
     return true;
@@ -203,7 +203,7 @@ bool ViewerPreferences::Duplex(DuplexType& result) const {
         return true;
     }
 
-    throw syntax::ParseException("Unknown duplex: " + name->ToString());
+    LOG_ERROR_AND_THROW(syntax::ParseException, "Unknown duplex: {}", name->ToString());
 }
 
 bool ViewerPreferences::PickTrayByPDFSize(syntax::BooleanObjectPtr& result) const {

--- a/src/vanillapdf/semantics/utils/semantic_utils.cpp
+++ b/src/vanillapdf/semantics/utils/semantic_utils.cpp
@@ -17,7 +17,7 @@ Version SemanticUtils::GetVersionFromName(const syntax::NameObjectPtr& name) {
     std::smatch sm;
     std::regex header_regex("([0-9])\\.([0-9])");
     if (!std::regex_match(ver_str, sm, header_regex)) {
-        throw NotSupportedException("Unsupported pdf version: " + ver_str);
+        LOG_ERROR_AND_THROW(NotSupportedException, "Unsupported pdf version: {}", ver_str);
     }
 
     assert(sm.size() == 3);
@@ -32,18 +32,18 @@ Version SemanticUtils::GetVersionFromName(const syntax::NameObjectPtr& name) {
             case 5: return Version::PDF15;
             case 6: return Version::PDF16;
             case 7: return Version::PDF17;
-            default: throw NotSupportedException("Unsupported pdf version: " + ver_str);
+            default: LOG_ERROR_AND_THROW(NotSupportedException, "Unsupported pdf version: {}", ver_str);
         }
     }
 
     if (stoi(sm[1]) == 2) {
         switch (stoi(sm[2])) {
             case 0: return Version::PDF20;
-            default: throw NotSupportedException("Unsupported pdf version: " + ver_str);
+            default: LOG_ERROR_AND_THROW(NotSupportedException, "Unsupported pdf version: {}", ver_str);
         }
     }
 
-    throw NotSupportedException("Unsupported pdf version: " + ver_str);
+    LOG_ERROR_AND_THROW(NotSupportedException, "Unsupported pdf version: {}", ver_str);
 }
 
 using document_map_type = std::unordered_map<syntax::File*, WeakReference<Document>>;

--- a/src/vanillapdf/syntax/exceptions/syntax_exceptions.cpp
+++ b/src/vanillapdf/syntax/exceptions/syntax_exceptions.cpp
@@ -29,9 +29,8 @@ ObjectMissingException::ObjectMissingException(types::big_uint objNumber, types:
 ObjectMissingException::ObjectMissingException(const char * const & msg) : ExceptionBase(msg) {}
 ObjectMissingException::ObjectMissingException(const std::string& msg) : ExceptionBase(msg) {}
 
-DuplicateKeyException::DuplicateKeyException(const std::string& key)
-    : ExceptionBase("The key " + key + " was already present in the dictionary") {
-}
+DuplicateKeyException::DuplicateKeyException(const char * const & msg) : ExceptionBase(msg) {}
+DuplicateKeyException::DuplicateKeyException(const std::string& msg) : ExceptionBase(msg) {}
 
 } // syntax
 } // vanillapdf

--- a/src/vanillapdf/syntax/exceptions/syntax_exceptions.h
+++ b/src/vanillapdf/syntax/exceptions/syntax_exceptions.h
@@ -38,7 +38,8 @@ public:
 
 class DuplicateKeyException : public ExceptionBase {
 public:
-    explicit DuplicateKeyException(const std::string& key);
+    explicit DuplicateKeyException(const char * const & msg);
+    explicit DuplicateKeyException(const std::string& msg);
     virtual Type code() const noexcept { return Type::DuplicateKey; }
 };
 

--- a/src/vanillapdf/syntax/files/file.cpp
+++ b/src/vanillapdf/syntax/files/file.cpp
@@ -70,15 +70,15 @@ FilePtr File::CreateStream(IInputOutputStreamPtr stream, const std::string& name
 IInputOutputStreamPtr File::CreateIOStream(const std::string& path, std::ios_base::openmode mode, IOStrategy strategy) {
     switch (strategy) {
         case IOStrategy::Undefined:
-            throw InvalidParameterException("IOStrategy::Undefined is not a valid strategy, caller must pick a concrete strategy");
+            LOG_ERROR_AND_THROW(InvalidParameterException, "IOStrategy::Undefined is not a valid strategy, caller must pick a concrete strategy");
         case IOStrategy::FileStream:
             return StreamUtils::CreateFileStream(path, mode);
         case IOStrategy::Memory:
             return StreamUtils::CreateMemoryBufferStream(path, mode);
         case IOStrategy::MemoryMapped:
-            throw NotSupportedException("IOStrategy::MemoryMapped is not yet supported");
+            LOG_ERROR_AND_THROW(NotSupportedException, "IOStrategy::MemoryMapped is not yet supported");
         default:
-            throw GeneralException("Unknown IOStrategy: " + std::to_string(static_cast<int>(strategy)));
+            LOG_ERROR_AND_THROW_GENERAL("Unknown IOStrategy: {}", static_cast<int>(strategy));
     }
 }
 
@@ -581,7 +581,7 @@ BufferPtr File::DecryptData(const Buffer& data,
         // Encrypted documents shall be opened with default empty password
         bool passed = SetEncryptionPassword("");
         if (!passed) {
-            throw InvalidPasswordException("Could not decrypt file using default password");
+            LOG_ERROR_AND_THROW(InvalidPasswordException, "Could not decrypt file using default password");
         }
     }
 
@@ -666,7 +666,7 @@ BufferPtr File::EncryptData(const Buffer& data,
         // Encrypted documents shall be opened with default empty password
         bool passed = SetEncryptionPassword("");
         if (!passed) {
-            throw InvalidPasswordException("Could not decrypt file using default password");
+            LOG_ERROR_AND_THROW(InvalidPasswordException, "Could not decrypt file using default password");
         }
     }
 
@@ -774,7 +774,7 @@ void File::ReadXref(types::stream_offset offset) {
             auto hybrid_xref = stream.ReadXref(stm_offset);
 
             if (!ConvertUtils<XrefBasePtr>::IsType<XrefStreamPtr>(hybrid_xref)) {
-                throw ParseException("Hybrid xref is not a stream");
+                LOG_ERROR_AND_THROW(ParseException, "Hybrid xref is not a stream");
             }
 
             auto hybrid_xref_stream = ConvertUtils<XrefBasePtr>::ConvertTo<XrefStreamPtr>(hybrid_xref);
@@ -813,13 +813,13 @@ types::stream_offset File::GetLastXrefOffset(types::stream_size file_size) {
 
     _input->SetInputPosition(-to_read, SeekDirection::End);
     if (_input->IsFail()) {
-        throw IOErrorException("Failed to seek for reading the file trailer");
+        LOG_ERROR_AND_THROW(IOErrorException, "Failed to seek for reading the file trailer");
     }
 
     BufferPtr file_trailer(make_deferred_container<Buffer>(to_read));
     auto bytes_read = _input->Read(file_trailer, to_read);
     if (bytes_read != to_read) {
-        throw IOErrorException("Failed to read file trailer");
+        LOG_ERROR_AND_THROW(IOErrorException, "Failed to read file trailer");
     }
 
     std::reverse(file_trailer.begin(), file_trailer.end());
@@ -935,7 +935,7 @@ ObjectPtr File::GetIndirectObjectInternal(
         case XrefEntryBase::Usage::Free:
             return NullObject::GetInstance();
         default:
-            throw ParseException("Unknown xref entry type: " + std::to_string(static_cast<int>(item->GetUsage())));
+            LOG_ERROR_AND_THROW(ParseException, "Unknown xref entry type: {}", static_cast<int>(item->GetUsage()));
     }
 }
 
@@ -1037,7 +1037,7 @@ XrefUsedEntryBasePtr File::AllocateNewEntry() {
         return new_entry;
     }
 
-    throw IOErrorException("Unable to allocate new entry");
+    LOG_ERROR_AND_THROW(IOErrorException, "Unable to allocate new entry");
 }
 
 void File::FixObjectReferences(const std::map<ObjectPtr, ObjectPtr>& map, std::map<ObjectPtr, bool>& visited, ObjectPtr copied) {

--- a/src/vanillapdf/syntax/files/file_structure_validation_result.cpp
+++ b/src/vanillapdf/syntax/files/file_structure_validation_result.cpp
@@ -18,7 +18,7 @@ void FileStructureValidationResult::AddIssue(FileStructureIssuePtr issue) {
 
 FileStructureIssuePtr FileStructureValidationResult::GetIssueAt(types::size_type index) const {
     if (index >= m_issues.size()) {
-        LOG_ERROR_AND_THROW(InvalidParameterException, "Issue index out of range");
+        LOG_ERROR_AND_THROW(InvalidParameterException, "Issue index {} is out of range, the result holds {} issue(s)", index, m_issues.size());
     }
 
     return m_issues[index];

--- a/src/vanillapdf/syntax/files/file_structure_validation_result.cpp
+++ b/src/vanillapdf/syntax/files/file_structure_validation_result.cpp
@@ -18,7 +18,7 @@ void FileStructureValidationResult::AddIssue(FileStructureIssuePtr issue) {
 
 FileStructureIssuePtr FileStructureValidationResult::GetIssueAt(types::size_type index) const {
     if (index >= m_issues.size()) {
-        throw InvalidParameterException("Issue index out of range");
+        LOG_ERROR_AND_THROW(InvalidParameterException, "Issue index out of range");
     }
 
     return m_issues[index];

--- a/src/vanillapdf/syntax/files/file_writer.cpp
+++ b/src/vanillapdf/syntax/files/file_writer.cpp
@@ -243,7 +243,7 @@ void FileWriter::RecalculateObjectStreamContent(XrefChainPtr chain, XrefBasePtr 
 
         assert(is_stream && "Object stream has incorrect type");
         if (!is_stream) {
-            LOG_ERROR_AND_THROW(ParseException, "Object stream has incorrect type");
+            LOG_ERROR_AND_THROW(ParseException, "Object stream shall be a Stream, but is {}", Object::TypeName(object_stream_object->GetObjectType()));
         }
 
         auto object_stream = ObjectUtils::ConvertTo<StreamObjectPtr>(object_stream_object);

--- a/src/vanillapdf/syntax/files/file_writer.cpp
+++ b/src/vanillapdf/syntax/files/file_writer.cpp
@@ -53,7 +53,7 @@ void FileWriter::Write(FilePtr source, FilePtr destination) {
     // Verify that configuration flags are valid
     bool valid_configuration = ValidateConfiguration(source, reason);
     if (!valid_configuration) {
-        throw InvalidParameterException(reason);
+        LOG_ERROR_AND_THROW(InvalidParameterException, "{}", reason);
     }
 
     // Get destination output stream
@@ -95,7 +95,7 @@ void FileWriter::WriteIncremental(FilePtr source, FilePtr destination) {
 
     // Incremental update is a licensed feature
     if (!LicenseInfo::IsValid()) {
-        throw LicenseRequiredException("Incremental update is a licensed feature");
+        LOG_ERROR_AND_THROW(LicenseRequiredException, "Incremental update is a licensed feature");
     }
 
     // Terminate if the source file was not initialized
@@ -223,7 +223,7 @@ void FileWriter::RecalculateObjectStreamContent(XrefChainPtr chain, XrefBasePtr 
 
         assert(object_stream_found && "Object stream was not found");
         if (!object_stream_found) {
-            throw ParseException("Object stream was not found");
+            LOG_ERROR_AND_THROW(ParseException, "Object stream was not found");
         }
 
         auto object_stream_entry = chain->GetXrefEntry(object_stream_number, 0);
@@ -231,7 +231,7 @@ void FileWriter::RecalculateObjectStreamContent(XrefChainPtr chain, XrefBasePtr 
 
         assert(object_stream_entry_used && "Object stream is not in use");
         if (!object_stream_entry_used) {
-            throw ParseException("Object stream is not in use");
+            LOG_ERROR_AND_THROW(ParseException, "Object stream is not in use");
         }
 
         auto object_stream_used_entry = ConvertUtils<XrefEntryBasePtr>::ConvertTo<XrefUsedEntryPtr>(object_stream_entry);
@@ -243,7 +243,7 @@ void FileWriter::RecalculateObjectStreamContent(XrefChainPtr chain, XrefBasePtr 
 
         assert(is_stream && "Object stream has incorrect type");
         if (!is_stream) {
-            throw ParseException("Object stream has incorrect type");
+            LOG_ERROR_AND_THROW(ParseException, "Object stream has incorrect type");
         }
 
         auto object_stream = ObjectUtils::ConvertTo<StreamObjectPtr>(object_stream_object);
@@ -346,7 +346,7 @@ void FileWriter::CloneHybridStreams(FilePtr source, FilePtr destination) {
     assert(source_chain->GetSize() == destination_chain->GetSize() && "Error in xref cloning");
 
     if (source_chain->GetSize() != destination_chain->GetSize()) {
-        throw ParseException("Invalid xref size");
+        LOG_ERROR_AND_THROW(ParseException, "Invalid xref size");
     }
 
     for (; dest_iterator != destination_chain->end(); ++dest_iterator, ++source_iterator) {
@@ -355,7 +355,7 @@ void FileWriter::CloneHybridStreams(FilePtr source, FilePtr destination) {
 
         assert(new_xref->GetType() == original_xref->GetType() && "Cloning error");
         if (new_xref->GetType() != original_xref->GetType()) {
-            throw ParseException("Error in cloning xref");
+            LOG_ERROR_AND_THROW(ParseException, "Error in cloning xref");
         }
 
         if (original_xref->GetType() != XrefBase::Type::Table) {
@@ -376,13 +376,13 @@ void FileWriter::CloneHybridStreams(FilePtr source, FilePtr destination) {
 
         auto destination_hybrid_entry = destination_chain->GetXrefEntry(source_hybrid_stream_object_number, source_hybrid_stream_generation_number);
         if (!ConvertUtils<XrefEntryBasePtr>::IsType<XrefUsedEntryBasePtr>(destination_hybrid_entry)) {
-            throw ParseException("Destination xref is not in use");
+            LOG_ERROR_AND_THROW(ParseException, "Destination xref is not in use");
         }
 
         auto destination_hybrid_used_entry = ConvertUtils<XrefEntryBasePtr>::ConvertTo<XrefUsedEntryBasePtr>(destination_hybrid_entry);
         auto destination_hybrid_object = destination_hybrid_used_entry->GetReference();
         if (!ConvertUtils<ObjectPtr>::IsType<StreamObjectPtr>(destination_hybrid_object)) {
-            throw ParseException("Cloned hybrid xref is not a stream");
+            LOG_ERROR_AND_THROW(ParseException, "Cloned hybrid xref is not a stream");
         }
 
         auto cloned_hybrid_xref = CloneXref(destination, source_hybrid_stream);
@@ -404,7 +404,7 @@ void FileWriter::FixStreamReferences(XrefChainPtr source, XrefChainPtr destinati
     assert(source->GetSize() == destination->GetSize() && "Error in xref cloning");
 
     if (source->GetSize() != destination->GetSize()) {
-        throw ParseException("Invalid xref size");
+        LOG_ERROR_AND_THROW(ParseException, "Invalid xref size");
     }
 
     for (; dest_iterator != destination->end(); ++dest_iterator, ++source_iterator) {
@@ -413,7 +413,7 @@ void FileWriter::FixStreamReferences(XrefChainPtr source, XrefChainPtr destinati
 
         assert(new_xref->GetType() == original_xref->GetType() && "Cloning error");
         if (new_xref->GetType() != original_xref->GetType()) {
-            throw ParseException("Error in cloning xref");
+            LOG_ERROR_AND_THROW(ParseException, "Error in cloning xref");
         }
 
         bool is_original_stream = ConvertUtils<XrefBasePtr>::IsType<XrefStreamPtr>(original_xref);
@@ -474,7 +474,7 @@ void FileWriter::SetEncryptionData(FilePtr source, FilePtr destination) {
         auto trailer_dictionary = chain_value->GetTrailerDictionary();
 
         if (!trailer_dictionary->Contains(constant::Name::Encrypt)) {
-            throw ParseException("Destination trailer dictionary does not contain encryption entry");
+            LOG_ERROR_AND_THROW(ParseException, "Destination trailer dictionary does not contain encryption entry");
         }
 
         // TODO Compare the source and destination dictionaries?
@@ -483,7 +483,7 @@ void FileWriter::SetEncryptionData(FilePtr source, FilePtr destination) {
     }
 
     if (!ObjectUtils::IsType<DictionaryObjectPtr>(destination_encryption_object)) {
-        throw ParseException("Destination encryption object is not a dictionary");
+        LOG_ERROR_AND_THROW(ParseException, "Destination encryption object is not a dictionary");
     }
 
     auto dictionary_obj = ObjectUtils::ConvertTo<DictionaryObjectPtr>(destination_encryption_object);
@@ -738,7 +738,7 @@ void FileWriter::RecalculateStreamsLength(XrefBasePtr source) {
             assert(!ObjectUtils::IsType<StreamObjectPtr>(new_obj));
 
             if (ObjectUtils::IsType<StreamObjectPtr>(new_obj)) {
-                throw ParseException("Stream object should not be inside object stream");
+                LOG_ERROR_AND_THROW(ParseException, "Stream object should not be inside object stream");
             }
 
             continue;
@@ -757,7 +757,7 @@ XrefBasePtr FileWriter::FindPreviousXref(XrefChainPtr chain, XrefBasePtr source)
 
         if (Identity(current_xref, source)) {
             if (first_xref) {
-                throw InvalidParameterException("First xref does not have a previous entry");
+                LOG_ERROR_AND_THROW(InvalidParameterException, "First xref does not have a previous entry");
             }
 
             return *prev_xref_iterator;
@@ -772,7 +772,7 @@ XrefBasePtr FileWriter::FindPreviousXref(XrefChainPtr chain, XrefBasePtr source)
         first_xref = false;
     }
 
-    throw InvalidParameterException("Could not find previous xref");
+    LOG_ERROR_AND_THROW(InvalidParameterException, "Could not find previous xref");
 }
 
 HeaderPtr FileWriter::CloneHeader(FilePtr source, FilePtr destination) {
@@ -1294,7 +1294,7 @@ void FileWriter::WriteHeader(IOutputStreamPtr output, HeaderPtr header) {
     case Version::PDF20:
         output->Write("2.0"); break;
     default:
-        throw InvalidParameterException("Unknown PDF version: " + std::to_string(static_cast<int32_t>(version)));
+        LOG_ERROR_AND_THROW(InvalidParameterException, "Unknown PDF version: {}", static_cast<int32_t>(version));
     }
 
     output->WriteLine();

--- a/src/vanillapdf/syntax/files/file_writer.cpp
+++ b/src/vanillapdf/syntax/files/file_writer.cpp
@@ -346,7 +346,7 @@ void FileWriter::CloneHybridStreams(FilePtr source, FilePtr destination) {
     assert(source_chain->GetSize() == destination_chain->GetSize() && "Error in xref cloning");
 
     if (source_chain->GetSize() != destination_chain->GetSize()) {
-        LOG_ERROR_AND_THROW(ParseException, "Invalid xref size");
+        LOG_ERROR_AND_THROW(ParseException, "Cloned xref chain has {} xrefs, but the source has {}", destination_chain->GetSize(), source_chain->GetSize());
     }
 
     for (; dest_iterator != destination_chain->end(); ++dest_iterator, ++source_iterator) {
@@ -404,7 +404,7 @@ void FileWriter::FixStreamReferences(XrefChainPtr source, XrefChainPtr destinati
     assert(source->GetSize() == destination->GetSize() && "Error in xref cloning");
 
     if (source->GetSize() != destination->GetSize()) {
-        LOG_ERROR_AND_THROW(ParseException, "Invalid xref size");
+        LOG_ERROR_AND_THROW(ParseException, "Cloned xref chain has {} xrefs, but the source has {}", destination->GetSize(), source->GetSize());
     }
 
     for (; dest_iterator != destination->end(); ++dest_iterator, ++source_iterator) {

--- a/src/vanillapdf/syntax/files/xref.cpp
+++ b/src/vanillapdf/syntax/files/xref.cpp
@@ -30,7 +30,7 @@ void XrefStream::RecalculateContent() {
 
     assert(fields->GetSize() == 3);
     if (fields->GetSize() != 3) {
-        LOG_ERROR_AND_THROW(ObjectMissingException, "Xref stream width does not contain three integers");
+        LOG_ERROR_AND_THROW(ObjectMissingException, "Xref stream /W shall contain three integers, but contains {}", fields->GetSize());
     }
 
     auto field1_size = fields->GetValue(0);
@@ -199,7 +199,7 @@ void XrefStream::WriteValue(IOutputStream& dest, types::big_uint value, int64_t 
     // This means, that the operation would overflow
     assert(shifted_value == 0 && "Xref stream value overflow");
     if (shifted_value != 0) {
-        LOG_ERROR_AND_THROW(ObjectMissingException, "Xref stream width is too small");
+        LOG_ERROR_AND_THROW(ObjectMissingException, "Xref stream field width of {} byte(s) is too small for value {}", width, value);
     }
 
     // Writes <value> as a sequence of <width> bytes into <dest>

--- a/src/vanillapdf/syntax/files/xref.cpp
+++ b/src/vanillapdf/syntax/files/xref.cpp
@@ -23,14 +23,14 @@ void XrefStream::RecalculateContent() {
 
     auto header = _stream->GetHeader();
     if (!header->Contains(constant::Name::W)) {
-        throw ObjectMissingException("Stream header does not contain width");
+        LOG_ERROR_AND_THROW(ObjectMissingException, "Stream header does not contain width");
     }
 
     auto fields = header->FindAs<ArrayObjectPtr<IntegerObjectPtr>>(constant::Name::W);
 
     assert(fields->GetSize() == 3);
     if (fields->GetSize() != 3) {
-        throw ObjectMissingException("Xref stream width does not contain three integers");
+        LOG_ERROR_AND_THROW(ObjectMissingException, "Xref stream width does not contain three integers");
     }
 
     auto field1_size = fields->GetValue(0);
@@ -199,7 +199,7 @@ void XrefStream::WriteValue(IOutputStream& dest, types::big_uint value, int64_t 
     // This means, that the operation would overflow
     assert(shifted_value == 0 && "Xref stream value overflow");
     if (shifted_value != 0) {
-        throw ObjectMissingException("Xref stream width is too small");
+        LOG_ERROR_AND_THROW(ObjectMissingException, "Xref stream width is too small");
     }
 
     // Writes <value> as a sequence of <width> bytes into <dest>
@@ -217,7 +217,7 @@ void XrefTable::Add(XrefEntryBasePtr entry) {
     // Xref table can only stored free and used entries
     assert((is_free || is_used) && "Adding unsupported entry type into the xref table");
     if (!is_free && !is_used) {
-        throw ObjectMissingException("Adding unsupported entry type into the xref table");
+        LOG_ERROR_AND_THROW(ObjectMissingException, "Adding unsupported entry type into the xref table");
     }
 
     // Perform the addition
@@ -365,7 +365,7 @@ XrefStreamPtr XrefTable::GetHybridStream(void) const {
     assert(has_stream && "Trying to access hybrid stream, that was not set");
 
     if (!has_stream) {
-        throw ObjectMissingException("Trying to access hybrid stream, that was not set");
+        LOG_ERROR_AND_THROW(ObjectMissingException, "Trying to access hybrid stream, that was not set");
     }
 
     return m_xref_stm;
@@ -421,7 +421,7 @@ StreamObjectPtr XrefStream::GetStreamObject(void) const {
     assert(has_stream && "Trying to access stream object, that was not set");
 
     if (!has_stream) {
-        throw ObjectMissingException("Trying to access stream object, that was not set");
+        LOG_ERROR_AND_THROW(ObjectMissingException, "Trying to access stream object, that was not set");
     }
 
     return _stream;

--- a/src/vanillapdf/syntax/files/xref_entry.cpp
+++ b/src/vanillapdf/syntax/files/xref_entry.cpp
@@ -168,7 +168,7 @@ void XrefUsedEntry::Initialize(void) {
     }
 
     if (_offset == constant::BAD_OFFSET) {
-        throw ObjectMissingException("Xref entry data offset is not initialized");
+        LOG_ERROR_AND_THROW(ObjectMissingException, "Xref entry data offset is not initialized");
     }
 
     ACCESS_LOCK_GUARD(m_access_lock);

--- a/src/vanillapdf/syntax/filters/ascii_85_decode_filter.cpp
+++ b/src/vanillapdf/syntax/filters/ascii_85_decode_filter.cpp
@@ -7,7 +7,7 @@ namespace vanillapdf {
 namespace syntax {
 
 BufferPtr ASCII85DecodeFilter::Encode(IInputStreamPtr, types::stream_size, DictionaryObjectPtr parameters /* = DictionaryObjectPtr() */, AttributeListPtr /* = AttributeListPtr() */) const {
-    throw NotSupportedException("ASCII85DecodeFilter encoding is not supported");
+    LOG_ERROR_AND_THROW(NotSupportedException, "ASCII85DecodeFilter encoding is not supported");
 }
 
 BufferPtr ASCII85DecodeFilter::Decode(IInputStreamPtr src, types::stream_size length, DictionaryObjectPtr parameters /* = DictionaryObjectPtr() */, AttributeListPtr /* = AttributeListPtr() */) const {
@@ -21,7 +21,7 @@ BufferPtr ASCII85DecodeFilter::Decode(IInputStreamPtr src, types::stream_size le
         auto meta = src->Get();
 
         if (meta == std::char_traits<char>::eof()) {
-            throw ParseException("Unexpected end of file inside stream");
+            LOG_ERROR_AND_THROW(ParseException, "Unexpected end of file inside stream");
         }
 
         auto ch = ValueConvertUtils::SafeConvert<unsigned char>(meta);
@@ -47,7 +47,7 @@ BufferPtr ASCII85DecodeFilter::Decode(IInputStreamPtr src, types::stream_size le
 
         // Character outside of base 85 range
         if (ch < '!' || ch > 'u') {
-            throw ParseException("Illegal character in ascii 85 filter: " + std::to_string(ch));
+            LOG_ERROR_AND_THROW(ParseException, "Illegal character in ascii 85 filter: {}", ch);
         }
 
         // Insert to our sequence

--- a/src/vanillapdf/syntax/filters/ascii_hex_decode_filter.cpp
+++ b/src/vanillapdf/syntax/filters/ascii_hex_decode_filter.cpp
@@ -16,7 +16,7 @@ char HexPairToByte(const std::string& hex_pair) {
 }
 
 BufferPtr ASCIIHexDecodeFilter::Encode(IInputStreamPtr, types::stream_size, DictionaryObjectPtr parameters/* = DictionaryObjectPtr() */, AttributeListPtr object_attributes /* = AttributeListPtr() */) const {
-    throw NotSupportedException("ASCIIHexDecodeFilter encoding is not supported");
+    LOG_ERROR_AND_THROW(NotSupportedException, "ASCIIHexDecodeFilter encoding is not supported");
 }
 
 BufferPtr ASCIIHexDecodeFilter::Decode(IInputStreamPtr src, types::stream_size length, DictionaryObjectPtr parameters/* = DictionaryObjectPtr() */, AttributeListPtr object_attributes /* = AttributeListPtr() */) const {
@@ -26,7 +26,7 @@ BufferPtr ASCIIHexDecodeFilter::Decode(IInputStreamPtr src, types::stream_size l
     for (decltype(length) i = 0; i < length; ++i) {
         auto meta = src->Get();
         if (meta == std::char_traits<char>::eof()) {
-            throw ParseException("Unexpected end of file inside stream");
+            LOG_ERROR_AND_THROW(ParseException, "Unexpected end of file inside stream");
         }
 
         auto ch = ValueConvertUtils::SafeConvert<unsigned char>(meta);

--- a/src/vanillapdf/syntax/filters/dct_decode_filter.cpp
+++ b/src/vanillapdf/syntax/filters/dct_decode_filter.cpp
@@ -36,9 +36,7 @@ void error_exit(j_common_ptr cinfo) {
     char buffer[JMSG_LENGTH_MAX];
     (*cinfo->err->format_message) (cinfo, buffer);
 
-    spdlog::error("JPEG decompression exited with error: {}", buffer);
-
-    throw ImageCodecErrorException(buffer);
+    LOG_ERROR_AND_THROW(ImageCodecErrorException, "JPEG decompression exited with error: {}", buffer);
 }
 
 void output_message(j_common_ptr cinfo) {
@@ -51,11 +49,11 @@ void output_message(j_common_ptr cinfo) {
 void init_destination(j_compress_ptr cinfo) {
 
     if (cinfo == nullptr) {
-        throw ImageCodecErrorException("Invalid jpeg pointer");
+        LOG_ERROR_AND_THROW(ImageCodecErrorException, "Invalid jpeg pointer");
     }
 
     if (cinfo->dest == nullptr) {
-        throw ImageCodecErrorException("Missing jpeg dest manager");
+        LOG_ERROR_AND_THROW(ImageCodecErrorException, "Missing jpeg dest manager");
     }
 
     CustomDestinationManager* destination = reinterpret_cast<CustomDestinationManager*>(cinfo->dest);
@@ -68,11 +66,11 @@ void init_destination(j_compress_ptr cinfo) {
 boolean empty_output_buffer(j_compress_ptr cinfo) {
 
     if (cinfo == nullptr) {
-        throw ImageCodecErrorException("Invalid jpeg pointer");
+        LOG_ERROR_AND_THROW(ImageCodecErrorException, "Invalid jpeg pointer");
     }
 
     if (cinfo->dest == nullptr) {
-        throw ImageCodecErrorException("Missing jpeg dest manager");
+        LOG_ERROR_AND_THROW(ImageCodecErrorException, "Missing jpeg dest manager");
     }
 
     CustomDestinationManager* destination = reinterpret_cast<CustomDestinationManager*>(cinfo->dest);
@@ -87,11 +85,11 @@ boolean empty_output_buffer(j_compress_ptr cinfo) {
 void term_destination(j_compress_ptr cinfo) {
 
     if (cinfo == nullptr) {
-        throw ImageCodecErrorException("Invalid jpeg pointer");
+        LOG_ERROR_AND_THROW(ImageCodecErrorException, "Invalid jpeg pointer");
     }
 
     if (cinfo->dest == nullptr) {
-        throw ImageCodecErrorException("Missing jpeg dest manager");
+        LOG_ERROR_AND_THROW(ImageCodecErrorException, "Missing jpeg dest manager");
     }
 
     CustomDestinationManager* destination = reinterpret_cast<CustomDestinationManager*>(cinfo->dest);
@@ -152,7 +150,7 @@ BufferPtr DCTDecodeFilter::Encode(IInputStreamPtr src, types::stream_size length
             spdlog::error("Non-standard color spaces {} are not supported", color_space_array->ToString());
 
             // TODO: ICCBased, Indexed, Lab, Separation, DeviceN
-            throw NotSupportedException("Non-standard colorspaces are not supported");
+            LOG_ERROR_AND_THROW(NotSupportedException, "Non-standard colorspaces are not supported");
         }
     }
 
@@ -178,15 +176,15 @@ BufferPtr DCTDecodeFilter::Encode(IInputStreamPtr src, types::stream_size length
 
     // In case the input parameters are missing, terminate immediately
     if (width.empty()) {
-        throw ImageCodecErrorException("Missing parameter Width");
+        LOG_ERROR_AND_THROW(ImageCodecErrorException, "Missing parameter Width");
     }
 
     if (height.empty()) {
-        throw ImageCodecErrorException("Missing parameter Height");
+        LOG_ERROR_AND_THROW(ImageCodecErrorException, "Missing parameter Height");
     }
 
     if (color_space.empty()) {
-        throw ImageCodecErrorException("Missing parameter ColorSpace");
+        LOG_ERROR_AND_THROW(ImageCodecErrorException, "Missing parameter ColorSpace");
     }
 
     jpeg_compress_struct jpeg = { };
@@ -231,22 +229,12 @@ BufferPtr DCTDecodeFilter::Encode(IInputStreamPtr src, types::stream_size length
 
         auto read_plus_row = SafeAddition<decltype(length)>(read_total, row_size);
         if (read_plus_row > length) {
-            throw ImageCodecErrorException(
-                "Insufficient source data, read_plus_row: " +
-                std::to_string(read_plus_row) +
-                ", length: " +
-                std::to_string(length)
-            );
+            LOG_ERROR_AND_THROW(ImageCodecErrorException, "Insufficient source data, read_plus_row: {}, length: {}", read_plus_row, length);
         }
 
         auto read = src->Read(buffer, row_size);
         if (read != row_size) {
-            throw ImageCodecErrorException(
-                "Insufficient source data, read: " +
-                std::to_string(read) +
-                ", row_size: " +
-                std::to_string(row_size)
-            );
+            LOG_ERROR_AND_THROW(ImageCodecErrorException, "Insufficient source data, read: {}, row_size: {}", read, row_size);
         }
 
         JSAMPROW row_pointer[1];
@@ -262,7 +250,7 @@ BufferPtr DCTDecodeFilter::Encode(IInputStreamPtr src, types::stream_size length
 
 #else
     (void) src; (void) length;
-    throw NotSupportedException("This library was compiled without JPEG support");
+    LOG_ERROR_AND_THROW(NotSupportedException, "This library was compiled without JPEG support");
 #endif
 }
 
@@ -314,12 +302,12 @@ BufferPtr DCTDecodeFilter::Decode(IInputStreamPtr src, types::stream_size length
 
     int header = jpeg_read_header(&jpeg, TRUE);
     if (header != JPEG_HEADER_OK) {
-        throw ImageCodecErrorException("Could not read jpeg header");
+        LOG_ERROR_AND_THROW(ImageCodecErrorException, "Could not read jpeg header");
     }
 
     boolean started = jpeg_start_decompress(&jpeg);
     if (started != TRUE) {
-        throw ImageCodecErrorException("Could not start jpeg decompression");
+        LOG_ERROR_AND_THROW(ImageCodecErrorException, "Could not start jpeg decompression");
     }
 
     // Pre-allocate output buffer for the entire decoded image
@@ -337,7 +325,7 @@ BufferPtr DCTDecodeFilter::Decode(IInputStreamPtr src, types::stream_size length
 
     boolean finished = jpeg_finish_decompress(&jpeg);
     if (finished != TRUE) {
-        throw ImageCodecErrorException("Could not finish jpeg decompression");
+        LOG_ERROR_AND_THROW(ImageCodecErrorException, "Could not finish jpeg decompression");
     }
 
     ImageMetadataObjectAttribute::ColorSpaceType attribute_color_space = ImageMetadataObjectAttribute::ColorSpaceType::Undefined;
@@ -368,7 +356,7 @@ BufferPtr DCTDecodeFilter::Decode(IInputStreamPtr src, types::stream_size length
 
 #else
     (void) src; (void) length;
-    throw NotSupportedException("This library was compiled without JPEG support");
+    LOG_ERROR_AND_THROW(NotSupportedException, "This library was compiled without JPEG support");
 #endif
 
 }

--- a/src/vanillapdf/syntax/filters/flate_decode_filter.cpp
+++ b/src/vanillapdf/syntax/filters/flate_decode_filter.cpp
@@ -103,9 +103,9 @@ BufferPtr FlateDecodeFilter::ApplyPredictor(IInputStreamPtr src, types::stream_s
     }
 
     if (*predictor == 2) {
-        throw NotSupportedException("TIFF predictor is currently not supported");
+        LOG_ERROR_AND_THROW(NotSupportedException, "TIFF predictor is currently not supported");
     } else if (*predictor < 10) {
-        throw DataCorruptionException("Unknown predictor type");
+        LOG_ERROR_AND_THROW(DataCorruptionException, "Unknown predictor type");
     }
 
     uint32_t colors_int = colors->SafeConvert<uint32_t>();

--- a/src/vanillapdf/syntax/filters/flate_decode_filter.cpp
+++ b/src/vanillapdf/syntax/filters/flate_decode_filter.cpp
@@ -105,7 +105,7 @@ BufferPtr FlateDecodeFilter::ApplyPredictor(IInputStreamPtr src, types::stream_s
     if (*predictor == 2) {
         LOG_ERROR_AND_THROW(NotSupportedException, "TIFF predictor is currently not supported");
     } else if (*predictor < 10) {
-        LOG_ERROR_AND_THROW(DataCorruptionException, "Unknown predictor type");
+        LOG_ERROR_AND_THROW(DataCorruptionException, "Unknown predictor type: {}", predictor->GetIntegerValue());
     }
 
     uint32_t colors_int = colors->SafeConvert<uint32_t>();

--- a/src/vanillapdf/syntax/filters/jpx_decode_filter.cpp
+++ b/src/vanillapdf/syntax/filters/jpx_decode_filter.cpp
@@ -61,7 +61,7 @@ static OPJ_BOOL memory_stream_seek(OPJ_OFF_T p_nb_bytes, void* p_user_data) {
 }
 
 BufferPtr JPXDecodeFilter::Encode(IInputStreamPtr src, types::stream_size, DictionaryObjectPtr /* = DictionaryObjectPtr() */, AttributeListPtr /* = AttributeListPtr() */) const {
-    throw NotSupportedException("JPXDecodeFilter encoding is not supported");
+    LOG_ERROR_AND_THROW(NotSupportedException, "JPXDecodeFilter encoding is not supported");
 }
 
 BufferPtr JPXDecodeFilter::Decode(IInputStreamPtr src, types::stream_size length, DictionaryObjectPtr /* = DictionaryObjectPtr() */, AttributeListPtr object_attributes /* = AttributeListPtr() */) const {
@@ -73,7 +73,7 @@ BufferPtr JPXDecodeFilter::Decode(IInputStreamPtr src, types::stream_size length
     // Initialize the JPEG2000 decoder
     auto codec = opj_create_decompress(OPJ_CODEC_JP2);
     if (codec == nullptr) {
-        throw ImageCodecErrorException("Failed to create JPEG2000 decoder");
+        LOG_ERROR_AND_THROW(ImageCodecErrorException, "Failed to create JPEG2000 decoder");
     }
 
     SCOPE_GUARD([codec]() { opj_destroy_codec(codec); });
@@ -88,7 +88,7 @@ BufferPtr JPXDecodeFilter::Decode(IInputStreamPtr src, types::stream_size length
     // Set up the stream
     opj_stream_t* stream = opj_stream_create(length_converted, OPJ_TRUE);
     if (stream == nullptr) {
-        throw ImageCodecErrorException("Failed to create JPEG2000 stream");
+        LOG_ERROR_AND_THROW(ImageCodecErrorException, "Failed to create JPEG2000 stream");
     }
 
     SCOPE_GUARD([stream]() { opj_stream_destroy(stream); });
@@ -102,7 +102,7 @@ BufferPtr JPXDecodeFilter::Decode(IInputStreamPtr src, types::stream_size length
     // Setup the decoder
     bool decoder_setup_result = opj_setup_decoder(codec, &parameters);
     if (!decoder_setup_result) {
-        throw ImageCodecErrorException("Failed to setup JPEG2000 decoder");
+        LOG_ERROR_AND_THROW(ImageCodecErrorException, "Failed to setup JPEG2000 decoder");
     }
 
     opj_image_t* image = nullptr;
@@ -116,16 +116,16 @@ BufferPtr JPXDecodeFilter::Decode(IInputStreamPtr src, types::stream_size length
     SCOPE_GUARD([image]() { opj_image_destroy(image); });
 
     if (!read_header_result) {
-        throw ImageCodecErrorException("Failed to read JPEG2000 header");
+        LOG_ERROR_AND_THROW(ImageCodecErrorException, "Failed to read JPEG2000 header");
     }
 
     if (!opj_set_decode_area(codec, image, parameters.DA_x0, parameters.DA_y0, parameters.DA_x1, parameters.DA_y1)) {
-        throw ImageCodecErrorException("Failed to decode JPEG2000 area");
+        LOG_ERROR_AND_THROW(ImageCodecErrorException, "Failed to decode JPEG2000 area");
     }
 
     // Decode the image
     if (!opj_decode(codec, stream, image)) {
-        throw ImageCodecErrorException("Failed to decode JPEG2000 image");
+        LOG_ERROR_AND_THROW(ImageCodecErrorException, "Failed to decode JPEG2000 image");
     }
 
     // TODO: This code hangs the application in the unit tests
@@ -135,7 +135,7 @@ BufferPtr JPXDecodeFilter::Decode(IInputStreamPtr src, types::stream_size length
 
     // JPEG decompression returned empty results
     if (image->comps == nullptr) {
-        throw ImageCodecErrorException("Received empty image components in JPEG2000 decompression");
+        LOG_ERROR_AND_THROW(ImageCodecErrorException, "Received empty image components in JPEG2000 decompression");
     }
 
     if (image->color_space == OPJ_CLRSPC_SRGB ||
@@ -231,7 +231,7 @@ BufferPtr JPXDecodeFilter::Decode(IInputStreamPtr src, types::stream_size length
         return make_deferred_container<Buffer>(result.begin(), result.end());
     }
 
-    throw ImageCodecErrorException("Unknown JPEG2000 color space: " + std::to_string(image->color_space));
+    LOG_ERROR_AND_THROW(ImageCodecErrorException, "Unknown JPEG2000 color space: {}", static_cast<int>(image->color_space));
 }
 
 BufferPtr JPXDecodeFilter::Encode(BufferPtr src, DictionaryObjectPtr parameters, AttributeListPtr object_attributes /* = AttributeListPtr() */) const {

--- a/src/vanillapdf/syntax/filters/lzw_decode_filter.cpp
+++ b/src/vanillapdf/syntax/filters/lzw_decode_filter.cpp
@@ -12,11 +12,11 @@ namespace syntax {
 using namespace std;
 
 BufferPtr LZWDecodeFilter::Encode(IInputStreamPtr src, types::stream_size, DictionaryObjectPtr /* = DictionaryObjectPtr() */, AttributeListPtr /* = AttributeListPtr() */) const {
-    throw NotSupportedException("LZWDecodeFilter encoding is not supported");
+    LOG_ERROR_AND_THROW(NotSupportedException, "LZWDecodeFilter encoding is not supported");
 }
 
 BufferPtr LZWDecodeFilter::Decode(IInputStreamPtr src, types::stream_size, DictionaryObjectPtr /* = DictionaryObjectPtr() */, AttributeListPtr /* = AttributeListPtr() */) const {
-    throw NotSupportedException("LZWDecodeFilter decoding is not supported");
+    LOG_ERROR_AND_THROW(NotSupportedException, "LZWDecodeFilter decoding is not supported");
 }
 
 BufferPtr LZWDecodeFilter::Encode(BufferPtr src, DictionaryObjectPtr parameters, AttributeListPtr object_attributes /* = AttributeListPtr() */) const {

--- a/src/vanillapdf/syntax/objects/dictionary_object.cpp
+++ b/src/vanillapdf/syntax/objects/dictionary_object.cpp
@@ -210,7 +210,7 @@ void DictionaryObject::InsertInternal(NameObjectPtr name, ContainableObjectPtr v
     auto found = _list.find(name);
     if (found != _list.end()) {
         if (!overwrite) {
-            throw DuplicateKeyException("The key " + name->ToString() + " was already present in the dictionary");
+            LOG_ERROR_AND_THROW(DuplicateKeyException, "The key {} was already present in the dictionary", name->ToString());
         }
 
         // Only a genuine, dirtying overwrite is worth flagging.

--- a/src/vanillapdf/syntax/objects/indirect_reference_object.cpp
+++ b/src/vanillapdf/syntax/objects/indirect_reference_object.cpp
@@ -135,7 +135,7 @@ void IndirectReferenceObject::SetReferencedObject(ObjectPtr obj) {
     assert(indirect_or_null && "Referenced object is neither indirect nor null");
 
     if (!indirect_or_null) {
-        throw InvalidParameterException("Indirect reference must point to indirect object");
+        LOG_ERROR_AND_THROW(InvalidParameterException, "Indirect reference must point to indirect object");
     }
 
     if (obj->IsIndirect()) {

--- a/src/vanillapdf/syntax/objects/mixed_array_object.cpp
+++ b/src/vanillapdf/syntax/objects/mixed_array_object.cpp
@@ -112,7 +112,7 @@ void MixedArrayObject::Insert(size_type at, ContainableObjectPtr value) {
     ACCESS_LOCK_GUARD(m_access_lock);
 
     if (at > _list.size()) {
-        LOG_ERROR_AND_THROW(InvalidParameterException, "Index was outside the bounds of the array");
+        LOG_ERROR_AND_THROW(InvalidParameterException, "Index {} was outside the bounds of the array of size {}", at, _list.size());
     }
 
     _list.insert(_list.begin() + at, value);
@@ -151,7 +151,7 @@ void MixedArrayObject::SetValue(size_type at, ContainableObjectPtr value) {
     ACCESS_LOCK_GUARD(m_access_lock);
 
     if (at >= _list.size()) {
-        LOG_ERROR_AND_THROW(InvalidParameterException, "Index was outside the bounds of the array");
+        LOG_ERROR_AND_THROW(InvalidParameterException, "Index {} was outside the bounds of the array of size {}", at, _list.size());
     }
 
     _list[at] = value;

--- a/src/vanillapdf/syntax/objects/mixed_array_object.cpp
+++ b/src/vanillapdf/syntax/objects/mixed_array_object.cpp
@@ -112,7 +112,7 @@ void MixedArrayObject::Insert(size_type at, ContainableObjectPtr value) {
     ACCESS_LOCK_GUARD(m_access_lock);
 
     if (at > _list.size()) {
-        throw InvalidParameterException("Index was outside the bounds of the array");
+        LOG_ERROR_AND_THROW(InvalidParameterException, "Index was outside the bounds of the array");
     }
 
     _list.insert(_list.begin() + at, value);
@@ -151,7 +151,7 @@ void MixedArrayObject::SetValue(size_type at, ContainableObjectPtr value) {
     ACCESS_LOCK_GUARD(m_access_lock);
 
     if (at >= _list.size()) {
-        throw InvalidParameterException("Index was outside the bounds of the array");
+        LOG_ERROR_AND_THROW(InvalidParameterException, "Index was outside the bounds of the array");
     }
 
     _list[at] = value;

--- a/src/vanillapdf/syntax/objects/numeric_object.cpp
+++ b/src/vanillapdf/syntax/objects/numeric_object.cpp
@@ -106,11 +106,11 @@ void NumericObjectBackend::ToggleBit(int pos, bool value) {
     }
 
     if (m_type == Type::Real) {
-        throw NotSupportedException("Cannot toggle bits on floating point numbers");
+        LOG_ERROR_AND_THROW(NotSupportedException, "Cannot toggle bits on floating point numbers");
     }
 
     assert(false && "Unknown numeric type");
-    throw InvalidParameterException("Unknown numeric type");
+    LOG_ERROR_AND_THROW(InvalidParameterException, "Unknown numeric type");
 }
 
 void NumericObjectBackend::SetBit(int pos) {
@@ -133,11 +133,11 @@ bool NumericObjectBackend::IsBitSet(int pos) const {
     }
 
     if (m_type == Type::Real) {
-        throw NotSupportedException("Cannot read bits on floating point numbers");
+        LOG_ERROR_AND_THROW(NotSupportedException, "Cannot read bits on floating point numbers");
     }
 
     assert(false && "Unknown numeric type");
-    throw InvalidParameterException("Unknown numeric type");
+    LOG_ERROR_AND_THROW(InvalidParameterException, "Unknown numeric type");
 }
 
 types::big_int NumericObjectBackend::GetIntegerValue(void) const {
@@ -154,7 +154,7 @@ types::big_int NumericObjectBackend::GetIntegerValue(void) const {
     }
 
     assert(false && "Unknown numeric type");
-    throw InvalidParameterException("Unknown numeric type");
+    LOG_ERROR_AND_THROW(InvalidParameterException, "Unknown numeric type");
 }
 
 types::big_uint NumericObjectBackend::GetUnsignedIntegerValue(void) const {
@@ -172,7 +172,7 @@ types::big_uint NumericObjectBackend::GetUnsignedIntegerValue(void) const {
     }
 
     assert(false && "Unknown numeric type");
-    throw InvalidParameterException("Unknown numeric type");
+    LOG_ERROR_AND_THROW(InvalidParameterException, "Unknown numeric type");
 }
 
 types::real NumericObjectBackend::GetRealValue(void) const {
@@ -190,7 +190,7 @@ types::real NumericObjectBackend::GetRealValue(void) const {
     }
 
     assert(false && "Unknown numeric type");
-    throw InvalidParameterException("Unknown numeric type");
+    LOG_ERROR_AND_THROW(InvalidParameterException, "Unknown numeric type");
 }
 
 std::string NumericObjectBackend::IntegerString(void) const {
@@ -241,7 +241,7 @@ std::string NumericObjectBackend::ToString(void) const {
     }
 
     assert(false && "Unknown numeric type");
-    throw InvalidParameterException("Unknown numeric type");
+    LOG_ERROR_AND_THROW(InvalidParameterException, "Unknown numeric type");
 }
 
 size_t NumericObjectBackend::Hash() const {
@@ -261,7 +261,7 @@ size_t NumericObjectBackend::Hash() const {
     }
 
     assert(false && "Unknown numeric type");
-    throw InvalidParameterException("Unknown numeric type");
+    LOG_ERROR_AND_THROW(InvalidParameterException, "Unknown numeric type");
 }
 
 size_t NumericObject::Hash() const {

--- a/src/vanillapdf/syntax/objects/numeric_object.cpp
+++ b/src/vanillapdf/syntax/objects/numeric_object.cpp
@@ -110,7 +110,7 @@ void NumericObjectBackend::ToggleBit(int pos, bool value) {
     }
 
     assert(false && "Unknown numeric type");
-    LOG_ERROR_AND_THROW(InvalidParameterException, "Unknown numeric type");
+    LOG_ERROR_AND_THROW(InvalidParameterException, "Unknown numeric type: {}", static_cast<int>(m_type));
 }
 
 void NumericObjectBackend::SetBit(int pos) {
@@ -137,7 +137,7 @@ bool NumericObjectBackend::IsBitSet(int pos) const {
     }
 
     assert(false && "Unknown numeric type");
-    LOG_ERROR_AND_THROW(InvalidParameterException, "Unknown numeric type");
+    LOG_ERROR_AND_THROW(InvalidParameterException, "Unknown numeric type: {}", static_cast<int>(m_type));
 }
 
 types::big_int NumericObjectBackend::GetIntegerValue(void) const {
@@ -154,7 +154,7 @@ types::big_int NumericObjectBackend::GetIntegerValue(void) const {
     }
 
     assert(false && "Unknown numeric type");
-    LOG_ERROR_AND_THROW(InvalidParameterException, "Unknown numeric type");
+    LOG_ERROR_AND_THROW(InvalidParameterException, "Unknown numeric type: {}", static_cast<int>(m_type));
 }
 
 types::big_uint NumericObjectBackend::GetUnsignedIntegerValue(void) const {
@@ -172,7 +172,7 @@ types::big_uint NumericObjectBackend::GetUnsignedIntegerValue(void) const {
     }
 
     assert(false && "Unknown numeric type");
-    LOG_ERROR_AND_THROW(InvalidParameterException, "Unknown numeric type");
+    LOG_ERROR_AND_THROW(InvalidParameterException, "Unknown numeric type: {}", static_cast<int>(m_type));
 }
 
 types::real NumericObjectBackend::GetRealValue(void) const {
@@ -190,7 +190,7 @@ types::real NumericObjectBackend::GetRealValue(void) const {
     }
 
     assert(false && "Unknown numeric type");
-    LOG_ERROR_AND_THROW(InvalidParameterException, "Unknown numeric type");
+    LOG_ERROR_AND_THROW(InvalidParameterException, "Unknown numeric type: {}", static_cast<int>(m_type));
 }
 
 std::string NumericObjectBackend::IntegerString(void) const {
@@ -241,7 +241,7 @@ std::string NumericObjectBackend::ToString(void) const {
     }
 
     assert(false && "Unknown numeric type");
-    LOG_ERROR_AND_THROW(InvalidParameterException, "Unknown numeric type");
+    LOG_ERROR_AND_THROW(InvalidParameterException, "Unknown numeric type: {}", static_cast<int>(m_type));
 }
 
 size_t NumericObjectBackend::Hash() const {
@@ -261,7 +261,7 @@ size_t NumericObjectBackend::Hash() const {
     }
 
     assert(false && "Unknown numeric type");
-    LOG_ERROR_AND_THROW(InvalidParameterException, "Unknown numeric type");
+    LOG_ERROR_AND_THROW(InvalidParameterException, "Unknown numeric type: {}", static_cast<int>(m_type));
 }
 
 size_t NumericObject::Hash() const {

--- a/src/vanillapdf/syntax/objects/object.cpp
+++ b/src/vanillapdf/syntax/objects/object.cpp
@@ -172,10 +172,10 @@ types::big_uint Object::GetObjectNumber() const {
     }
 
     if (has_owner) {
-        throw InvalidParameterException("Object does not an indirect object, but is a composite of another object");
+        LOG_ERROR_AND_THROW(InvalidParameterException, "Object does not an indirect object, but is a composite of another object");
     }
 
-    throw InvalidParameterException("Object does not have assigned object number");
+    LOG_ERROR_AND_THROW(InvalidParameterException, "Object does not have assigned object number");
 }
 
 types::ushort Object::GetGenerationNumber() const {
@@ -192,10 +192,10 @@ types::ushort Object::GetGenerationNumber() const {
     }
 
     if (has_owner) {
-        throw InvalidParameterException("Object does not an indirect object, but a composite of another object");
+        LOG_ERROR_AND_THROW(InvalidParameterException, "Object does not an indirect object, but a composite of another object");
     }
 
-    throw InvalidParameterException("Object does not have assigned generation number");
+    LOG_ERROR_AND_THROW(InvalidParameterException, "Object does not have assigned generation number");
 }
 
 types::big_uint Object::GetRootObjectNumber() const {
@@ -216,7 +216,7 @@ types::big_uint Object::GetRootObjectNumber() const {
         return owner->GetRootObjectNumber();
     }
 
-    throw InvalidParameterException("Object does not have assigned object number");
+    LOG_ERROR_AND_THROW(InvalidParameterException, "Object does not have assigned object number");
 }
 
 types::ushort Object::GetRootGenerationNumber() const {
@@ -237,7 +237,7 @@ types::ushort Object::GetRootGenerationNumber() const {
         return owner->GetRootGenerationNumber();
     }
 
-    throw InvalidParameterException("Object does not have assigned generation number");
+    LOG_ERROR_AND_THROW(InvalidParameterException, "Object does not have assigned generation number");
 }
 
 bool Object::IsEncryptionExempted() const {
@@ -285,7 +285,7 @@ const char* Object::TypeName(Type type) {
 void Object::CloneBaseProperties(Object* other) const {
     assert(other != nullptr && "Invalid clone object parameter");
     if (other == nullptr) {
-        throw InvalidParameterException("Invalid clone object parameter");
+        LOG_ERROR_AND_THROW(InvalidParameterException, "Invalid clone object parameter");
     }
 
     other->SetFile(m_file);

--- a/src/vanillapdf/syntax/objects/object.cpp
+++ b/src/vanillapdf/syntax/objects/object.cpp
@@ -172,7 +172,7 @@ types::big_uint Object::GetObjectNumber() const {
     }
 
     if (has_owner) {
-        LOG_ERROR_AND_THROW(InvalidParameterException, "Object does not an indirect object, but is a composite of another object");
+        LOG_ERROR_AND_THROW(InvalidParameterException, "Object is not an indirect object, but is a composite of another object");
     }
 
     LOG_ERROR_AND_THROW(InvalidParameterException, "Object does not have assigned object number");
@@ -192,7 +192,7 @@ types::ushort Object::GetGenerationNumber() const {
     }
 
     if (has_owner) {
-        LOG_ERROR_AND_THROW(InvalidParameterException, "Object does not an indirect object, but a composite of another object");
+        LOG_ERROR_AND_THROW(InvalidParameterException, "Object is not an indirect object, but is a composite of another object");
     }
 
     LOG_ERROR_AND_THROW(InvalidParameterException, "Object does not have assigned generation number");
@@ -278,7 +278,11 @@ const char* Object::TypeName(Type type) {
         case Type::IndirectReference:
             return "IndirectReference";
         default:
-            return nullptr;
+
+            // The name is used in log and exception messages, so it has to stay
+            // a printable string even for values outside of the enumeration.
+
+            return "Undefined";
     }
 }
 

--- a/src/vanillapdf/syntax/objects/stream_object.cpp
+++ b/src/vanillapdf/syntax/objects/stream_object.cpp
@@ -170,7 +170,7 @@ BufferPtr StreamObject::GetBodyRaw() const {
     }
 
     if (_raw_data_offset == constant::BAD_OFFSET) {
-        throw ParseException("Stream object data offset is not initialized");
+        LOG_ERROR_AND_THROW(ParseException, "Stream object data offset is not initialized");
     }
 
     auto offset = _raw_data_offset;
@@ -288,7 +288,7 @@ BufferPtr StreamObject::GetBody() const {
     }
 
     assert(is_filter_name ^ is_filter_array);
-    throw ParseException("Filter is neither name nor array of names");
+    LOG_ERROR_AND_THROW(ParseException, "Filter is neither name nor array of names");
 }
 
 BufferPtr StreamObject::GetBodyEncoded() const {
@@ -418,7 +418,7 @@ BufferPtr StreamObject::GetBodyEncoded() const {
     }
 
     assert(is_filter_name ^ is_filter_array);
-    throw ParseException("Filter is neither name nor array of names");
+    LOG_ERROR_AND_THROW(ParseException, "Filter is neither name nor array of names");
 }
 
 BufferPtr StreamObject::GetBodyDecrypted() const {

--- a/src/vanillapdf/syntax/objects/string_object.cpp
+++ b/src/vanillapdf/syntax/objects/string_object.cpp
@@ -368,7 +368,7 @@ BufferPtr LiteralStringObject::GetRawValueDecoded() const {
     }
 
     if (nested_count != 0) {
-        throw ParseException("Improperly terminated literal string sequence: " + result->ToString());
+        LOG_ERROR_AND_THROW(ParseException, "Improperly terminated literal string sequence: {}", result->ToString());
     }
 
     return result;

--- a/src/vanillapdf/syntax/parsers/parser.cpp
+++ b/src/vanillapdf/syntax/parsers/parser.cpp
@@ -561,7 +561,7 @@ XrefStreamPtr Parser::ParseXrefStream(
 
     assert(fields->GetSize() == 3);
     if (fields->GetSize() != 3) {
-        LOG_ERROR_AND_THROW(ParseException, "Xref stream width does not contain three integers");
+        LOG_ERROR_AND_THROW(ParseException, "Xref stream /W shall contain three integers, but contains {}", fields->GetSize());
     }
 
     auto size = header->FindAs<IntegerObjectPtr>(constant::Name::Size);

--- a/src/vanillapdf/syntax/parsers/parser.cpp
+++ b/src/vanillapdf/syntax/parsers/parser.cpp
@@ -561,7 +561,7 @@ XrefStreamPtr Parser::ParseXrefStream(
 
     assert(fields->GetSize() == 3);
     if (fields->GetSize() != 3) {
-        throw ParseException("Xref stream width does not contain three integers");
+        LOG_ERROR_AND_THROW(ParseException, "Xref stream width does not contain three integers");
     }
 
     auto size = header->FindAs<IntegerObjectPtr>(constant::Name::Size);
@@ -779,7 +779,7 @@ XrefStreamPtr Parser::ParseXrefStream(
 
         if (!ConvertUtils<XrefEntryBasePtr>::IsType<XrefUsedEntryPtr>(entry)) {
             assert(false && "How could this be entry of different type");
-            throw ParseException("Xref entry has incorrect type");
+            LOG_ERROR_AND_THROW(ParseException, "Xref entry has incorrect type");
         }
 
         auto used_entry = ConvertUtils<XrefEntryBasePtr>::ConvertTo<XrefUsedEntryPtr>(entry);
@@ -857,7 +857,7 @@ HeaderPtr Parser::ReadHeader(void) {
                 case 7:
                     result->SetVersion(Version::PDF17); break;
                 default:
-                    throw NotSupportedException("Invalid PDF version: " + line);
+                    LOG_ERROR_AND_THROW(NotSupportedException, "Invalid PDF version: {}", line);
             }
 
             return result;
@@ -868,7 +868,7 @@ HeaderPtr Parser::ReadHeader(void) {
                 case 0:
                     result->SetVersion(Version::PDF20); break;
                 default:
-                    throw NotSupportedException("Invalid PDF version: " + line);
+                    LOG_ERROR_AND_THROW(NotSupportedException, "Invalid PDF version: {}", line);
             }
 
             return result;

--- a/src/vanillapdf/syntax/parsers/parser.cpp
+++ b/src/vanillapdf/syntax/parsers/parser.cpp
@@ -779,7 +779,8 @@ XrefStreamPtr Parser::ParseXrefStream(
 
         if (!ConvertUtils<XrefEntryBasePtr>::IsType<XrefUsedEntryPtr>(entry)) {
             assert(false && "How could this be entry of different type");
-            LOG_ERROR_AND_THROW(ParseException, "Xref entry has incorrect type");
+            LOG_ERROR_AND_THROW(ParseException, "Xref entry {} {} shall be a used entry, but has usage {}",
+            stream_obj_number, stream_gen_number, static_cast<int>(entry->GetUsage()));
         }
 
         auto used_entry = ConvertUtils<XrefEntryBasePtr>::ConvertTo<XrefUsedEntryPtr>(entry);

--- a/src/vanillapdf/syntax/parsers/parser_utils.cpp
+++ b/src/vanillapdf/syntax/parsers/parser_utils.cpp
@@ -19,7 +19,7 @@ BooleanObjectPtr ParserUtils::CreateBoolean(TokenPtr token) {
     }
 
     assert(!"Expected boolean token type");
-    throw ParseException("Expected boolean token type");
+    LOG_ERROR_AND_THROW(ParseException, "Expected boolean token type");
 }
 
 types::big_int ParserUtils::GetIntegerValue(TokenPtr token) {

--- a/src/vanillapdf/syntax/utils/encryption.cpp
+++ b/src/vanillapdf/syntax/utils/encryption.cpp
@@ -124,7 +124,7 @@ BufferPtr EncryptionUtils::ComputeObjectKey(
 
 #else
     (void) key; (void) objNumber; (void) genNumber; (void) alg;
-    throw NotSupportedException("This library was compiled without OpenSSL support");
+    LOG_ERROR_AND_THROW(NotSupportedException, "This library was compiled without OpenSSL support");
 #endif
 
 }
@@ -222,7 +222,7 @@ BufferPtr EncryptionUtils::ComputeRC4(const Buffer& key, types::size_type key_le
 
 #else
     (void) key; (void) key_length; (void) data;
-    throw NotSupportedException("This library was compiled without OpenSSL support");
+    LOG_ERROR_AND_THROW(NotSupportedException, "This library was compiled without OpenSSL support");
 #endif
 
 }
@@ -273,7 +273,7 @@ BufferPtr EncryptionUtils::ComputeMD5(const Buffer& data, types::size_type lengt
     return key_digest;
 
 #else
-    throw NotSupportedException("This library was compiled without OpenSSL support");
+    LOG_ERROR_AND_THROW(NotSupportedException, "This library was compiled without OpenSSL support");
 #endif
 
 }
@@ -316,7 +316,7 @@ BufferPtr EncryptionUtils::ComputeSHA256(const Buffer& data) {
     return digest;
 
 #else
-    throw NotSupportedException("This library was compiled without OpenSSL support");
+    LOG_ERROR_AND_THROW(NotSupportedException, "This library was compiled without OpenSSL support");
 #endif
 
 }
@@ -361,7 +361,7 @@ BufferPtr EncryptionUtils::ComputeSHA384(const Buffer& data) {
     return digest;
 
 #else
-    throw NotSupportedException("This library was compiled without OpenSSL support");
+    LOG_ERROR_AND_THROW(NotSupportedException, "This library was compiled without OpenSSL support");
 #endif
 
 }
@@ -404,7 +404,7 @@ BufferPtr EncryptionUtils::ComputeSHA512(const Buffer& data) {
     return digest;
 
 #else
-    throw NotSupportedException("This library was compiled without OpenSSL support");
+    LOG_ERROR_AND_THROW(NotSupportedException, "This library was compiled without OpenSSL support");
 #endif
 
 }
@@ -506,7 +506,7 @@ BufferPtr EncryptionUtils::AESDecrypt(const Buffer& key, types::size_type key_le
 
 #else
     (void) key; (void) key_length; (void) data;
-    throw NotSupportedException("This library was compiled without OpenSSL support");
+    LOG_ERROR_AND_THROW(NotSupportedException, "This library was compiled without OpenSSL support");
 #endif
 
 }
@@ -610,7 +610,7 @@ BufferPtr EncryptionUtils::AESEncrypt(const Buffer& key, types::size_type key_le
 
 #else
     (void) key; (void) key_length; (void) data;
-    throw NotSupportedException("This library was compiled without OpenSSL support");
+    LOG_ERROR_AND_THROW(NotSupportedException, "This library was compiled without OpenSSL support");
 #endif
 
 }
@@ -664,7 +664,7 @@ BufferPtr EncryptionUtils::AESEncryptCBC_ZeroIV(const Buffer& key, const Buffer&
 
 #else
     (void) key; (void) data;
-    throw NotSupportedException("This library was compiled without OpenSSL support");
+    LOG_ERROR_AND_THROW(NotSupportedException, "This library was compiled without OpenSSL support");
 #endif
 
 }
@@ -718,7 +718,7 @@ BufferPtr EncryptionUtils::AESDecryptCBC_ZeroIV(const Buffer& key, const Buffer&
 
 #else
     (void) key; (void) data;
-    throw NotSupportedException("This library was compiled without OpenSSL support");
+    LOG_ERROR_AND_THROW(NotSupportedException, "This library was compiled without OpenSSL support");
 #endif
 
 }
@@ -770,7 +770,7 @@ BufferPtr EncryptionUtils::AESEncryptECB(const Buffer& key, const Buffer& data) 
 
 #else
     (void) key; (void) data;
-    throw NotSupportedException("This library was compiled without OpenSSL support");
+    LOG_ERROR_AND_THROW(NotSupportedException, "This library was compiled without OpenSSL support");
 #endif
 
 }
@@ -822,7 +822,7 @@ BufferPtr EncryptionUtils::AESDecryptECB(const Buffer& key, const Buffer& data) 
 
 #else
     (void) key; (void) data;
-    throw NotSupportedException("This library was compiled without OpenSSL support");
+    LOG_ERROR_AND_THROW(NotSupportedException, "This library was compiled without OpenSSL support");
 #endif
 
 }
@@ -1001,11 +1001,11 @@ BufferPtr EncryptionUtils::GenerateOwnerEncryptionKey(
     CryptoUtils::InitializeOpenSSL();
 
     if (algorithm == EncryptionAlgorithm::Undefined) {
-        throw CryptoErrorException("Could not generate encryption key for Undefined encryption algorithm");
+        LOG_ERROR_AND_THROW(CryptoErrorException, "Could not generate encryption key for Undefined encryption algorithm");
     }
 
     if (algorithm == EncryptionAlgorithm::None) {
-        throw CryptoErrorException("Could not generate encryption key for None encryption algorithm");
+        LOG_ERROR_AND_THROW(CryptoErrorException, "Could not generate encryption key for None encryption algorithm");
     }
 
     if (algorithm == EncryptionAlgorithm::RC4 ||
@@ -1072,10 +1072,10 @@ BufferPtr EncryptionUtils::GenerateOwnerEncryptionKey(
         return stepg;
     }
 
-    throw NotSupportedException("Unknown encryption algorithm: " + std::to_string(static_cast<int>(algorithm)));
+    LOG_ERROR_AND_THROW(NotSupportedException, "Unknown encryption algorithm: {}", static_cast<int>(algorithm));
 
 #else
-    throw NotSupportedException("This library was compiled without OpenSSL support");
+    LOG_ERROR_AND_THROW(NotSupportedException, "This library was compiled without OpenSSL support");
 #endif
 }
 
@@ -1094,11 +1094,11 @@ BufferPtr EncryptionUtils::GenerateUserEncryptionKey(
     CryptoUtils::InitializeOpenSSL();
 
     if (algorithm == EncryptionAlgorithm::Undefined) {
-        throw CryptoErrorException("Could not generate encryption key for Undefined encryption algorithm");
+        LOG_ERROR_AND_THROW(CryptoErrorException, "Could not generate encryption key for Undefined encryption algorithm");
     }
 
     if (algorithm == EncryptionAlgorithm::None) {
-        throw CryptoErrorException("Could not generate encryption key for None encryption algorithm");
+        LOG_ERROR_AND_THROW(CryptoErrorException, "Could not generate encryption key for None encryption algorithm");
     }
 
     if (algorithm == EncryptionAlgorithm::RC4 ||
@@ -1114,10 +1114,10 @@ BufferPtr EncryptionUtils::GenerateUserEncryptionKey(
         return EncryptionUtils::ComputeRC4(decryption_key_digest, 5, hardcoded_pad);
     }
 
-    throw NotSupportedException("Unknown encryption algorithm: " + std::to_string(static_cast<int>(algorithm)));
+    LOG_ERROR_AND_THROW(NotSupportedException, "Unknown encryption algorithm: {}", static_cast<int>(algorithm));
 
 #else
-    throw NotSupportedException("This library was compiled without OpenSSL support");
+    LOG_ERROR_AND_THROW(NotSupportedException, "This library was compiled without OpenSSL support");
 #endif
 }
 
@@ -1158,7 +1158,7 @@ bool EncryptionUtils::CheckKey(
     (void) input; (void) document_id; (void) owner_data;
     (void) user_data; (void) permissions; (void) revision;
     (void) key_length; (void) decryption_key;
-    throw NotSupportedException("This library was compiled without OpenSSL support");
+    LOG_ERROR_AND_THROW(NotSupportedException, "This library was compiled without OpenSSL support");
 #endif
 
 }
@@ -1271,7 +1271,7 @@ BufferPtr EncryptionUtils::CalculateDecryptionCompareDataV3(
     return compare_data;
 
 #else
-    throw NotSupportedException("This library was compiled without OpenSSL support");
+    LOG_ERROR_AND_THROW(NotSupportedException, "This library was compiled without OpenSSL support");
 #endif
 }
 
@@ -1339,7 +1339,7 @@ BufferPtr EncryptionUtils::CalculateDecryptionKeyDigest(
     return decryption_key_digest;
 
 #else
-    throw NotSupportedException("This library was compiled without OpenSSL support");
+    LOG_ERROR_AND_THROW(NotSupportedException, "This library was compiled without OpenSSL support");
 #endif
 
 }
@@ -1419,7 +1419,7 @@ BufferPtr EncryptionUtils::GetRecipientKey
 
 #else
     (void) enveloped_data; (void) length_bits; (void) algorithm; (void) key;
-    throw NotSupportedException("This library was compiled without OpenSSL support");
+    LOG_ERROR_AND_THROW(NotSupportedException, "This library was compiled without OpenSSL support");
 #endif
 
 }
@@ -1550,11 +1550,11 @@ BufferPtr EncryptionUtils::DecryptEnvelopedData(const syntax::ArrayObject<syntax
         }
     }
 
-    throw CryptoErrorException("Could not find matching certificate");
+    LOG_ERROR_AND_THROW(CryptoErrorException, "Could not find matching certificate");
 
 #else
     (void) enveloped_data; (void) key;
-    throw NotSupportedException("This library was compiled without OpenSSL support");
+    LOG_ERROR_AND_THROW(NotSupportedException, "This library was compiled without OpenSSL support");
 #endif
 
 }
@@ -1672,7 +1672,7 @@ BufferPtr EncryptionUtils::ComputeAuthenticationOwnerData(const Buffer& pad_pass
 
 #else
     (void) pad_password; (void) encryption_dictionary;
-    throw NotSupportedException("This library was compiled without OpenSSL support");
+    LOG_ERROR_AND_THROW(NotSupportedException, "This library was compiled without OpenSSL support");
 #endif
 
 }
@@ -1696,7 +1696,7 @@ BufferPtr EncryptionUtils::GenerateRandomData(int length) {
 
 #else
     (void)length;
-    throw NotSupportedException("This library was compiled without OpenSSL support");
+    LOG_ERROR_AND_THROW(NotSupportedException, "This library was compiled without OpenSSL support");
 #endif
 
 }
@@ -1810,7 +1810,7 @@ BufferPtr EncryptionUtils::ComputeHashR6(
 
 #else
     (void) password; (void) salt; (void) u_value;
-    throw NotSupportedException("This library was compiled without OpenSSL support");
+    LOG_ERROR_AND_THROW(NotSupportedException, "This library was compiled without OpenSSL support");
 #endif
 
 }
@@ -1893,7 +1893,7 @@ EncryptionUtils::EncryptionDataR6 EncryptionUtils::GenerateEncryptionDataR6(
 
 #else
     (void) user_password; (void) owner_password; (void) permissions;
-    throw NotSupportedException("This library was compiled without OpenSSL support");
+    LOG_ERROR_AND_THROW(NotSupportedException, "This library was compiled without OpenSSL support");
 #endif
 
 }
@@ -1973,7 +1973,7 @@ bool EncryptionUtils::CheckKeyR6(
     (void) password; (void) u_value; (void) ue_value;
     (void) o_value; (void) oe_value; (void) perms_value;
     (void) decryption_key;
-    throw NotSupportedException("This library was compiled without OpenSSL support");
+    LOG_ERROR_AND_THROW(NotSupportedException, "This library was compiled without OpenSSL support");
 #endif
 
 }

--- a/src/vanillapdf/syntax/utils/encryption.cpp
+++ b/src/vanillapdf/syntax/utils/encryption.cpp
@@ -444,7 +444,7 @@ BufferPtr EncryptionUtils::AESDecrypt(const Buffer& key, types::size_type key_le
     }
 
     if (evp_cipher == nullptr) {
-        LOG_ERROR_AND_THROW(CryptoErrorException, "Unknown AES key length: " + std::to_string(key_length));
+        LOG_ERROR_AND_THROW(CryptoErrorException, "Unknown AES key length: {}", key_length);
     }
 
     auto evp_cipher_ctx = EVP_CIPHER_CTX_new();
@@ -545,7 +545,7 @@ BufferPtr EncryptionUtils::AESEncrypt(const Buffer& key, types::size_type key_le
     }
 
     if (evp_cipher == nullptr) {
-        LOG_ERROR_AND_THROW(CryptoErrorException, "Unknown AES key length: " + std::to_string(key_length));
+        LOG_ERROR_AND_THROW(CryptoErrorException, "Unknown AES key length: {}", key_length);
     }
 
     auto evp_cipher_ctx = EVP_CIPHER_CTX_new();

--- a/src/vanillapdf/syntax/utils/object_attribute_list.cpp
+++ b/src/vanillapdf/syntax/utils/object_attribute_list.cpp
@@ -29,7 +29,7 @@ void AttributeList::Add(BaseAttributePtr attribute, bool overwrite /*= false*/) 
 
     auto attribute_type = attribute->GetType();
     if (!overwrite && Contains(attribute_type)) {
-        throw DuplicateKeyException("The key " + std::to_string(static_cast<int>(attribute_type)) + " was already present in the dictionary");
+        LOG_ERROR_AND_THROW(DuplicateKeyException, "An attribute of type {} was already present in the attribute list", static_cast<int>(attribute_type));
     }
 
     GetAttributes()->insert({ attribute_type , attribute });

--- a/src/vanillapdf/syntax/utils/object_attribute_list.cpp
+++ b/src/vanillapdf/syntax/utils/object_attribute_list.cpp
@@ -51,7 +51,7 @@ bool AttributeList::Remove(BaseAttribute::Type type) {
 BaseAttributePtr AttributeList::Get(BaseAttribute::Type type) const {
     auto found = GetAttributes()->find(type);
     if (found == GetAttributes()->end()) {
-        throw ObjectMissingException("Attribute with key " + std::to_string(static_cast<int>(type)) + " was not found in the list");
+        LOG_ERROR_AND_THROW(ObjectMissingException, "Attribute with key {} was not found in the list", static_cast<int>(type));
     }
 
     return found->second;

--- a/src/vanillapdf/syntax/utils/object_utils.h
+++ b/src/vanillapdf/syntax/utils/object_utils.h
@@ -3,6 +3,7 @@
 
 #include "utils/deferred.h"
 #include "utils/exceptions.h"
+#include "utils/log.h"
 #include "utils/conversion_utils.h"
 
 #include "syntax/objects/object.h"
@@ -151,8 +152,7 @@ public:
 
         auto found = visited.find(id);
         if (found != visited.end() && found->second) {
-            throw ConversionException(
-                fmt::format("Cyclic reference was found for {} {} R", obj_number, gen_number));
+            LOG_ERROR_AND_THROW(ConversionException, "Cyclic reference was found for {} {} R", obj_number, gen_number);
         }
 
         visited[id] = true;

--- a/src/vanillapdf/syntax/utils/output_pointer.h
+++ b/src/vanillapdf/syntax/utils/output_pointer.h
@@ -3,6 +3,7 @@
 
 #include "utils/deferred.h"
 #include "utils/unknown_interface.h"
+#include "utils/log.h"
 
 #include "syntax/objects/object.h"
 #include "syntax/objects/array_object.h"
@@ -40,7 +41,7 @@ public:
 
     T* GetValue() const {
         if (m_value == nullptr) {
-            throw InvalidParameterException("Uninitialized pointer");
+            LOG_ERROR_AND_THROW(InvalidParameterException, "Uninitialized pointer");
         }
 
         return m_value.get();

--- a/src/vanillapdf/utils/buffer.h
+++ b/src/vanillapdf/utils/buffer.h
@@ -5,6 +5,7 @@
 #include "utils/character.h"
 #include "utils/conversion_utils.h"
 #include "utils/versionable.h"
+#include "utils/log.h"
 
 #include "utils/streams/input_stream_interface.h"
 
@@ -95,7 +96,7 @@ public:
                 result |= static_cast<T>(static_cast<uint8_t>(m_data[i])) << (i * 8);
             }
         } else {
-            throw GeneralException("Unsupported byte order");
+            LOG_ERROR_AND_THROW_GENERAL("Unsupported byte order");
         }
 
         return result;
@@ -117,7 +118,7 @@ public:
                 buf->push_back(static_cast<char>((value >> (i * 8)) & 0xFF));
             }
         } else {
-            throw GeneralException("Unsupported byte order");
+            LOG_ERROR_AND_THROW_GENERAL("Unsupported byte order");
         }
 
         return buf;

--- a/src/vanillapdf/utils/buffer.h
+++ b/src/vanillapdf/utils/buffer.h
@@ -96,7 +96,7 @@ public:
                 result |= static_cast<T>(static_cast<uint8_t>(m_data[i])) << (i * 8);
             }
         } else {
-            LOG_ERROR_AND_THROW_GENERAL("Unsupported byte order");
+            LOG_ERROR_AND_THROW_GENERAL("Unsupported byte order: {}", static_cast<int>(order));
         }
 
         return result;
@@ -118,7 +118,7 @@ public:
                 buf->push_back(static_cast<char>((value >> (i * 8)) & 0xFF));
             }
         } else {
-            LOG_ERROR_AND_THROW_GENERAL("Unsupported byte order");
+            LOG_ERROR_AND_THROW_GENERAL("Unsupported byte order: {}", static_cast<int>(order));
         }
 
         return buf;

--- a/src/vanillapdf/utils/crypto_utils.cpp
+++ b/src/vanillapdf/utils/crypto_utils.cpp
@@ -35,7 +35,7 @@ static OSSL_PROVIDER* g_default_provider = nullptr;
 const EVP_MD* CryptoUtils::GetAlgorithm(MessageDigestAlgorithm algorithm) {
 
     if (algorithm == MessageDigestAlgorithm::Undefined) {
-        throw CryptoErrorException("No message digest algorithm was selected");
+        LOG_ERROR_AND_THROW(CryptoErrorException, "No message digest algorithm was selected");
     }
 
     if (algorithm == MessageDigestAlgorithm::MDNULL) {
@@ -46,7 +46,7 @@ const EVP_MD* CryptoUtils::GetAlgorithm(MessageDigestAlgorithm algorithm) {
     #ifndef OPENSSL_NO_MD2
         return EVP_md2();
     #else
-        throw NotSupportedException("OpenSSL was compiled without MD2 message digest support");
+        LOG_ERROR_AND_THROW(NotSupportedException, "OpenSSL was compiled without MD2 message digest support");
     #endif
     }
 
@@ -82,7 +82,7 @@ const EVP_MD* CryptoUtils::GetAlgorithm(MessageDigestAlgorithm algorithm) {
     #ifndef OPENSSL_NO_MDC2
         return EVP_mdc2();
     #else
-        throw NotSupportedException("OpenSSL was compiled without MDC2 message digest support");
+        LOG_ERROR_AND_THROW(NotSupportedException, "OpenSSL was compiled without MDC2 message digest support");
     #endif
     }
 
@@ -94,7 +94,7 @@ const EVP_MD* CryptoUtils::GetAlgorithm(MessageDigestAlgorithm algorithm) {
         return EVP_whirlpool();
     }
 
-    throw CryptoErrorException("Unknown message digest algorithm");
+    LOG_ERROR_AND_THROW(CryptoErrorException, "Unknown message digest algorithm");
 }
 
 std::string CryptoUtils::GetLastOpensslError() {
@@ -139,12 +139,12 @@ void CryptoUtils::InitializeOpenSSL() {
 
     g_legacy_provider = OSSL_PROVIDER_load(nullptr, "legacy");
     if (g_legacy_provider == nullptr) {
-        throw CryptoErrorException("Failed to initialize legacy OSSL provider, " + GetLastOpensslError());
+        LOG_ERROR_AND_THROW(CryptoErrorException, "Failed to initialize legacy OSSL provider, {}", GetLastOpensslError());
     }
 
     g_default_provider = OSSL_PROVIDER_load(nullptr, "default");
     if (g_default_provider == nullptr) {
-        throw CryptoErrorException("Failed to initialize default OSSL provider, " + GetLastOpensslError());
+        LOG_ERROR_AND_THROW(CryptoErrorException, "Failed to initialize default OSSL provider, {}", GetLastOpensslError());
     }
 
     OpenSSL_add_all_algorithms();
@@ -190,16 +190,16 @@ void CryptoUtils::CleanupOpenSSL() {
 // Stub implementations when OpenSSL is not available
 
 const EVP_MD* CryptoUtils::GetAlgorithm(MessageDigestAlgorithm) {
-    throw NotSupportedException("This library was compiled without OpenSSL support");
+    LOG_ERROR_AND_THROW(NotSupportedException, "This library was compiled without OpenSSL support");
 }
 
 std::string CryptoUtils::GetLastOpensslError() {
-    throw NotSupportedException("This library was compiled without OpenSSL support");
+    LOG_ERROR_AND_THROW(NotSupportedException, "This library was compiled without OpenSSL support");
 }
 
 
 void CryptoUtils::InitializeOpenSSL() {
-    throw NotSupportedException("This library was compiled without OpenSSL support");
+    LOG_ERROR_AND_THROW(NotSupportedException, "This library was compiled without OpenSSL support");
 }
 
 void CryptoUtils::CleanupOpenSSL() {

--- a/src/vanillapdf/utils/crypto_utils.cpp
+++ b/src/vanillapdf/utils/crypto_utils.cpp
@@ -94,7 +94,7 @@ const EVP_MD* CryptoUtils::GetAlgorithm(MessageDigestAlgorithm algorithm) {
         return EVP_whirlpool();
     }
 
-    LOG_ERROR_AND_THROW(CryptoErrorException, "Unknown message digest algorithm");
+    LOG_ERROR_AND_THROW(CryptoErrorException, "Unknown message digest algorithm: {}", static_cast<int>(algorithm));
 }
 
 std::string CryptoUtils::GetLastOpensslError() {

--- a/src/vanillapdf/utils/license_info.cpp
+++ b/src/vanillapdf/utils/license_info.cpp
@@ -35,7 +35,7 @@ static const char CERTIFICATES_NODE[] =			"certificates";
 static X509* LoadCertificate(const std::string& certificate) {
     auto signing_certificate_bio = BIO_new(BIO_s_mem());
     if (signing_certificate_bio == nullptr) {
-        throw IOErrorException("Could not create memory buffer");
+        LOG_ERROR_AND_THROW(IOErrorException, "Could not create memory buffer");
     }
 
     SCOPE_GUARD([signing_certificate_bio]() { BIO_free(signing_certificate_bio); });
@@ -43,12 +43,12 @@ static X509* LoadCertificate(const std::string& certificate) {
     auto signing_certificate_size = vanillapdf::ValueConvertUtils::SafeConvert<int>(certificate.size());
     auto bytes_written = BIO_write(signing_certificate_bio, certificate.data(), signing_certificate_size);
     if (bytes_written <= 0) {
-        throw IOErrorException("Could not write certificate data");
+        LOG_ERROR_AND_THROW(IOErrorException, "Could not write certificate data");
     }
 
     auto certificate_x509 = PEM_read_bio_X509(signing_certificate_bio, nullptr, nullptr, nullptr);
     if (certificate_x509 == nullptr) {
-        throw IOErrorException("Could not read PEM certificate");
+        LOG_ERROR_AND_THROW(IOErrorException, "Could not read PEM certificate");
     }
 
     return certificate_x509;
@@ -72,7 +72,7 @@ void LicenseInfo::SetLicense(IInputStreamPtr stream, types::stream_size length) 
     Buffer buffer(length);
     auto read = stream->Read(buffer, length);
     if (read != length) {
-        throw IOErrorException("Could not read license file");
+        LOG_ERROR_AND_THROW(IOErrorException, "Could not read license file");
     }
 
     // Forward content
@@ -90,14 +90,14 @@ void LicenseInfo::SetLicense([[maybe_unused]] const Buffer& data) {
     // Check license version
     auto version_node = json_data[VERSION_NODE];
     if (!version_node.is_string()) {
-        throw InvalidLicenseException("Missing license version");
+        LOG_ERROR_AND_THROW(InvalidLicenseException, "Missing license version");
     }
 
     // Check license version format
     auto version_string = version_node.get<std::string>();
     auto delimiter_offset = version_string.find('.');
     if (delimiter_offset == std::string::npos) {
-        throw InvalidLicenseException("Invalid license version format");
+        LOG_ERROR_AND_THROW(InvalidLicenseException, "Invalid license version format");
     }
 
     // Obtain version details
@@ -123,23 +123,21 @@ void LicenseInfo::SetLicense([[maybe_unused]] const Buffer& data) {
             !note_node.is_string() ||
             !serial_node.is_string() ||
             !updates_expiration_node.is_string()) {
-            throw InvalidLicenseException("Invalid license data format");
+            LOG_ERROR_AND_THROW(InvalidLicenseException, "Invalid license data format");
         }
 
         // Check serial on blacklist
         auto serial_string = serial_node.get<std::string>();
         bool blacklisted = CheckBlacklist(serial_string);
         if (blacklisted) {
-            throw InvalidLicenseException(
-                fmt::format("Your license with serial {} is blacklisted", serial_string));
+            LOG_ERROR_AND_THROW(InvalidLicenseException, "Your license with serial {} is blacklisted", serial_string);
         }
 
         // Check updates expiration
         auto updates_expiration_string = updates_expiration_node.get<std::string>();
         bool updates_expired = CheckUpdateExpiration(updates_expiration_string);
         if (updates_expired) {
-            throw InvalidLicenseException(
-                fmt::format("Your license updates expired on {}", updates_expiration_string));
+            LOG_ERROR_AND_THROW(InvalidLicenseException, "Your license updates expired on {}", updates_expiration_string);
         }
 
         // Check signature
@@ -149,7 +147,7 @@ void LicenseInfo::SetLicense([[maybe_unused]] const Buffer& data) {
         if (!signature_node.is_string() ||
             !certificates_node.is_array() ||
             certificates_node.size() == 0) {
-            throw InvalidLicenseException("Invalid license signature format");
+            LOG_ERROR_AND_THROW(InvalidLicenseException, "Invalid license signature format");
         }
 
         std::stringstream signed_content;
@@ -168,7 +166,7 @@ void LicenseInfo::SetLicense([[maybe_unused]] const Buffer& data) {
 
         // Could not verify license signature
         if (!signature_valid) {
-            throw InvalidLicenseException("Invalid license signature");
+            LOG_ERROR_AND_THROW(InvalidLicenseException, "Invalid license signature");
         }
 
         // Verify certificate
@@ -177,7 +175,7 @@ void LicenseInfo::SetLicense([[maybe_unused]] const Buffer& data) {
 
         // Invalid certificate chain
         if (!chain_valid) {
-            throw InvalidLicenseException("Invalid certificate chain");
+            LOG_ERROR_AND_THROW(InvalidLicenseException, "Invalid certificate chain");
         }
 
         m_temporary_expiration.clear();
@@ -191,7 +189,7 @@ void LicenseInfo::SetLicense([[maybe_unused]] const Buffer& data) {
     }
 
     // None of the known license format matches
-    throw IOErrorException("Unknown license version: " + version_string);
+    LOG_ERROR_AND_THROW(IOErrorException, "Unknown license version: {}", version_string);
 
 #else
     spdlog::debug("SetLicense called but licensing support is not compiled in");
@@ -204,7 +202,7 @@ void LicenseInfo::SetLicense([[maybe_unused]] const char * filename) {
     // Determine file size
     auto file = std::make_shared<std::ifstream>(filename, std::ios::binary | std::ios::ate);
     if (!file || !file->good()) {
-        throw IOErrorException("Could not open license file " + std::string(filename));
+        LOG_ERROR_AND_THROW(IOErrorException, "Could not open license file {}", filename);
     }
 
     auto length = file->tellg();
@@ -323,7 +321,7 @@ bool LicenseInfo::CheckTemporaryExpiration(const std::string& expiration) {
 
     auto expiration_since_epoch = std::mktime(&expiration_tm);
     if (expiration_since_epoch == -1) {
-        throw IOErrorException("Could not interpret expiration time as valid date time");
+        LOG_ERROR_AND_THROW(IOErrorException, "Could not interpret expiration time as valid date time");
     }
 
     auto expiration_time = std::chrono::system_clock::from_time_t(expiration_since_epoch);
@@ -343,7 +341,7 @@ bool LicenseInfo::CheckUpdateExpiration(const std::string& expiration) {
 
     auto expiration_since_epoch = std::mktime(&expiration_tm);
     if (expiration_since_epoch == -1) {
-        throw IOErrorException("Could not interpret expiration time as valid date time");
+        LOG_ERROR_AND_THROW(IOErrorException, "Could not interpret expiration time as valid date time");
     }
 
     auto expiration_time = std::chrono::system_clock::from_time_t(expiration_since_epoch);
@@ -359,7 +357,7 @@ bool LicenseInfo::CheckUpdateExpiration(const std::string& expiration) {
 
     auto build_since_epoch = std::mktime(&build_tm);
     if (build_since_epoch == -1) {
-        throw IOErrorException("Could not interpret build time as valid date time");
+        LOG_ERROR_AND_THROW(IOErrorException, "Could not interpret build time as valid date time");
     }
 
     auto build_time = std::chrono::system_clock::from_time_t(build_since_epoch);

--- a/src/vanillapdf/utils/misc_utils.cpp
+++ b/src/vanillapdf/utils/misc_utils.cpp
@@ -15,14 +15,14 @@ BufferPtr MiscUtils::ToBase64(const Buffer& value) {
 
     auto memory_bio = BIO_new(BIO_s_mem());
     if (memory_bio == nullptr) {
-        throw IOErrorException("Could not create memory buffer");
+        LOG_ERROR_AND_THROW(IOErrorException, "Could not create memory buffer");
     }
 
     SCOPE_GUARD([memory_bio]() { BIO_free_all(memory_bio); });
 
     auto base64_bio = BIO_new(BIO_f_base64());
     if (base64_bio == nullptr) {
-        throw IOErrorException("Could not create base64 filter");
+        LOG_ERROR_AND_THROW(IOErrorException, "Could not create base64 filter");
     }
 
     SCOPE_GUARD([base64_bio]() { BIO_free_all(base64_bio); });
@@ -36,18 +36,18 @@ BufferPtr MiscUtils::ToBase64(const Buffer& value) {
     auto value_size = ValueConvertUtils::SafeConvert<int>(value.size());
     auto bytes_written = BIO_write(memory_bio, value.data(), value_size);
     if (bytes_written <= 0) {
-        throw IOErrorException("Could not write data");
+        LOG_ERROR_AND_THROW(IOErrorException, "Could not write data");
     }
 
     auto flushed = BIO_flush(base64_bio);
     if (flushed != 1) {
-        throw IOErrorException("Could not flush buffer");
+        LOG_ERROR_AND_THROW(IOErrorException, "Could not flush buffer");
     }
 
     BUF_MEM* memory_buffer = nullptr;
     auto have_mem_ptr = BIO_get_mem_ptr(memory_bio, &memory_buffer);
     if (have_mem_ptr != 1) {
-        throw IOErrorException("Could not get memory pointer");
+        LOG_ERROR_AND_THROW(IOErrorException, "Could not get memory pointer");
     }
 
     return make_deferred_container<Buffer>(memory_buffer->data, memory_buffer->length);
@@ -57,14 +57,14 @@ BufferPtr MiscUtils::FromBase64(const Buffer& value) {
 
     auto memory_bio = BIO_new(BIO_s_mem());
     if (memory_bio == nullptr) {
-        throw IOErrorException("Could not create memory buffer");
+        LOG_ERROR_AND_THROW(IOErrorException, "Could not create memory buffer");
     }
 
     SCOPE_GUARD([memory_bio]() { BIO_free(memory_bio); });
 
     auto base64_bio = BIO_new(BIO_f_base64());
     if (base64_bio == nullptr) {
-        throw IOErrorException("Could not create base64 filter");
+        LOG_ERROR_AND_THROW(IOErrorException, "Could not create base64 filter");
     }
 
     SCOPE_GUARD([base64_bio]() { BIO_free(base64_bio); });
@@ -72,12 +72,12 @@ BufferPtr MiscUtils::FromBase64(const Buffer& value) {
     auto value_size = ValueConvertUtils::SafeConvert<int>(value.size());
     auto bytes_written = BIO_write(memory_bio, value.data(), value_size);
     if (bytes_written <= 0) {
-        throw IOErrorException("Could not write data into buffer: " + std::to_string(bytes_written));
+        LOG_ERROR_AND_THROW(IOErrorException, "Could not write data into buffer: {}", bytes_written);
     }
 
     auto flushed = BIO_flush(memory_bio);
     if (flushed != 1) {
-        throw IOErrorException("Could not flush buffer: " + std::to_string(flushed));
+        LOG_ERROR_AND_THROW(IOErrorException, "Could not flush buffer: {}", flushed);
     }
 
     // Insert base64 filter into bio chain
@@ -97,7 +97,7 @@ BufferPtr MiscUtils::FromBase64(const Buffer& value) {
         }
 
         if (bytes_read == -2) {
-            throw IOErrorException("Could not read data");
+            LOG_ERROR_AND_THROW(IOErrorException, "Could not read data");
         }
 
         // Assume the byte count is positive
@@ -116,14 +116,14 @@ BufferPtr MiscUtils::FromBase64(const Buffer& value) {
 BufferPtr MiscUtils::CalculateHash(const Buffer& data, MessageDigestAlgorithm digest_algorithm) {
     auto memory_bio = BIO_new(BIO_s_mem());
     if (memory_bio == nullptr) {
-        throw IOErrorException("Could not create memory buffer");
+        LOG_ERROR_AND_THROW(IOErrorException, "Could not create memory buffer");
     }
 
     SCOPE_GUARD([memory_bio]() { BIO_free(memory_bio); });
 
     auto md_bio = BIO_new(BIO_f_md());
     if (md_bio == nullptr) {
-        throw IOErrorException("Could not create hash filter");
+        LOG_ERROR_AND_THROW(IOErrorException, "Could not create hash filter");
     }
 
     SCOPE_GUARD([md_bio]() { BIO_free(md_bio); });
@@ -131,7 +131,7 @@ BufferPtr MiscUtils::CalculateHash(const Buffer& data, MessageDigestAlgorithm di
     auto algorithm = CryptoUtils::GetAlgorithm(digest_algorithm);
     auto md_set = BIO_set_md(md_bio, algorithm);
     if (md_set != 1) {
-        throw IOErrorException("Could not set digest algorithm");
+        LOG_ERROR_AND_THROW(IOErrorException, "Could not set digest algorithm");
     }
 
     // Insert md into bio chain
@@ -140,12 +140,12 @@ BufferPtr MiscUtils::CalculateHash(const Buffer& data, MessageDigestAlgorithm di
     auto data_size = ValueConvertUtils::SafeConvert<int>(data.size());
     auto bytes_written = BIO_write(memory_bio, data.data(), data_size);
     if (bytes_written <= 0) {
-        throw IOErrorException("");
+        LOG_ERROR_AND_THROW(IOErrorException, "");
     }
 
     auto flushed = BIO_flush(memory_bio);
     if (flushed != 1) {
-        throw IOErrorException("Could not flush buffer");
+        LOG_ERROR_AND_THROW(IOErrorException, "Could not flush buffer");
     }
 
     BufferPtr hash_buffer = make_deferred_container<Buffer>(EVP_MAX_MD_SIZE);
@@ -153,7 +153,7 @@ BufferPtr MiscUtils::CalculateHash(const Buffer& data, MessageDigestAlgorithm di
     auto hash_buffer_size = ValueConvertUtils::SafeConvert<int>(hash_buffer->size());
     auto bytes_read = BIO_gets(md_bio, hash_buffer->data(), hash_buffer_size);
     if (bytes_read <= 0) {
-        throw IOErrorException("Could not calculate hash");
+        LOG_ERROR_AND_THROW(IOErrorException, "Could not calculate hash");
     }
 
     return hash_buffer;

--- a/src/vanillapdf/utils/misc_utils.cpp
+++ b/src/vanillapdf/utils/misc_utils.cpp
@@ -140,7 +140,7 @@ BufferPtr MiscUtils::CalculateHash(const Buffer& data, MessageDigestAlgorithm di
     auto data_size = ValueConvertUtils::SafeConvert<int>(data.size());
     auto bytes_written = BIO_write(memory_bio, data.data(), data_size);
     if (bytes_written <= 0) {
-        LOG_ERROR_AND_THROW(IOErrorException, "");
+        LOG_ERROR_AND_THROW(IOErrorException, "Could not write data into the digest buffer: {}", bytes_written);
     }
 
     auto flushed = BIO_flush(memory_bio);

--- a/src/vanillapdf/utils/pdf_version.h
+++ b/src/vanillapdf/utils/pdf_version.h
@@ -19,6 +19,35 @@ enum class Version {
     PDF20
 };
 
+inline const char* VersionName(Version version) {
+    switch (version) {
+        case Version::PDF10:
+            return "1.0";
+        case Version::PDF11:
+            return "1.1";
+        case Version::PDF12:
+            return "1.2";
+        case Version::PDF13:
+            return "1.3";
+        case Version::PDF14:
+            return "1.4";
+        case Version::PDF15:
+            return "1.5";
+        case Version::PDF16:
+            return "1.6";
+        case Version::PDF17:
+            return "1.7";
+        case Version::PDF20:
+            return "2.0";
+        default:
+
+            // The name is used in log and exception messages, so it has to stay
+            // a printable string even for values outside of the enumeration.
+
+            return "Undefined";
+    }
+}
+
 template <Version ver>
 class RequireVersion {
 public:
@@ -27,7 +56,7 @@ public:
     void OnWriteCheck(Version file_version) {
         if (static_cast<unsigned char>(ver) > static_cast<unsigned char>(file_version)) {
             LOG_ERROR_AND_THROW(InvalidParameterException, "The entry requires PDF version {}, but the file declares {}",
-                static_cast<int>(ver), static_cast<int>(file_version));
+                VersionName(ver), VersionName(file_version));
         }
     }
 };

--- a/src/vanillapdf/utils/pdf_version.h
+++ b/src/vanillapdf/utils/pdf_version.h
@@ -26,7 +26,8 @@ public:
 
     void OnWriteCheck(Version file_version) {
         if (static_cast<unsigned char>(ver) > static_cast<unsigned char>(file_version)) {
-            LOG_ERROR_AND_THROW(InvalidParameterException, "Expected file version does not match");
+            LOG_ERROR_AND_THROW(InvalidParameterException, "The entry requires PDF version {}, but the file declares {}",
+                static_cast<int>(ver), static_cast<int>(file_version));
         }
     }
 };

--- a/src/vanillapdf/utils/pdf_version.h
+++ b/src/vanillapdf/utils/pdf_version.h
@@ -2,6 +2,7 @@
 #define _PDF_VERSION_H
 
 #include "utils/exceptions.h"
+#include "utils/log.h"
 
 namespace vanillapdf {
 
@@ -24,8 +25,9 @@ public:
     RequireVersion() = default;
 
     void OnWriteCheck(Version file_version) {
-        if (static_cast<unsigned char>(ver) > static_cast<unsigned char>(file_version))
-            throw InvalidParameterException("Expected file version does not match");
+        if (static_cast<unsigned char>(ver) > static_cast<unsigned char>(file_version)) {
+            LOG_ERROR_AND_THROW(InvalidParameterException, "Expected file version does not match");
+        }
     }
 };
 

--- a/src/vanillapdf/utils/pkcs12_key.cpp
+++ b/src/vanillapdf/utils/pkcs12_key.cpp
@@ -129,7 +129,7 @@ PKCS12Key::PKCS12KeyImpl::PKCS12KeyImpl(const std::string& path, std::string_vie
     SCOPE_GUARD_CAPTURE_REFERENCES(file.close());
 
     if (!file || !file.good()) {
-        throw CryptoErrorException("Could not open file: " + path);
+        LOG_ERROR_AND_THROW(CryptoErrorException, "Could not open file: {}", path);
     }
 
     Buffer data;
@@ -169,7 +169,7 @@ void PKCS12Key::PKCS12KeyImpl::Load(const Buffer& data, std::string_view passwor
 
     PKCS12* p12_raw = d2i_PKCS12_bio(bio, nullptr);
     if (nullptr == p12_raw) {
-        throw CryptoErrorException("Could not parse der structure PKCS#12, " + CryptoUtils::GetLastOpensslError());
+        LOG_ERROR_AND_THROW(CryptoErrorException, "Could not parse der structure PKCS#12, {}", CryptoUtils::GetLastOpensslError());
     }
     p12 = std::unique_ptr<PKCS12, PKCS12Deleter>(p12_raw);
 
@@ -178,7 +178,7 @@ void PKCS12Key::PKCS12KeyImpl::Load(const Buffer& data, std::string_view passwor
     X509* cert_raw = nullptr;
     int parsed = PKCS12_parse(p12.get(), password.data(), &key_raw, &cert_raw, &additional_certs);
     if (1 != parsed) {
-        throw CryptoErrorException("Could not parse PKCS#12, " + CryptoUtils::GetLastOpensslError());
+        LOG_ERROR_AND_THROW(CryptoErrorException, "Could not parse PKCS#12, {}", CryptoUtils::GetLastOpensslError());
     }
 
     key = std::unique_ptr<EVP_PKEY, EVPPKEYDeleter>(key_raw);
@@ -195,14 +195,14 @@ void PKCS12Key::PKCS12KeyImpl::Load(const Buffer& data, std::string_view passwor
 
         int length = i2d_X509(additional_cert, nullptr);
         if (length < 0) {
-            throw CryptoErrorException("Could not get PKCS#7 size, " + CryptoUtils::GetLastOpensslError());
+            LOG_ERROR_AND_THROW(CryptoErrorException, "Could not get PKCS#7 size, {}", CryptoUtils::GetLastOpensslError());
         }
 
         BufferPtr additional_cert_data = make_deferred_container<Buffer>(length);
         auto data_pointer = (unsigned char *) additional_cert_data->data();
         int converted = i2d_X509(additional_cert, &data_pointer);
         if (converted < 0) {
-            throw CryptoErrorException("Could not convert PKCS#7, " + CryptoUtils::GetLastOpensslError());
+            LOG_ERROR_AND_THROW(CryptoErrorException, "Could not convert PKCS#7, {}", CryptoUtils::GetLastOpensslError());
         }
 
         m_certificates->Append(additional_cert_data);
@@ -244,7 +244,7 @@ BufferPtr PKCS12Key::PKCS12KeyImpl::Decrypt(const Buffer& data) {
 #else
 
     (void) data;
-    throw NotSupportedException("This library was compiled without OpenSSL support");
+    LOG_ERROR_AND_THROW(NotSupportedException, "This library was compiled without OpenSSL support");
 
 #endif
 
@@ -274,7 +274,7 @@ bool PKCS12Key::PKCS12KeyImpl::ContainsPrivateKey(const Buffer& issuer, const Bu
 #else
 
     (void) issuer; (void) serial;
-    throw NotSupportedException("This library was compiled without OpenSSL support");
+    LOG_ERROR_AND_THROW(NotSupportedException, "This library was compiled without OpenSSL support");
 
 #endif
 
@@ -313,7 +313,7 @@ void PKCS12Key::PKCS12KeyImpl::SignInitialize(MessageDigestAlgorithm algorithm) 
     CMS_ContentInfo* cms_raw = CMS_sign(nullptr, nullptr, nullptr, nullptr,
                                         CMS_PARTIAL | CMS_DETACHED | CMS_BINARY);
     if (cms_raw == nullptr) {
-        throw CryptoErrorException("Could not create CMS structure, " + CryptoUtils::GetLastOpensslError());
+        LOG_ERROR_AND_THROW(CryptoErrorException, "Could not create CMS structure, {}", CryptoUtils::GetLastOpensslError());
     }
     m_cms = std::unique_ptr<CMS_ContentInfo, CMSDeleter>(cms_raw);
 
@@ -323,19 +323,19 @@ void PKCS12Key::PKCS12KeyImpl::SignInitialize(MessageDigestAlgorithm algorithm) 
     CMS_SignerInfo* si = CMS_add1_signer(m_cms.get(), cert.get(), key.get(), message_digest,
                                          CMS_PARTIAL | CMS_NOSMIMECAP);
     if (si == nullptr) {
-        throw CryptoErrorException("Could not add CMS signer, " + CryptoUtils::GetLastOpensslError());
+        LOG_ERROR_AND_THROW(CryptoErrorException, "Could not add CMS signer, {}", CryptoUtils::GetLastOpensslError());
     }
 
     // Add signing time signed attribute
     ASN1_UTCTIME* signing_time = X509_gmtime_adj(nullptr, 0);
     if (signing_time == nullptr) {
-        throw CryptoErrorException("Could not create signing time, " + CryptoUtils::GetLastOpensslError());
+        LOG_ERROR_AND_THROW(CryptoErrorException, "Could not create signing time, {}", CryptoUtils::GetLastOpensslError());
     }
     SCOPE_GUARD([signing_time]() { ASN1_UTCTIME_free(signing_time); });
 
     if (!CMS_signed_add1_attr_by_NID(si, NID_pkcs9_signingTime,
                                       V_ASN1_UTCTIME, signing_time, -1)) {
-        throw CryptoErrorException("Could not add signing time attribute, " + CryptoUtils::GetLastOpensslError());
+        LOG_ERROR_AND_THROW(CryptoErrorException, "Could not add signing time attribute, {}", CryptoUtils::GetLastOpensslError());
     }
 
     // Embed certificate chain (intermediate CAs from the PKCS#12 bag).
@@ -348,12 +348,12 @@ void PKCS12Key::PKCS12KeyImpl::SignInitialize(MessageDigestAlgorithm algorithm) 
         auto raw_data_size = ValueConvertUtils::SafeConvert<long>(extra_certificate_data->size());
         auto extra_certificate = d2i_X509(nullptr, &raw_data, raw_data_size);
         if (extra_certificate == nullptr) {
-            throw CryptoErrorException("Extra certificate is invalid, " + CryptoUtils::GetLastOpensslError());
+            LOG_ERROR_AND_THROW(CryptoErrorException, "Extra certificate is invalid, {}", CryptoUtils::GetLastOpensslError());
         }
         SCOPE_GUARD([extra_certificate]() { X509_free(extra_certificate); });
 
         if (!CMS_add1_cert(m_cms.get(), extra_certificate)) {
-            throw CryptoErrorException("Could not add extra certificate, " + CryptoUtils::GetLastOpensslError());
+            LOG_ERROR_AND_THROW(CryptoErrorException, "Could not add extra certificate, {}", CryptoUtils::GetLastOpensslError());
         }
     }
 
@@ -361,14 +361,14 @@ void PKCS12Key::PKCS12KeyImpl::SignInitialize(MessageDigestAlgorithm algorithm) 
     // CMS_final() reads this BIO to compute the message digest and perform signing.
     BIO* bio_raw = BIO_new(BIO_s_mem());
     if (bio_raw == nullptr) {
-        throw CryptoErrorException("Could not create data BIO, " + CryptoUtils::GetLastOpensslError());
+        LOG_ERROR_AND_THROW(CryptoErrorException, "Could not create data BIO, {}", CryptoUtils::GetLastOpensslError());
     }
     m_data_bio = std::unique_ptr<BIO, BIODeleter>(bio_raw);
 
 #else
 
     (void) algorithm;
-    throw NotSupportedException("This library was compiled without OpenSSL support");
+    LOG_ERROR_AND_THROW(NotSupportedException, "This library was compiled without OpenSSL support");
 
 #endif
 
@@ -398,7 +398,7 @@ void PKCS12Key::PKCS12KeyImpl::SignUpdate(IInputStreamPtr data, types::stream_si
 
         int written = BIO_write(m_data_bio.get(), buffer.data(), read_converted);
         if (written != read_converted) {
-            throw CryptoErrorException("Could not write data");
+            LOG_ERROR_AND_THROW(CryptoErrorException, "Could not write data");
         }
 
         read_total = read_total + read;
@@ -407,7 +407,7 @@ void PKCS12Key::PKCS12KeyImpl::SignUpdate(IInputStreamPtr data, types::stream_si
 #else
 
     (void) data;
-    throw NotSupportedException("This library was compiled without OpenSSL support");
+    LOG_ERROR_AND_THROW(NotSupportedException, "This library was compiled without OpenSSL support");
 
 #endif
 
@@ -423,26 +423,26 @@ BufferPtr PKCS12Key::PKCS12KeyImpl::SignFinal() {
     // of the accumulated data without needing a reset or a separate read BIO.
     int finalized = CMS_final(m_cms.get(), m_data_bio.get(), nullptr, CMS_DETACHED | CMS_BINARY);
     if (finalized != 1) {
-        throw CryptoErrorException("Could not finalize CMS, " + CryptoUtils::GetLastOpensslError());
+        LOG_ERROR_AND_THROW(CryptoErrorException, "Could not finalize CMS, {}", CryptoUtils::GetLastOpensslError());
     }
 
     int length = i2d_CMS_ContentInfo(m_cms.get(), nullptr);
     if (length < 0) {
-        throw CryptoErrorException("Could not get CMS size, " + CryptoUtils::GetLastOpensslError());
+        LOG_ERROR_AND_THROW(CryptoErrorException, "Could not get CMS size, {}", CryptoUtils::GetLastOpensslError());
     }
 
     BufferPtr result = make_deferred_container<Buffer>(length);
     auto data_pointer = (unsigned char*) result->data();
     int converted = i2d_CMS_ContentInfo(m_cms.get(), &data_pointer);
     if (converted < 0) {
-        throw CryptoErrorException("Could not convert CMS, " + CryptoUtils::GetLastOpensslError());
+        LOG_ERROR_AND_THROW(CryptoErrorException, "Could not convert CMS, {}", CryptoUtils::GetLastOpensslError());
     }
 
     return result;
 
 #else
 
-    throw NotSupportedException("This library was compiled without OpenSSL support");
+    LOG_ERROR_AND_THROW(NotSupportedException, "This library was compiled without OpenSSL support");
 
 #endif
 
@@ -464,27 +464,27 @@ BufferPtr PKCS12Key::PKCS12KeyImpl::GetCertificate() const {
 #if defined(VANILLAPDF_HAVE_OPENSSL)
 
     if (!cert) {
-        throw CryptoErrorException("No certificate available in PKCS12 key");
+        LOG_ERROR_AND_THROW(CryptoErrorException, "No certificate available in PKCS12 key");
     }
 
     // Convert X509* to DER format (same technique used for additional certs)
     int length = i2d_X509(cert.get(), nullptr);
     if (length < 0) {
-        throw CryptoErrorException("Could not get certificate size, " + CryptoUtils::GetLastOpensslError());
+        LOG_ERROR_AND_THROW(CryptoErrorException, "Could not get certificate size, {}", CryptoUtils::GetLastOpensslError());
     }
 
     BufferPtr cert_data = make_deferred_container<Buffer>(length);
     auto data_pointer = (unsigned char *) cert_data->data();
     int converted = i2d_X509(cert.get(), &data_pointer);
     if (converted < 0) {
-        throw CryptoErrorException("Could not convert certificate to DER, " + CryptoUtils::GetLastOpensslError());
+        LOG_ERROR_AND_THROW(CryptoErrorException, "Could not convert certificate to DER, {}", CryptoUtils::GetLastOpensslError());
     }
 
     return cert_data;
 
 #else
 
-    throw NotSupportedException("This library was compiled without OpenSSL support");
+    LOG_ERROR_AND_THROW(NotSupportedException, "This library was compiled without OpenSSL support");
 
 #endif
 

--- a/src/vanillapdf/utils/resource.cpp
+++ b/src/vanillapdf/utils/resource.cpp
@@ -41,7 +41,7 @@ BufferPtr Resource::Load(ResourceID id) {
         case ResourceID::SERIAL_BLACKLIST:
             return make_deferred_container<Buffer>(SERIAL_BLACKLIST, sizeof(SERIAL_BLACKLIST));
         default:
-            throw InvalidParameterException("Undefined resource ID: " + std::to_string(static_cast<int>(id)));
+            LOG_ERROR_AND_THROW(InvalidParameterException, "Undefined resource ID: {}", static_cast<int>(id));
     }
 }
 

--- a/src/vanillapdf/utils/streams/input_stream.cpp
+++ b/src/vanillapdf/utils/streams/input_stream.cpp
@@ -9,7 +9,7 @@ namespace vanillapdf {
 
 InputStream::InputStream(std::shared_ptr<std::istream> stream) : m_stream(stream) {
     if (m_stream == nullptr) {
-        throw IOErrorException("Could not create input stream");
+        LOG_ERROR_AND_THROW(IOErrorException, "Could not create input stream");
     }
 
     m_input_lock = std::shared_ptr<std::recursive_mutex>(pdf_new std::recursive_mutex());
@@ -106,13 +106,13 @@ BufferPtr InputStream::Readline(void) {
     bool stream_failed = m_stream->fail();
     assert(!stream_failed && "Stream is in failed state");
     if (stream_failed) {
-        throw IOErrorException("Stream is in failed state");
+        LOG_ERROR_AND_THROW(IOErrorException, "Stream is in failed state");
     }
 
     bool stream_eof = m_stream->eof();
     assert(!stream_eof && "Stream reached eof");
     if (stream_eof) {
-        throw IOErrorException("Stream reached eof");
+        LOG_ERROR_AND_THROW(IOErrorException, "Stream reached eof");
     }
 
     for (;;) {

--- a/src/vanillapdf/utils/streams/memory_buffer_input_stream.cpp
+++ b/src/vanillapdf/utils/streams/memory_buffer_input_stream.cpp
@@ -12,7 +12,7 @@ namespace vanillapdf {
 MemoryBufferInputStream::MemoryBufferInputStream(std::shared_ptr<fmt::memory_buffer> buffer)
     : m_buffer(std::move(buffer)) {
     if (m_buffer == nullptr) {
-        throw GeneralException("Could not create memory buffer input stream with null buffer");
+        LOG_ERROR_AND_THROW_GENERAL("Could not create memory buffer input stream with null buffer");
     }
 
     m_input_lock = std::shared_ptr<std::recursive_mutex>(pdf_new std::recursive_mutex());
@@ -102,7 +102,7 @@ void MemoryBufferInputStream::SetInputPosition(types::stream_size pos, SeekDirec
             m_position = buffer_size + pos;
             break;
         default:
-            throw GeneralException("Unknown seek direction: " + std::to_string(static_cast<int>(way)));
+            LOG_ERROR_AND_THROW_GENERAL("Unknown seek direction: {}", static_cast<int>(way));
     }
 
     if (m_position < 0) {
@@ -122,7 +122,7 @@ BufferPtr MemoryBufferInputStream::Readline(void) {
 
     assert(m_position < buffer_size && "Stream reached eof");
     if (m_position >= buffer_size) {
-        throw GeneralException("Stream reached eof");
+        LOG_ERROR_AND_THROW_GENERAL("Stream reached eof");
     }
 
     for (;;) {

--- a/src/vanillapdf/utils/streams/memory_buffer_output_stream.cpp
+++ b/src/vanillapdf/utils/streams/memory_buffer_output_stream.cpp
@@ -14,7 +14,7 @@ MemoryBufferOutputStream::MemoryBufferOutputStream()
 MemoryBufferOutputStream::MemoryBufferOutputStream(std::shared_ptr<fmt::memory_buffer> buffer)
     : m_buffer(std::move(buffer)) {
     if (m_buffer == nullptr) {
-        throw GeneralException("Could not create memory buffer output stream with null buffer");
+        LOG_ERROR_AND_THROW_GENERAL("Could not create memory buffer output stream with null buffer");
     }
 }
 

--- a/src/vanillapdf/utils/streams/output_stream.cpp
+++ b/src/vanillapdf/utils/streams/output_stream.cpp
@@ -9,7 +9,7 @@ namespace vanillapdf {
 
 OutputStream::OutputStream(std::shared_ptr<std::ostream> stream) : m_stream(stream) {
     if (m_stream == nullptr) {
-        throw IOErrorException("Could not create output stream");
+        LOG_ERROR_AND_THROW(IOErrorException, "Could not create output stream");
     }
 
     m_output_lock = std::shared_ptr<std::recursive_mutex>(pdf_new std::recursive_mutex());

--- a/src/vanillapdf/utils/streams/stream_utils.cpp
+++ b/src/vanillapdf/utils/streams/stream_utils.cpp
@@ -84,7 +84,7 @@ SeekDirection StreamUtils::ConvertToSeekDirection(std::ios_base::seekdir value) 
         return SeekDirection::End;
     }
 
-    throw IOErrorException("Unknown seek direction: " + std::to_string(value));
+    LOG_ERROR_AND_THROW(IOErrorException, "Unknown seek direction: {}", static_cast<int>(value));
 }
 
 std::ios_base::seekdir StreamUtils::ConvertFromSeekDirection(SeekDirection value) {
@@ -100,7 +100,7 @@ std::ios_base::seekdir StreamUtils::ConvertFromSeekDirection(SeekDirection value
         return std::ios_base::end;
     }
 
-    throw IOErrorException("Unknown seek direction: " + std::to_string(static_cast<int>(value)));
+    LOG_ERROR_AND_THROW(IOErrorException, "Unknown seek direction: {}", static_cast<int>(value));
 }
 
 IInputOutputStreamPtr StreamUtils::CreateFileStream(const std::string& path, std::ios_base::openmode mode) {

--- a/src/vanillapdf/utils/time_utils.cpp
+++ b/src/vanillapdf/utils/time_utils.cpp
@@ -20,7 +20,7 @@ TimeInfo TimeUtils::GetCurrentTime() {
     std::lock_guard<std::mutex> locker(m_chrono);
     auto gm_time = std::gmtime(&rawtime);
     if (gm_time == nullptr) {
-        throw IOErrorException("Could not get local time");
+        LOG_ERROR_AND_THROW(IOErrorException, "Could not get local time");
     }
 
     TimeInfo result;

--- a/src/vanillapdf/utils/unknown_interface.h
+++ b/src/vanillapdf/utils/unknown_interface.h
@@ -2,6 +2,7 @@
 #define _UNKNOWN_INTERFACE_H
 
 #include "utils/exceptions.h"
+#include "utils/log.h"
 
 #include <memory>
 #include <atomic>
@@ -95,12 +96,12 @@ public:
 
     Deferred<T> GetReference() const {
         if (IsEmpty()) {
-            throw InvalidParameterException("Pointer object was not set");
+            LOG_ERROR_AND_THROW(InvalidParameterException, "Pointer object was not set");
         }
 
         auto acquired = TryGetReference();
         if (!acquired.has_value()) {
-            throw InvalidParameterException("Object has been already disposed");
+            LOG_ERROR_AND_THROW(InvalidParameterException, "Object has been already disposed");
         }
 
         return acquired.value();
@@ -258,7 +259,7 @@ public:
 
         T* converted = static_cast<U*>(this);
         if (converted == nullptr) {
-            throw InvalidParameterException("Pointer object was not set");
+            LOG_ERROR_AND_THROW(InvalidParameterException, "Pointer object was not set");
         }
 
         return WeakReference<T>(converted, m_weak_ref);

--- a/src/vanillapdf/utils/zlib_wrapper.cpp
+++ b/src/vanillapdf/utils/zlib_wrapper.cpp
@@ -35,7 +35,7 @@ static BufferPtr Inflate(IInputStreamPtr input, types::stream_size length, types
     strm.next_in = Z_NULL;
     rv = inflateInit(&strm);
     if (rv != Z_OK) {
-        throw DataCorruptionException("Zlib initialization failed");
+        LOG_ERROR_AND_THROW(DataCorruptionException, "Zlib initialization failed");
     }
 
     /* clean up */
@@ -84,10 +84,10 @@ static BufferPtr Inflate(IInputStreamPtr input, types::stream_size length, types
 
             if (rv == Z_NEED_DICT || rv == Z_MEM_ERROR) {
                 if (nullptr != strm.msg) {
-                    throw DataCorruptionException("Could not decompress data: " + std::string(strm.msg));
+                    LOG_ERROR_AND_THROW(DataCorruptionException, "Could not decompress data: {}", strm.msg);
                 }
 
-                throw DataCorruptionException("Could not decompress data");
+                LOG_ERROR_AND_THROW(DataCorruptionException, "Could not decompress data");
             }
 
             unsigned int have = constant::BUFFER_SIZE - strm.avail_out;
@@ -101,7 +101,7 @@ static BufferPtr Inflate(IInputStreamPtr input, types::stream_size length, types
 
 #else
     (void) input; (void) length; (void) errors_after;
-    throw NotSupportedException("This library is compiled without zlib support");
+    LOG_ERROR_AND_THROW(NotSupportedException, "This library is compiled without zlib support");
 #endif
 
 }
@@ -127,7 +127,7 @@ static BufferPtr Deflate(IInputStreamPtr input, types::stream_size length) {
     strm.opaque = Z_NULL;
     rv = deflateInit(&strm, Z_DEFAULT_COMPRESSION);
     if (rv != Z_OK) {
-        throw DataCorruptionException("Zlib initialization failed: " + std::to_string(rv));
+        LOG_ERROR_AND_THROW(DataCorruptionException, "Zlib initialization failed: {}", rv);
     }
 
     /* clean up */
@@ -163,7 +163,7 @@ static BufferPtr Deflate(IInputStreamPtr input, types::stream_size length) {
 
 #else
     (void) input; (void) length;
-    throw NotSupportedException("This library is compiled without zlib support");
+    LOG_ERROR_AND_THROW(NotSupportedException, "This library is compiled without zlib support");
 #endif
 
 }


### PR DESCRIPTION
## Summary

Two related changes to how the library reports errors: every message-carrying `throw` now logs before it throws, and the messages themselves now name the value that caused the failure.

Previously a `throw NotSupportedException("...")` unwound silently, so a failure reached the caller as an error code at the C API boundary with nothing in the log to say what happened or where. 375 sites across 61 files now go through `LOG_ERROR_AND_THROW` (or `LOG_ERROR_AND_THROW_GENERAL` for `GeneralException`), which emits an `spdlog::error` with the same text first.

## Commits

| Commit | What |
| --- | --- |
| `2ceebf1` | The mechanical macro conversion, and the bulk of the diff |
| `94331554` | Include the offending value in ~90 messages |
| `919a085` | Name the color space and PDF version where the enum value is valid |
| `584cbb5` | Name the offending type in four remaining type mismatches |
| `74d928a` | Fix `DuplicateKeyException` doubling its own message |

## Two things a reviewer cannot see from the diff

**The macro expands to two statements, so brace-less `if` bodies had to gain braces.** Without them only the `spdlog::error` would have been guarded by the condition and the `throw` would have run unconditionally. Three sites hit this (`tree.h` twice, `pdf_version.h`), and they are the reason for the otherwise unexplained brace-only hunks. Wrapping the macro in `do { ... } while (0)` would remove the footgun for good, but it risks MSVC's "not all control paths return a value" on the many functions that end in the macro, so I left it for a separate change.

**64 throws are deliberately not converted.** The macro always constructs the exception from a formatted message, and these constructors take something else and compose the prose themselves: `ParseException(offset)`, `ObjectMissingException(number[, generation])`, `FileDisposedException()`, `FileNotInitializedException(filename)`, `DataCorruptionException(size[, message])`, plus the `ConversionExceptionFactory` and `SemanticContextExceptionFactory` throws, which build the exception object rather than a message. Converting them would have changed the message each constructor produces. Getting those logged needs a different mechanism and is worth its own PR.

## Message changes

Content stream operations were the worst offenders, with 32 sites saying only "Unexpected number of arguments" or "Unexpected argument type". They now name the operator, what it expected and what arrived:

```
Operator Tf expects 2 operands, but 3 were found
Operator cm expects an Integer operand d, but found Name
```

The same treatment is applied wherever the value was already in hand: numeric, timezone and trapped enum values, array and tree indices with the container size, xref `/W` widths and chain sizes, the predictor, digest algorithm, AES key length, byte order and PDF version. `MiscUtils::CalculateHash` was throwing with a literally empty message, which is now the `BIO_write` result.

Where the value reaching the message is a *valid* enumerator and simply the wrong one, it is named rather than printed as a number, via the new `Color::ColorSpaceName` and `VersionName` helpers:

```
The Red component is only available in DeviceRGB colors, but this color is DeviceGray
The entry requires PDF version 1.7, but the file declares 1.4
```

Branches that fire only when the value is *not* a valid enumerator keep printing the raw number, which is the part worth seeing there — a name table would print "Undefined" and discard it. The version strings in `FileWriter`'s header switch are deliberately left duplicated rather than sharing `VersionName`: those bytes are a file-format contract, and coupling them to a string that exists to be read by a human would let a reworded message change what gets written into the file.

Messages that were already complete statements are untouched. "Document does not have a catalog" omits no value.

## Bugs fixed along the way

`Object::TypeName` returned `nullptr` for values outside the enumeration. Its callers pass the result straight into a message, so formatting a null `const char*` through fmt was undefined behaviour, and `Object_TypeName` handed the null to C API callers as success. It returns `"Undefined"` now, and the two new helpers follow the same rule.

`DuplicateKeyException`'s constructor composed "The key `<key>` was already present in the dictionary", but both call sites passed that whole sentence as the key, so the message came out doubled. The composing constructor could not have been right for both callers anyway — `AttributeList::Add` is not a dictionary, yet the prose said it was. It is now a plain message constructor like its message-style siblings, and `AttributeList::Add` says an attribute of that type was already present in the attribute list.

Also fixes two typos: "Object does not an indirect object" and a missing separator in "Unknown numbering style".

## Test plan

- `windows-x64-msvc-18` Release and Debug both build clean.
- Full Release suite passes, 772/772 (`MPK_SLOVLEX.pdf` is disabled in the manifest).
- Exception types and error codes are unchanged throughout, so the C API contract is unaffected. The one message that changed as part of the conversion rather than the message pass is `dct_decode_filter`'s libjpeg `error_exit` callback, where the throw now carries the same "JPEG decompression exited with error: ..." text as the `spdlog::error` it replaced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
