### PR TITLE
fix: Give the content stream fuzz target a file to parse against

### DIFF
--- a/src/vanillapdf.fuzzer/fuzz_content_stream.cpp
+++ b/src/vanillapdf.fuzzer/fuzz_content_stream.cpp
@@ -4,9 +4,31 @@
 #include <cstddef>
 #include <cstdint>
 
+// A content stream is parsed in the context of the file it belongs to. The parser
+// stamps that file onto every object it produces and reads it back for diagnostics,
+// which is why ContentParser_Create rejects a null file, and why both callers inside
+// the library pass the file the stream came from.
+//
+// This target used to pass nullptr, so the call failed on every input and it returned
+// before the parser ran. It reported 69 edges after 34 million executions, all of them
+// in buffer creation.
+//
+// The document is not what is being fuzzed, so an empty file over a memory stream
+// stands in for it. It carries no objects, which is all the parser needs to resolve
+// nothing against.
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
     static bool initialized = (fuzzer_init(), true);
     (void)initialized;
+
+    HandleGuard<InputOutputStreamHandle, InputOutputStream_Release> document_stream;
+    if (InputOutputStream_CreateFromMemory(document_stream.out()) != VANILLAPDF_ERROR_SUCCESS) {
+        return 0;
+    }
+
+    HandleGuard<FileHandle, File_Release> file;
+    if (File_CreateStream(document_stream, "fuzz_content_stream.pdf", file.out()) != VANILLAPDF_ERROR_SUCCESS) {
+        return 0;
+    }
 
     HandleGuard<BufferHandle, Buffer_Release> buffer;
     if (Buffer_CreateFromData(reinterpret_cast<const char*>(data),
@@ -21,7 +43,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
     }
 
     HandleGuard<ContentParserHandle, ContentParser_Release> parser;
-    if (ContentParser_Create(nullptr, stream, parser.out()) != VANILLAPDF_ERROR_SUCCESS) {
+    if (ContentParser_Create(file, stream, parser.out()) != VANILLAPDF_ERROR_SUCCESS) {
         return 0;
     }
 


### PR DESCRIPTION
`vanillapdf.fuzz.content_stream` has never parsed a content stream.

A content stream is parsed in the context of the file it belongs to. `ParserBase` stamps that file onto every object the parser produces (`parser.cpp:40,55,69,76,83`) and reads it back for diagnostics through `_file.GetReference()`, which throws when the reference is inactive. `ContentParser_Create` therefore rejects a null file, and both callers inside the library pass the file the stream came from (`content_stream.cpp:21`, `page_contents.cpp:138`).

The fuzz target passed `nullptr`:

```
Buffer_CreateFromData        -> 0
InputStream_CreateFromBuffer -> 0
ContentParser_Create(NULL)   -> 1   (SUCCESS=0, PARAMETER_VALUE=1)

>>> the fuzz target returns here, the content stream is never parsed
```

Every input failed at that call and returned before the parser ran, and the early return made it silent. The symptom was visible in the statistics for anyone looking: 34 million executions, 114,900 executions per second, and still **69 edges** with a corpus that never grew past its three seed files. The job has been spending 600 seconds of CI a week measuring `Buffer_CreateFromData`.

## The fix

An empty file over a memory stream now stands in for the document. It carries no objects, which is all the parser needs to resolve nothing against, and it avoids embedding a PDF literal whose cross-reference offsets would rot.

| | before | after |
| --- | --- | --- |
| coverage | 69 edges | **1987** |
| corpus | 4 units | **939** |
| new units found | 0 | 4014 |
| executions in 300s | 34,584,964 | 257,488 |

The execution rate falls from 114,900/s to 855/s because the target now does the work it was meant to do. A 300 second run is clean, no crash, leak, timeout or out of memory artifacts.

## Why the file is created per input rather than cached

Measured rather than assumed: creating the stream and file takes **5.07 microseconds** (200,000 creations in 1.014 s), against roughly **633 microseconds** for an average iteration. Caching it would save under one percent, and would introduce a process lifetime that none of the other targets carry, so the target keeps the same flat RAII shape as its neighbours.

## Note on dictionaries

This started as an attempt to add libFuzzer dictionaries, which were measured and dropped. Over 300 seconds with identical seeds, `file_parse` reached 3345 edges without a dictionary and 3289 with one. Two reasons: the seed corpus already contains real PDFs, so the keywords are already present for the mutator to copy, and libFuzzer derives tokens from comparison instrumentation by itself. That was observable in this target's own output, where it discovered a text operator unaided:

```
#45852 NEW cov: 1802 ft: 5520 corp: 616/22Kb lim: 60 MS: 1 CMP- DE: "TL"-
```
