### PR TITLE
refactor: Stop asserting conditions the file controls

### DIFF
--- a/src/vanillapdf.unittest/content_stream_test.cpp
+++ b/src/vanillapdf.unittest/content_stream_test.cpp
@@ -225,3 +225,58 @@ TEST(ContentObjectInlineImage, Samples) {
     ASSERT_EQ(image_data, "abc");
     ASSERT_EQ(image_samples, "abc");
 }
+
+// A content stream is untrusted input, so a malformed operator has to come back
+// as an error. These used to be asserted as well as thrown, which aborted a
+// debug build on a document a caller could legitimately hand us - parsing
+// "1 2 3 Tf" tripped assert(operands.size() == 2) before the ParseException on
+// the following line ever ran.
+//
+// Only the operators the parser builds a dedicated operation for are covered.
+// Everything else (cm, q, Q, RG, rg, Td, ...) becomes an OperationGeneric,
+// which does not check its operands at all.
+struct MalformedOperationCase {
+    std::string_view name;
+    std::string_view content;
+};
+
+class MalformedContentStreamTest : public ::testing::TestWithParam<MalformedOperationCase> {};
+
+TEST_P(MalformedContentStreamTest, ReportsErrorInsteadOfAborting) {
+    const auto& param = GetParam();
+
+    HandleGuard<InputOutputStreamHandle, InputOutputStream_Release> io;
+    ASSERT_EQ(InputOutputStream_CreateFromMemory(io.out()), VANILLAPDF_ERROR_SUCCESS);
+
+    HandleGuard<FileHandle, File_Release> file;
+    ASSERT_EQ(File_CreateStream(io, "malformed_content_stream_test", file.out()), VANILLAPDF_ERROR_SUCCESS);
+
+    HandleGuard<BufferHandle, Buffer_Release> buffer;
+    ASSERT_EQ(Buffer_CreateFromData(param.content.data(), static_cast<size_type>(param.content.size()), buffer.out()), VANILLAPDF_ERROR_SUCCESS);
+
+    HandleGuard<InputStreamHandle, InputStream_Release> stream;
+    ASSERT_EQ(InputStream_CreateFromBuffer(buffer, stream.out()), VANILLAPDF_ERROR_SUCCESS);
+
+    HandleGuard<ContentParserHandle, ContentParser_Release> parser;
+    ASSERT_EQ(ContentParser_Create(file, stream, parser.out()), VANILLAPDF_ERROR_SUCCESS);
+
+    HandleGuard<ContentInstructionCollectionHandle, ContentInstructionCollection_Release> instructions;
+    EXPECT_NE(ContentParser_ReadInstructionCollection(parser, instructions.out()), VANILLAPDF_ERROR_SUCCESS);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    ContentStream,
+    MalformedContentStreamTest,
+    ::testing::Values(
+        MalformedOperationCase{ "TooManyTextFontOperands",  "1 2 3 Tf " },
+        MalformedOperationCase{ "TooFewTextFontOperands",   "1 Tf " },
+        MalformedOperationCase{ "TextFontOperandTypes",     "(a) (b) Tf " },
+        MalformedOperationCase{ "BeginTextWithOperands",    "1 2 BT " },
+        MalformedOperationCase{ "EndTextWithOperands",      "1 ET " },
+        MalformedOperationCase{ "TextShowOperandType",      "1 Tj " },
+        MalformedOperationCase{ "TextShowArrayOperandType", "1 TJ " }
+    ),
+    [](const ::testing::TestParamInfo<MalformedOperationCase>& info) {
+        return std::string(info.param.name);
+    }
+);

--- a/src/vanillapdf/contents/content_stream_operations.cpp
+++ b/src/vanillapdf/contents/content_stream_operations.cpp
@@ -16,35 +16,30 @@ namespace contents {
 using namespace syntax;
 
 OperationBeginText::OperationBeginText(const std::vector<ObjectPtr>& operands) {
-    assert(operands.size() == 0);
     if (operands.size() != 0) {
         LOG_ERROR_AND_THROW(syntax::ParseException, "Operator BT expects no operands, but {} were found", operands.size());
     }
 }
 
 OperationEndText::OperationEndText(const std::vector<ObjectPtr>& operands) {
-    assert(operands.size() == 0);
     if (operands.size() != 0) {
         LOG_ERROR_AND_THROW(syntax::ParseException, "Operator ET expects no operands, but {} were found", operands.size());
     }
 }
 
 OperationSaveGraphicsState::OperationSaveGraphicsState(const std::vector<ObjectPtr>& operands) {
-    assert(operands.size() == 0);
     if (operands.size() != 0) {
         LOG_ERROR_AND_THROW(syntax::ParseException, "Operator q expects no operands, but {} were found", operands.size());
     }
 }
 
 OperationRestoreGraphicsState::OperationRestoreGraphicsState(const std::vector<ObjectPtr>& operands) {
-    assert(operands.size() == 0);
     if (operands.size() != 0) {
         LOG_ERROR_AND_THROW(syntax::ParseException, "Operator Q expects no operands, but {} were found", operands.size());
     }
 }
 
 OperationSetStrokingColorSpaceRGB::OperationSetStrokingColorSpaceRGB(const std::vector<ObjectPtr>& operands) {
-    assert(operands.size() == 3);
     if (operands.size() != 3) {
         LOG_ERROR_AND_THROW(syntax::ParseException, "Operator RG expects 3 operands, but {} were found", operands.size());
     }
@@ -71,7 +66,6 @@ OperationSetStrokingColorSpaceRGB::OperationSetStrokingColorSpaceRGB(const std::
 }
 
 OperationSetNonstrokingColorSpaceRGB::OperationSetNonstrokingColorSpaceRGB(const std::vector<ObjectPtr>& operands) {
-    assert(operands.size() == 3);
     if (operands.size() != 3) {
         LOG_ERROR_AND_THROW(syntax::ParseException, "Operator rg expects 3 operands, but {} were found", operands.size());
     }
@@ -98,7 +92,6 @@ OperationSetNonstrokingColorSpaceRGB::OperationSetNonstrokingColorSpaceRGB(const
 }
 
 OperationTextFont::OperationTextFont(const std::vector<ObjectPtr>& operands) {
-    assert(operands.size() == 2);
     if (operands.size() != 2) {
         LOG_ERROR_AND_THROW(syntax::ParseException, "Operator Tf expects 2 operands, but {} were found", operands.size());
     }
@@ -106,12 +99,10 @@ OperationTextFont::OperationTextFont(const std::vector<ObjectPtr>& operands) {
     auto name = operands.at(0);
     auto scale = operands.at(1);
     if (!ObjectUtils::IsType<NameObjectPtr>(name)) {
-        assert(!"Text font operation has invalid arguments");
         LOG_ERROR_AND_THROW(syntax::ParseException, "Operator Tf expects a Name font, but found {}", Object::TypeName(name->GetObjectType()));
     }
 
     if (!ObjectUtils::IsType<RealObjectPtr>(scale)) {
-        assert(!"Text font operation has invalid arguments");
         LOG_ERROR_AND_THROW(syntax::ParseException, "Operator Tf expects a Real font size, but found {}", Object::TypeName(scale->GetObjectType()));
     }
 
@@ -120,7 +111,6 @@ OperationTextFont::OperationTextFont(const std::vector<ObjectPtr>& operands) {
 }
 
 OperationTextTranslate::OperationTextTranslate(const std::vector<ObjectPtr>& operands) {
-    assert(operands.size() == 2);
     if (operands.size() != 2) {
         LOG_ERROR_AND_THROW(syntax::ParseException, "Operator Td expects 2 operands, but {} were found", operands.size());
     }
@@ -128,12 +118,10 @@ OperationTextTranslate::OperationTextTranslate(const std::vector<ObjectPtr>& ope
     auto x = operands.at(0);
     auto y = operands.at(1);
     if (!ObjectUtils::IsType<IntegerObjectPtr>(x)) {
-        assert(!"Text font operation has invalid arguments");
         LOG_ERROR_AND_THROW(syntax::ParseException, "Operator Td expects an Integer x offset, but found {}", Object::TypeName(x->GetObjectType()));
     }
 
     if (!ObjectUtils::IsType<IntegerObjectPtr>(y)) {
-        assert(!"Text font operation has invalid arguments");
         LOG_ERROR_AND_THROW(syntax::ParseException, "Operator Td expects an Integer y offset, but found {}", Object::TypeName(y->GetObjectType()));
     }
 
@@ -142,21 +130,18 @@ OperationTextTranslate::OperationTextTranslate(const std::vector<ObjectPtr>& ope
 }
 
 OperationBeginInlineImageObject::OperationBeginInlineImageObject(const std::vector<ObjectPtr>& operands) {
-    assert(operands.size() == 0);
     if (operands.size() != 0) {
         LOG_ERROR_AND_THROW(syntax::ParseException, "Operator BI expects no operands, but {} were found", operands.size());
     }
 }
 
 OperationBeginInlineImageData::OperationBeginInlineImageData(const std::vector<ObjectPtr>& operands) {
-    assert(operands.size() == 0);
     if (operands.size() != 0) {
         LOG_ERROR_AND_THROW(syntax::ParseException, "Operator ID expects no operands, but {} were found", operands.size());
     }
 }
 
 OperationEndInlineImageObject::OperationEndInlineImageObject(const std::vector<ObjectPtr>& operands) {
-    assert(operands.size() == 0);
     if (operands.size() != 0) {
         LOG_ERROR_AND_THROW(syntax::ParseException, "Operator EI expects no operands, but {} were found", operands.size());
     }
@@ -164,13 +149,11 @@ OperationEndInlineImageObject::OperationEndInlineImageObject(const std::vector<O
 
 OperationTextShow::OperationTextShow(const std::vector<ObjectPtr>& operands) {
     if (1 != operands.size()) {
-        assert(!"Text show operation has invalid arguments");
         LOG_ERROR_AND_THROW(syntax::ParseException, "Operator Tj expects 1 operand, but {} were found", operands.size());
     }
 
     auto item = operands.at(0);
     if (!ObjectUtils::IsType<StringObjectPtr>(item)) {
-        assert(!"Text show operation has invalid arguments");
         LOG_ERROR_AND_THROW(syntax::ParseException, "Operator Tj expects a String operand, but found {}", Object::TypeName(item->GetObjectType()));
     }
 
@@ -179,13 +162,11 @@ OperationTextShow::OperationTextShow(const std::vector<ObjectPtr>& operands) {
 
 OperationTextShowArray::OperationTextShowArray(const std::vector<ObjectPtr>& operands) {
     if (1 != operands.size()) {
-        assert(!"Text show array operation has invalid arguments");
         LOG_ERROR_AND_THROW(syntax::ParseException, "Operator TJ expects 1 operand, but {} were found", operands.size());
     }
 
     auto item = operands.at(0);
     if (!ObjectUtils::IsType<MixedArrayObjectPtr>(item)) {
-        assert(!"Text show array operation has invalid arguments");
         LOG_ERROR_AND_THROW(syntax::ParseException, "Operator TJ expects an Array operand, but found {}", Object::TypeName(item->GetObjectType()));
     }
 
@@ -194,43 +175,36 @@ OperationTextShowArray::OperationTextShowArray(const std::vector<ObjectPtr>& ope
 
 OperationTransformationMatrix::OperationTransformationMatrix(const std::vector<ObjectPtr>& operands) {
     if (6 != operands.size()) {
-        assert(!"Transformation matrix operation has invalid arguments");
         LOG_ERROR_AND_THROW(syntax::ParseException, "Operator cm expects 6 operands, but {} were found", operands.size());
     }
 
     auto a = operands.at(0);
     if (!ObjectUtils::IsType<IntegerObjectPtr>(a)) {
-        assert(!"Transformation matrix operation has invalid arguments");
         LOG_ERROR_AND_THROW(syntax::ParseException, "Operator cm expects an Integer operand a, but found {}", Object::TypeName(a->GetObjectType()));
     }
 
     auto b = operands.at(1);
     if (!ObjectUtils::IsType<IntegerObjectPtr>(b)) {
-        assert(!"Transformation matrix operation has invalid arguments");
         LOG_ERROR_AND_THROW(syntax::ParseException, "Operator cm expects an Integer operand b, but found {}", Object::TypeName(b->GetObjectType()));
     }
 
     auto c = operands.at(2);
     if (!ObjectUtils::IsType<IntegerObjectPtr>(c)) {
-        assert(!"Transformation matrix operation has invalid arguments");
         LOG_ERROR_AND_THROW(syntax::ParseException, "Operator cm expects an Integer operand c, but found {}", Object::TypeName(c->GetObjectType()));
     }
 
     auto d = operands.at(3);
     if (!ObjectUtils::IsType<IntegerObjectPtr>(d)) {
-        assert(!"Transformation matrix operation has invalid arguments");
         LOG_ERROR_AND_THROW(syntax::ParseException, "Operator cm expects an Integer operand d, but found {}", Object::TypeName(d->GetObjectType()));
     }
 
     auto e = operands.at(4);
     if (!ObjectUtils::IsType<IntegerObjectPtr>(e)) {
-        assert(!"Transformation matrix operation has invalid arguments");
         LOG_ERROR_AND_THROW(syntax::ParseException, "Operator cm expects an Integer operand e, but found {}", Object::TypeName(e->GetObjectType()));
     }
 
     auto f = operands.at(5);
     if (!ObjectUtils::IsType<IntegerObjectPtr>(f)) {
-        assert(!"Transformation matrix operation has invalid arguments");
         LOG_ERROR_AND_THROW(syntax::ParseException, "Operator cm expects an Integer operand f, but found {}", Object::TypeName(f->GetObjectType()));
     }
 

--- a/src/vanillapdf/contents/content_stream_parser.cpp
+++ b/src/vanillapdf/contents/content_stream_parser.cpp
@@ -72,14 +72,12 @@ InlineImageObjectPtr ContentStreamParser::ReadInlineImageObject(void) {
             break;
         }
 
-        assert(!"Unknown data in inline image dictionary");
         LOG_ERROR_AND_THROW(ParseException, "Unexpected token type {} in inline image dictionary", static_cast<int>(token_type));
     }
 
     // read operation begin image data
     auto inline_image_data_op = ReadOperation();
     if (inline_image_data_op->GetOperationType() != OperationBase::Type::BeginInlineImageData) {
-        assert(!"Invalid operation after inline image dictionary");
         LOG_ERROR_AND_THROW(ParseException, "Inline image dictionary shall be followed by the ID operator, but operation type {} was found",
             static_cast<int>(inline_image_data_op->GetOperationType()));
     }

--- a/src/vanillapdf/semantics/objects/annotations.cpp
+++ b/src/vanillapdf/semantics/objects/annotations.cpp
@@ -240,10 +240,7 @@ bool AnnotationBase::GetRect(OutputRectanglePtr& result) const {
 }
 
 void AnnotationBase::SetRect(RectanglePtr rect) {
-    if (_obj->Contains(constant::Name::Rect)) {
-        bool removed = _obj->Remove(constant::Name::Rect);
-        assert(removed && "Unable to remove existing item"); UNUSED(removed);
-    }
+    _obj->Remove(constant::Name::Rect);
     _obj->Insert(constant::Name::Rect, rect->GetObject());
 }
 
@@ -257,10 +254,7 @@ bool AnnotationBase::GetContents(syntax::OutputLiteralStringObjectPtr& result) c
 }
 
 void AnnotationBase::SetContents(syntax::LiteralStringObjectPtr contents) {
-    if (_obj->Contains(constant::Name::Contents)) {
-        bool removed = _obj->Remove(constant::Name::Contents);
-        assert(removed && "Unable to remove existing item"); UNUSED(removed);
-    }
+    _obj->Remove(constant::Name::Contents);
     _obj->Insert(constant::Name::Contents, contents);
 }
 
@@ -368,10 +362,7 @@ bool AnnotationBase::GetColor(OutputColorPtr& result) const {
 }
 
 void AnnotationBase::SetColor(ColorPtr color) {
-    if (_obj->Contains(constant::Name::C)) {
-        bool removed = _obj->Remove(constant::Name::C);
-        assert(removed && "Unable to remove existing item"); UNUSED(removed);
-    }
+    _obj->Remove(constant::Name::C);
     _obj->Insert(constant::Name::C, color->GetObject());
 }
 
@@ -387,10 +378,7 @@ bool TextAnnotation::GetAuthor(syntax::OutputStringObjectPtr& result) const {
 }
 
 void TextAnnotation::SetAuthor(syntax::StringObjectPtr author) {
-    if (_obj->Contains(constant::Name::T)) {
-        bool removed = _obj->Remove(constant::Name::T);
-        assert(removed && "Unable to remove existing item"); UNUSED(removed);
-    }
+    _obj->Remove(constant::Name::T);
     _obj->Insert(constant::Name::T, author);
 }
 
@@ -405,10 +393,7 @@ bool TextAnnotation::GetModificationDate(OutputDatePtr& result) const {
 }
 
 void TextAnnotation::SetModificationDate(DatePtr date) {
-    if (_obj->Contains(constant::Name::M)) {
-        bool removed = _obj->Remove(constant::Name::M);
-        assert(removed && "Unable to remove existing item"); UNUSED(removed);
-    }
+    _obj->Remove(constant::Name::M);
     _obj->Insert(constant::Name::M, date->GetObject());
 }
 
@@ -423,10 +408,7 @@ bool TextAnnotation::GetCreationDate(OutputDatePtr& result) const {
 }
 
 void TextAnnotation::SetCreationDate(DatePtr date) {
-    if (_obj->Contains(constant::Name::CreationDate)) {
-        bool removed = _obj->Remove(constant::Name::CreationDate);
-        assert(removed && "Unable to remove existing item"); UNUSED(removed);
-    }
+    _obj->Remove(constant::Name::CreationDate);
     _obj->Insert(constant::Name::CreationDate, date->GetObject());
 }
 
@@ -442,10 +424,7 @@ bool HighlightAnnotation::GetAuthor(syntax::OutputStringObjectPtr& result) const
 }
 
 void HighlightAnnotation::SetAuthor(syntax::StringObjectPtr author) {
-    if (_obj->Contains(constant::Name::T)) {
-        bool removed = _obj->Remove(constant::Name::T);
-        assert(removed && "Unable to remove existing item"); UNUSED(removed);
-    }
+    _obj->Remove(constant::Name::T);
     _obj->Insert(constant::Name::T, author);
 }
 
@@ -460,10 +439,7 @@ bool HighlightAnnotation::GetModificationDate(OutputDatePtr& result) const {
 }
 
 void HighlightAnnotation::SetModificationDate(DatePtr date) {
-    if (_obj->Contains(constant::Name::M)) {
-        bool removed = _obj->Remove(constant::Name::M);
-        assert(removed && "Unable to remove existing item"); UNUSED(removed);
-    }
+    _obj->Remove(constant::Name::M);
     _obj->Insert(constant::Name::M, date->GetObject());
 }
 
@@ -478,10 +454,7 @@ bool HighlightAnnotation::GetCreationDate(OutputDatePtr& result) const {
 }
 
 void HighlightAnnotation::SetCreationDate(DatePtr date) {
-    if (_obj->Contains(constant::Name::CreationDate)) {
-        bool removed = _obj->Remove(constant::Name::CreationDate);
-        assert(removed && "Unable to remove existing item"); UNUSED(removed);
-    }
+    _obj->Remove(constant::Name::CreationDate);
     _obj->Insert(constant::Name::CreationDate, date->GetObject());
 }
 
@@ -497,10 +470,7 @@ bool FreeTextAnnotation::GetAuthor(syntax::OutputStringObjectPtr& result) const 
 }
 
 void FreeTextAnnotation::SetAuthor(syntax::StringObjectPtr author) {
-    if (_obj->Contains(constant::Name::T)) {
-        bool removed = _obj->Remove(constant::Name::T);
-        assert(removed && "Unable to remove existing item"); UNUSED(removed);
-    }
+    _obj->Remove(constant::Name::T);
     _obj->Insert(constant::Name::T, author);
 }
 
@@ -515,10 +485,7 @@ bool FreeTextAnnotation::GetModificationDate(OutputDatePtr& result) const {
 }
 
 void FreeTextAnnotation::SetModificationDate(DatePtr date) {
-    if (_obj->Contains(constant::Name::M)) {
-        bool removed = _obj->Remove(constant::Name::M);
-        assert(removed && "Unable to remove existing item"); UNUSED(removed);
-    }
+    _obj->Remove(constant::Name::M);
     _obj->Insert(constant::Name::M, date->GetObject());
 }
 
@@ -533,10 +500,7 @@ bool FreeTextAnnotation::GetCreationDate(OutputDatePtr& result) const {
 }
 
 void FreeTextAnnotation::SetCreationDate(DatePtr date) {
-    if (_obj->Contains(constant::Name::CreationDate)) {
-        bool removed = _obj->Remove(constant::Name::CreationDate);
-        assert(removed && "Unable to remove existing item"); UNUSED(removed);
-    }
+    _obj->Remove(constant::Name::CreationDate);
     _obj->Insert(constant::Name::CreationDate, date->GetObject());
 }
 
@@ -550,10 +514,7 @@ AnnotationBase::Flags AnnotationBase::GetFlags() const {
 }
 
 void AnnotationBase::SetFlags(Flags flags) {
-    if (_obj->Contains(constant::Name::F)) {
-        bool removed = _obj->Remove(constant::Name::F);
-        assert(removed && "Unable to remove existing item"); UNUSED(removed);
-    }
+    _obj->Remove(constant::Name::F);
     auto flags_obj = make_deferred<syntax::IntegerObject>(static_cast<int32_t>(flags));
     _obj->Insert(constant::Name::F, flags_obj);
 }
@@ -595,10 +556,7 @@ bool HighlightAnnotation::GetQuadPoints(syntax::MixedArrayObjectPtr& result) con
 }
 
 void HighlightAnnotation::SetQuadPoints(syntax::MixedArrayObjectPtr quadPoints) {
-    if (_obj->Contains(constant::Name::QuadPoints)) {
-        bool removed = _obj->Remove(constant::Name::QuadPoints);
-        assert(removed && "Unable to remove existing item"); UNUSED(removed);
-    }
+    _obj->Remove(constant::Name::QuadPoints);
     _obj->Insert(constant::Name::QuadPoints, quadPoints);
 }
 
@@ -623,10 +581,7 @@ bool FreeTextAnnotation::GetDefaultAppearance(syntax::LiteralStringObjectPtr& re
 }
 
 void FreeTextAnnotation::SetDefaultAppearance(syntax::LiteralStringObjectPtr da) {
-    if (_obj->Contains(constant::Name::DA)) {
-        bool removed = _obj->Remove(constant::Name::DA);
-        assert(removed && "Unable to remove existing item"); UNUSED(removed);
-    }
+    _obj->Remove(constant::Name::DA);
     _obj->Insert(constant::Name::DA, da);
 }
 
@@ -654,10 +609,7 @@ bool UnderlineAnnotation::GetQuadPoints(syntax::MixedArrayObjectPtr& result) con
 }
 
 void UnderlineAnnotation::SetQuadPoints(syntax::MixedArrayObjectPtr quadPoints) {
-    if (_obj->Contains(constant::Name::QuadPoints)) {
-        bool removed = _obj->Remove(constant::Name::QuadPoints);
-        assert(removed && "Unable to remove existing item"); UNUSED(removed);
-    }
+    _obj->Remove(constant::Name::QuadPoints);
     _obj->Insert(constant::Name::QuadPoints, quadPoints);
 }
 
@@ -673,10 +625,7 @@ bool UnderlineAnnotation::GetAuthor(syntax::OutputStringObjectPtr& result) const
 }
 
 void UnderlineAnnotation::SetAuthor(syntax::StringObjectPtr author) {
-    if (_obj->Contains(constant::Name::T)) {
-        bool removed = _obj->Remove(constant::Name::T);
-        assert(removed && "Unable to remove existing item"); UNUSED(removed);
-    }
+    _obj->Remove(constant::Name::T);
     _obj->Insert(constant::Name::T, author);
 }
 
@@ -691,10 +640,7 @@ bool UnderlineAnnotation::GetModificationDate(OutputDatePtr& result) const {
 }
 
 void UnderlineAnnotation::SetModificationDate(DatePtr date) {
-    if (_obj->Contains(constant::Name::M)) {
-        bool removed = _obj->Remove(constant::Name::M);
-        assert(removed && "Unable to remove existing item"); UNUSED(removed);
-    }
+    _obj->Remove(constant::Name::M);
     _obj->Insert(constant::Name::M, date->GetObject());
 }
 
@@ -709,10 +655,7 @@ bool UnderlineAnnotation::GetCreationDate(OutputDatePtr& result) const {
 }
 
 void UnderlineAnnotation::SetCreationDate(DatePtr date) {
-    if (_obj->Contains(constant::Name::CreationDate)) {
-        bool removed = _obj->Remove(constant::Name::CreationDate);
-        assert(removed && "Unable to remove existing item"); UNUSED(removed);
-    }
+    _obj->Remove(constant::Name::CreationDate);
     _obj->Insert(constant::Name::CreationDate, date->GetObject());
 }
 
@@ -740,10 +683,7 @@ bool SquigglyAnnotation::GetQuadPoints(syntax::MixedArrayObjectPtr& result) cons
 }
 
 void SquigglyAnnotation::SetQuadPoints(syntax::MixedArrayObjectPtr quadPoints) {
-    if (_obj->Contains(constant::Name::QuadPoints)) {
-        bool removed = _obj->Remove(constant::Name::QuadPoints);
-        assert(removed && "Unable to remove existing item"); UNUSED(removed);
-    }
+    _obj->Remove(constant::Name::QuadPoints);
     _obj->Insert(constant::Name::QuadPoints, quadPoints);
 }
 
@@ -759,10 +699,7 @@ bool SquigglyAnnotation::GetAuthor(syntax::OutputStringObjectPtr& result) const 
 }
 
 void SquigglyAnnotation::SetAuthor(syntax::StringObjectPtr author) {
-    if (_obj->Contains(constant::Name::T)) {
-        bool removed = _obj->Remove(constant::Name::T);
-        assert(removed && "Unable to remove existing item"); UNUSED(removed);
-    }
+    _obj->Remove(constant::Name::T);
     _obj->Insert(constant::Name::T, author);
 }
 
@@ -777,10 +714,7 @@ bool SquigglyAnnotation::GetModificationDate(OutputDatePtr& result) const {
 }
 
 void SquigglyAnnotation::SetModificationDate(DatePtr date) {
-    if (_obj->Contains(constant::Name::M)) {
-        bool removed = _obj->Remove(constant::Name::M);
-        assert(removed && "Unable to remove existing item"); UNUSED(removed);
-    }
+    _obj->Remove(constant::Name::M);
     _obj->Insert(constant::Name::M, date->GetObject());
 }
 
@@ -795,10 +729,7 @@ bool SquigglyAnnotation::GetCreationDate(OutputDatePtr& result) const {
 }
 
 void SquigglyAnnotation::SetCreationDate(DatePtr date) {
-    if (_obj->Contains(constant::Name::CreationDate)) {
-        bool removed = _obj->Remove(constant::Name::CreationDate);
-        assert(removed && "Unable to remove existing item"); UNUSED(removed);
-    }
+    _obj->Remove(constant::Name::CreationDate);
     _obj->Insert(constant::Name::CreationDate, date->GetObject());
 }
 
@@ -826,10 +757,7 @@ bool StrikeOutAnnotation::GetQuadPoints(syntax::MixedArrayObjectPtr& result) con
 }
 
 void StrikeOutAnnotation::SetQuadPoints(syntax::MixedArrayObjectPtr quadPoints) {
-    if (_obj->Contains(constant::Name::QuadPoints)) {
-        bool removed = _obj->Remove(constant::Name::QuadPoints);
-        assert(removed && "Unable to remove existing item"); UNUSED(removed);
-    }
+    _obj->Remove(constant::Name::QuadPoints);
     _obj->Insert(constant::Name::QuadPoints, quadPoints);
 }
 
@@ -845,10 +773,7 @@ bool StrikeOutAnnotation::GetAuthor(syntax::OutputStringObjectPtr& result) const
 }
 
 void StrikeOutAnnotation::SetAuthor(syntax::StringObjectPtr author) {
-    if (_obj->Contains(constant::Name::T)) {
-        bool removed = _obj->Remove(constant::Name::T);
-        assert(removed && "Unable to remove existing item"); UNUSED(removed);
-    }
+    _obj->Remove(constant::Name::T);
     _obj->Insert(constant::Name::T, author);
 }
 
@@ -863,10 +788,7 @@ bool StrikeOutAnnotation::GetModificationDate(OutputDatePtr& result) const {
 }
 
 void StrikeOutAnnotation::SetModificationDate(DatePtr date) {
-    if (_obj->Contains(constant::Name::M)) {
-        bool removed = _obj->Remove(constant::Name::M);
-        assert(removed && "Unable to remove existing item"); UNUSED(removed);
-    }
+    _obj->Remove(constant::Name::M);
     _obj->Insert(constant::Name::M, date->GetObject());
 }
 
@@ -881,10 +803,7 @@ bool StrikeOutAnnotation::GetCreationDate(OutputDatePtr& result) const {
 }
 
 void StrikeOutAnnotation::SetCreationDate(DatePtr date) {
-    if (_obj->Contains(constant::Name::CreationDate)) {
-        bool removed = _obj->Remove(constant::Name::CreationDate);
-        assert(removed && "Unable to remove existing item"); UNUSED(removed);
-    }
+    _obj->Remove(constant::Name::CreationDate);
     _obj->Insert(constant::Name::CreationDate, date->GetObject());
 }
 
@@ -912,10 +831,7 @@ bool InkAnnotation::GetInkList(syntax::MixedArrayObjectPtr& result) const {
 }
 
 void InkAnnotation::SetInkList(syntax::MixedArrayObjectPtr inkList) {
-    if (_obj->Contains(constant::Name::InkList)) {
-        bool removed = _obj->Remove(constant::Name::InkList);
-        assert(removed && "Unable to remove existing item"); UNUSED(removed);
-    }
+    _obj->Remove(constant::Name::InkList);
     _obj->Insert(constant::Name::InkList, inkList);
 }
 
@@ -931,10 +847,7 @@ bool InkAnnotation::GetAuthor(syntax::OutputStringObjectPtr& result) const {
 }
 
 void InkAnnotation::SetAuthor(syntax::StringObjectPtr author) {
-    if (_obj->Contains(constant::Name::T)) {
-        bool removed = _obj->Remove(constant::Name::T);
-        assert(removed && "Unable to remove existing item"); UNUSED(removed);
-    }
+    _obj->Remove(constant::Name::T);
     _obj->Insert(constant::Name::T, author);
 }
 
@@ -949,10 +862,7 @@ bool InkAnnotation::GetModificationDate(OutputDatePtr& result) const {
 }
 
 void InkAnnotation::SetModificationDate(DatePtr date) {
-    if (_obj->Contains(constant::Name::M)) {
-        bool removed = _obj->Remove(constant::Name::M);
-        assert(removed && "Unable to remove existing item"); UNUSED(removed);
-    }
+    _obj->Remove(constant::Name::M);
     _obj->Insert(constant::Name::M, date->GetObject());
 }
 
@@ -967,10 +877,7 @@ bool InkAnnotation::GetCreationDate(OutputDatePtr& result) const {
 }
 
 void InkAnnotation::SetCreationDate(DatePtr date) {
-    if (_obj->Contains(constant::Name::CreationDate)) {
-        bool removed = _obj->Remove(constant::Name::CreationDate);
-        assert(removed && "Unable to remove existing item"); UNUSED(removed);
-    }
+    _obj->Remove(constant::Name::CreationDate);
     _obj->Insert(constant::Name::CreationDate, date->GetObject());
 }
 

--- a/src/vanillapdf/semantics/objects/destinations.cpp
+++ b/src/vanillapdf/semantics/objects/destinations.cpp
@@ -293,7 +293,6 @@ DestinationPtr DestinationBase::ResolveDestination(syntax::ObjectPtr dest_obj) {
 
         auto destination_name = syntax::ObjectUtils::ConvertTo<syntax::StringObjectPtr>(dest_obj);
 
-        assert(destinations->Contains(destination_name) && "Referenced destination does not exist");
         if (!destinations->Contains(destination_name)) {
             LOG_ERROR_AND_THROW(syntax::ObjectMissingException, "Referenced destination does not exist");
         }
@@ -326,7 +325,6 @@ DestinationPtr DestinationBase::ResolveDestination(syntax::ObjectPtr dest_obj) {
 
         auto destination_name = syntax::ObjectUtils::ConvertTo<syntax::NameObjectPtr>(dest_obj);
 
-        assert(destinations->Contains(destination_name) && "Referenced destination does not exist");
         if (!destinations->Contains(destination_name)) {
             LOG_ERROR_AND_THROW(syntax::ObjectMissingException, "Referenced destination does not exist");
         }
@@ -411,10 +409,7 @@ DestinationPtr NamedDestinations::Find(const syntax::NameObject& name) const {
 }
 
 void NamedDestinations::Insert(const syntax::NameObject& name, DestinationPtr value) {
-    if (_obj->Contains(name)) {
-        bool removed = _obj->Remove(name);
-        assert(removed && "Unable to remove existing item"); UNUSED(removed);
-    }
+    _obj->Remove(name);
 
     auto raw_obj = value->GetObject();
     if (raw_obj->IsIndirect()) {

--- a/src/vanillapdf/semantics/objects/document.cpp
+++ b/src/vanillapdf/semantics/objects/document.cpp
@@ -530,7 +530,6 @@ void Document::AppendStringDestination(StringObjectPtr key, DestinationPtr value
     }
 
     // Check for name conflicts
-    assert(!original_string_destinations->Contains(key) && "Name conflict");
     if (original_string_destinations->Contains(key)) {
         LOG_ERROR_AND_THROW(NotSupportedException, "Merge of conflicting names is not yet supported");
     }
@@ -570,7 +569,6 @@ void Document::AppendNameDestination(NameObjectPtr key, DestinationPtr value, Pa
     }
 
     // Check for name conflicts
-    assert(!original_destinations->Contains(key) && "Name conflict");
     if (original_destinations->Contains(key)) {
         LOG_ERROR_AND_THROW(NotSupportedException, "Merge of conflicting names is not yet supported");
     }

--- a/src/vanillapdf/semantics/objects/field_tree.cpp
+++ b/src/vanillapdf/semantics/objects/field_tree.cpp
@@ -244,10 +244,7 @@ void FieldTree::RemoveChild(FieldPtr field) {
         LOG_ERROR_AND_THROW(InvalidParameterException, "The field is no longer held by the container the hierarchy walk reached it through - the hierarchy was edited underneath the tree, call Invalidate first");
     }
 
-    if (field_dictionary->Contains(constant::Name::Parent)) {
-        bool parent_removed = field_dictionary->Remove(constant::Name::Parent);
-        assert(parent_removed && "Unable to remove existing item"); UNUSED(parent_removed);
-    }
+    field_dictionary->Remove(constant::Name::Parent);
 
     Invalidate();
 }
@@ -559,10 +556,7 @@ void FieldTree::LinkChild(const syntax::OutputDictionaryObjectPtr& parent, synta
     // Root-level fields have no /Parent (Table 220 requires it for kids
     // only); anything below the root references its parent
     if (parent.empty()) {
-        if (child->Contains(constant::Name::Parent)) {
-            bool removed = child->Remove(constant::Name::Parent);
-            assert(removed && "Unable to remove existing item"); UNUSED(removed);
-        }
+        child->Remove(constant::Name::Parent);
 
         return;
     }

--- a/src/vanillapdf/semantics/objects/fields.cpp
+++ b/src/vanillapdf/semantics/objects/fields.cpp
@@ -291,10 +291,7 @@ bool Field::GetFieldFlags(types::big_int& result) const {
 }
 
 void Field::SetFieldFlags(types::big_int value) {
-    if (_obj->Contains(constant::Name::Ff)) {
-        bool removed = _obj->Remove(constant::Name::Ff);
-        assert(removed && "Unable to remove existing item"); UNUSED(removed);
-    }
+    _obj->Remove(constant::Name::Ff);
     auto flags = make_deferred<syntax::IntegerObject>(value);
     _obj->Insert(constant::Name::Ff, flags);
 }
@@ -391,10 +388,7 @@ bool ButtonField::GetValue(syntax::OutputNameObjectPtr& result) const {
 }
 
 void ButtonField::SetValue(syntax::NameObjectPtr value) {
-    if (_obj->Contains(constant::Name::V)) {
-        bool removed = _obj->Remove(constant::Name::V);
-        assert(removed && "Unable to remove existing item"); UNUSED(removed);
-    }
+    _obj->Remove(constant::Name::V);
     _obj->Insert(constant::Name::V, value);
 }
 
@@ -414,10 +408,7 @@ bool TextField::GetValue(syntax::OutputStringObjectPtr& result) const {
 }
 
 void TextField::SetValue(syntax::StringObjectPtr value) {
-    if (_obj->Contains(constant::Name::V)) {
-        bool removed = _obj->Remove(constant::Name::V);
-        assert(removed && "Unable to remove existing item"); UNUSED(removed);
-    }
+    _obj->Remove(constant::Name::V);
     _obj->Insert(constant::Name::V, value);
 }
 
@@ -459,10 +450,7 @@ bool ChoiceField::GetValue(syntax::OutputStringObjectPtr& result) const {
 }
 
 void ChoiceField::SetValue(syntax::StringObjectPtr value) {
-    if (_obj->Contains(constant::Name::V)) {
-        bool removed = _obj->Remove(constant::Name::V);
-        assert(removed && "Unable to remove existing item"); UNUSED(removed);
-    }
+    _obj->Remove(constant::Name::V);
     _obj->Insert(constant::Name::V, value);
 }
 

--- a/src/vanillapdf/semantics/objects/interactive_forms.cpp
+++ b/src/vanillapdf/semantics/objects/interactive_forms.cpp
@@ -172,10 +172,7 @@ Field::Quadding InteractiveForm::ResolveQuadding(const FieldPtr& field) const {
 void InteractiveForm::SetNeedAppearances(bool value) {
     ACCESS_LOCK_GUARD(m_access_lock);
 
-    if (_obj->Contains(constant::Name::NeedAppearances)) {
-        bool removed = _obj->Remove(constant::Name::NeedAppearances);
-        assert(removed && "Unable to remove existing item"); UNUSED(removed);
-    }
+    _obj->Remove(constant::Name::NeedAppearances);
     auto bool_obj = make_deferred<syntax::BooleanObject>(value);
     _obj->Insert(constant::Name::NeedAppearances, bool_obj);
 }

--- a/src/vanillapdf/semantics/objects/outline.cpp
+++ b/src/vanillapdf/semantics/objects/outline.cpp
@@ -17,7 +17,6 @@ OutlineItemFlags::OutlineItemFlags(syntax::IntegerObjectPtr value) : HighLevelOb
 OutlineItem::OutlineItem(syntax::DictionaryObjectPtr root) : OutlineBase(root) {}
 
 OutlineItemColor::OutlineItemColor(syntax::ArrayObjectPtr<syntax::RealObjectPtr> rgb) : HighLevelObject(rgb) {
-    assert(rgb->GetSize() == 3);
     if (rgb->GetSize() != 3) {
         throw SemanticContextExceptionFactory::Construct<syntax::ArrayObject<syntax::RealObjectPtr>, OutlineItemColor>(rgb);
     }

--- a/src/vanillapdf/semantics/objects/page_contents.cpp
+++ b/src/vanillapdf/semantics/objects/page_contents.cpp
@@ -82,7 +82,6 @@ bool PageContents::RecalculateStreamData() {
         auto stream_array = ObjectUtils::ConvertTo<ArrayObjectPtr<StreamObjectPtr>>(object);
         auto stream_array_size = stream_array->GetSize();
 
-        assert(0 != stream_array_size && "Content stream array is empty");
         if (0 == stream_array_size) {
             LOG_ERROR_AND_THROW(syntax::ObjectMissingException, "Content stream array is empty");
         }

--- a/src/vanillapdf/semantics/objects/page_node_base.cpp
+++ b/src/vanillapdf/semantics/objects/page_node_base.cpp
@@ -33,10 +33,7 @@ PageNodeBasePtr PageNodeBase::GetParent() const {
 }
 
 void PageNodeBase::SetParent(PageNodeBasePtr parent) {
-    if (_obj->Contains(constant::Name::Parent)) {
-        bool removed = _obj->Remove(constant::Name::Parent);
-        assert(removed && "Unable to remove existing item"); UNUSED(removed);
-    }
+    _obj->Remove(constant::Name::Parent);
 
     syntax::IndirectReferenceObjectPtr parent_ref = make_deferred<syntax::IndirectReferenceObject>(parent->GetObject());
     _obj->Insert(constant::Name::Parent, parent_ref);

--- a/src/vanillapdf/semantics/objects/page_object.cpp
+++ b/src/vanillapdf/semantics/objects/page_object.cpp
@@ -39,10 +39,7 @@ bool PageObject::GetResources(OutputResourceDictionaryPtr& result) const {
 }
 
 void PageObject::SetResources(ResourceDictionaryPtr resources) {
-    if (_obj->Contains(Name::Resources)) {
-        bool removed = _obj->Remove(Name::Resources);
-        assert(removed && "Unable to remove existing item"); UNUSED(removed);
-    }
+    _obj->Remove(Name::Resources);
 
     _obj->Insert(Name::Resources, resources->GetObject());
 }
@@ -59,10 +56,7 @@ bool PageObject::GetMediaBox(OutputRectanglePtr& result) const {
 }
 
 void PageObject::SetMediaBox(RectanglePtr media_box) {
-    if (_obj->Contains(Name::MediaBox)) {
-        bool removed = _obj->Remove(Name::MediaBox);
-        assert(removed && "Unable to remove existing item"); UNUSED(removed);
-    }
+    _obj->Remove(Name::MediaBox);
 
     _obj->Insert(Name::MediaBox, media_box->GetObject());
 }
@@ -79,20 +73,14 @@ bool PageObject::GetAnnotations(OutputPageAnnotationsPtr& result) const {
 }
 
 void PageObject::SetAnnotations(PageAnnotationsPtr annots) {
-    if (_obj->Contains(Name::Annots)) {
-        bool removed = _obj->Remove(Name::Annots);
-        assert(removed && "Unable to remove existing item"); UNUSED(removed);
-    }
+    _obj->Remove(Name::Annots);
 
     _obj->Insert(Name::Annots, annots->GetObject());
 }
 
 
 void PageObject::SetContents(PageContentsPtr contents) {
-    if (_obj->Contains(Name::Contents)) {
-        bool removed = _obj->Remove(Name::Contents);
-        assert(removed && "Unable to remove existing item"); UNUSED(removed);
-    }
+    _obj->Remove(Name::Contents);
 
     IndirectReferenceObjectPtr contents_ref = make_deferred<IndirectReferenceObject>(contents->GetObject());
     _obj->Insert(Name::Contents, contents_ref);

--- a/src/vanillapdf/semantics/objects/rectangle.cpp
+++ b/src/vanillapdf/semantics/objects/rectangle.cpp
@@ -12,7 +12,6 @@ Rectangle::Rectangle() {
 }
 
 Rectangle::Rectangle(syntax::ArrayObjectPtr<syntax::RealObjectPtr> list) : HighLevelObject(list) {
-    assert(list->GetSize() == 4 && "Only fully specified rectangles are yet supported");
     if (list->GetSize() != 4) {
         LOG_ERROR_AND_THROW(InvalidParameterException, "Invalid rectangle size: {}", list->GetSize());
     }

--- a/src/vanillapdf/semantics/objects/tree.h
+++ b/src/vanillapdf/semantics/objects/tree.h
@@ -570,7 +570,6 @@ ValueT TreeBase<KeyT, ValueT>::FindInternal(const TreeNodeBasePtr node, const Ke
     if (node_type == TreeNodeBase::TreeNodeType::Leaf) {
         auto leaf = ConvertUtils<TreeNodeBasePtr>::ConvertTo<TreeNodeLeafPtr>(node);
         auto limits = leaf->Limits();
-        assert(limits->GetSize() == 2);
         if (limits->GetSize() != 2) {
             LOG_ERROR_AND_THROW(syntax::ObjectMissingException, "Tree node limits shall contain two values, but contain {}", limits->GetSize());
         }

--- a/src/vanillapdf/semantics/objects/viewer_preferences.cpp
+++ b/src/vanillapdf/semantics/objects/viewer_preferences.cpp
@@ -15,7 +15,6 @@ PageRange::SubRange::SubRange(syntax::IntegerObjectPtr first, syntax::IntegerObj
 }
 
 PageRange::PageRange(syntax::ArrayObjectPtr<syntax::IntegerObjectPtr> obj) : HighLevelObject(obj) {
-    assert(obj->GetSize() % 2 == 0);
     if (obj->GetSize() % 2 != 0) {
         throw SemanticContextExceptionFactory::Construct<syntax::ArrayObject<syntax::IntegerObjectPtr>, PageRange>(obj);
     }

--- a/src/vanillapdf/semantics/utils/byte_range.cpp
+++ b/src/vanillapdf/semantics/utils/byte_range.cpp
@@ -12,7 +12,6 @@ ByteRangeCollection::ByteRangeCollection() {
 }
 
 ByteRangeCollection::ByteRangeCollection(syntax::ArrayObjectPtr<syntax::IntegerObjectPtr> obj) : HighLevelObject(obj) {
-    assert(obj->GetSize() % 2 == 0);
     if (obj->GetSize() % 2 != 0) {
         throw SemanticContextExceptionFactory::Construct<syntax::ArrayObject<syntax::IntegerObjectPtr>, ByteRangeCollection>(obj);
     }

--- a/src/vanillapdf/syntax/files/file_writer.cpp
+++ b/src/vanillapdf/syntax/files/file_writer.cpp
@@ -221,7 +221,6 @@ void FileWriter::RecalculateObjectStreamContent(XrefChainPtr chain, XrefBasePtr 
         // 7.5.7 Object Streams: "The generation number of an object stream and of any compressed object shall be zero."
         bool object_stream_found = chain->Contains(object_stream_number, 0);
 
-        assert(object_stream_found && "Object stream was not found");
         if (!object_stream_found) {
             LOG_ERROR_AND_THROW(ParseException, "Object stream was not found");
         }
@@ -229,7 +228,6 @@ void FileWriter::RecalculateObjectStreamContent(XrefChainPtr chain, XrefBasePtr 
         auto object_stream_entry = chain->GetXrefEntry(object_stream_number, 0);
         bool object_stream_entry_used = ConvertUtils<XrefEntryBasePtr>::IsType<XrefUsedEntryPtr>(object_stream_entry);
 
-        assert(object_stream_entry_used && "Object stream is not in use");
         if (!object_stream_entry_used) {
             LOG_ERROR_AND_THROW(ParseException, "Object stream is not in use");
         }
@@ -241,7 +239,6 @@ void FileWriter::RecalculateObjectStreamContent(XrefChainPtr chain, XrefBasePtr 
         // Let me know, if you find a document with this condition
         bool is_stream = ObjectUtils::IsType<StreamObjectPtr>(object_stream_object);
 
-        assert(is_stream && "Object stream has incorrect type");
         if (!is_stream) {
             LOG_ERROR_AND_THROW(ParseException, "Object stream shall be a Stream, but is {}", Object::TypeName(object_stream_object->GetObjectType()));
         }
@@ -735,7 +732,6 @@ void FileWriter::RecalculateStreamsLength(XrefBasePtr source) {
             auto new_obj = compressed_entry->GetReference();
 
             // 7.5.7 The following objects shall not be stored in an object stream: Stream objects
-            assert(!ObjectUtils::IsType<StreamObjectPtr>(new_obj));
 
             if (ObjectUtils::IsType<StreamObjectPtr>(new_obj)) {
                 LOG_ERROR_AND_THROW(ParseException, "Stream object should not be inside object stream");

--- a/src/vanillapdf/syntax/files/xref.cpp
+++ b/src/vanillapdf/syntax/files/xref.cpp
@@ -28,7 +28,6 @@ void XrefStream::RecalculateContent() {
 
     auto fields = header->FindAs<ArrayObjectPtr<IntegerObjectPtr>>(constant::Name::W);
 
-    assert(fields->GetSize() == 3);
     if (fields->GetSize() != 3) {
         LOG_ERROR_AND_THROW(ObjectMissingException, "Xref stream /W shall contain three integers, but contains {}", fields->GetSize());
     }

--- a/src/vanillapdf/syntax/objects/indirect_reference_object.cpp
+++ b/src/vanillapdf/syntax/objects/indirect_reference_object.cpp
@@ -132,7 +132,6 @@ void IndirectReferenceObject::SetReferencedObject(ObjectPtr obj) {
 
     // Reference shall be indirect object or null
     bool indirect_or_null = (obj->IsIndirect() || ObjectUtils::IsType<NullObjectPtr>(obj));
-    assert(indirect_or_null && "Referenced object is neither indirect nor null");
 
     if (!indirect_or_null) {
         LOG_ERROR_AND_THROW(InvalidParameterException, "Indirect reference must point to indirect object");

--- a/src/vanillapdf/syntax/parsers/parser.cpp
+++ b/src/vanillapdf/syntax/parsers/parser.cpp
@@ -559,7 +559,6 @@ XrefStreamPtr Parser::ParseXrefStream(
 
     auto fields = header->FindAs<ArrayObjectPtr<IntegerObjectPtr>>(constant::Name::W);
 
-    assert(fields->GetSize() == 3);
     if (fields->GetSize() != 3) {
         LOG_ERROR_AND_THROW(ParseException, "Xref stream /W shall contain three integers, but contains {}", fields->GetSize());
     }
@@ -778,7 +777,6 @@ XrefStreamPtr Parser::ParseXrefStream(
         auto entry = chain->GetXrefEntry(stream_obj_number, stream_gen_number);
 
         if (!ConvertUtils<XrefEntryBasePtr>::IsType<XrefUsedEntryPtr>(entry)) {
-            assert(false && "How could this be entry of different type");
             LOG_ERROR_AND_THROW(ParseException, "Xref entry {} {} shall be a used entry, but has usage {}",
             stream_obj_number, stream_gen_number, static_cast<int>(entry->GetUsage()));
         }

--- a/src/vanillapdf/syntax/parsers/parser_utils.cpp
+++ b/src/vanillapdf/syntax/parsers/parser_utils.cpp
@@ -18,7 +18,6 @@ BooleanObjectPtr ParserUtils::CreateBoolean(TokenPtr token) {
         return make_deferred<BooleanObject>(false);
     }
 
-    assert(!"Expected boolean token type");
     LOG_ERROR_AND_THROW(ParseException, "Expected boolean token type");
 }
 

--- a/src/vanillapdf/syntax/utils/encryption.cpp
+++ b/src/vanillapdf/syntax/utils/encryption.cpp
@@ -417,7 +417,6 @@ BufferPtr EncryptionUtils::AESDecrypt(const Buffer& key, types::size_type key_le
 
 #if defined(VANILLAPDF_HAVE_OPENSSL)
 
-    assert(data.size() >= static_cast<size_t>(AES_CBC_IV_LENGTH));
     if (data.size() < static_cast<size_t>(AES_CBC_IV_LENGTH)) {
         LOG_ERROR_AND_THROW(CryptoErrorException, "Cannot find IV for encrypted data");
     }

--- a/src/vanillapdf/utils/streams/input_stream.cpp
+++ b/src/vanillapdf/utils/streams/input_stream.cpp
@@ -104,13 +104,11 @@ BufferPtr InputStream::Readline(void) {
     BufferPtr result;
 
     bool stream_failed = m_stream->fail();
-    assert(!stream_failed && "Stream is in failed state");
     if (stream_failed) {
         LOG_ERROR_AND_THROW(IOErrorException, "Stream is in failed state");
     }
 
     bool stream_eof = m_stream->eof();
-    assert(!stream_eof && "Stream reached eof");
     if (stream_eof) {
         LOG_ERROR_AND_THROW(IOErrorException, "Stream reached eof");
     }

--- a/src/vanillapdf/utils/streams/memory_buffer_input_stream.cpp
+++ b/src/vanillapdf/utils/streams/memory_buffer_input_stream.cpp
@@ -120,7 +120,6 @@ BufferPtr MemoryBufferInputStream::Readline(void) {
 
     auto buffer_size = static_cast<types::stream_size>(m_buffer->size());
 
-    assert(m_position < buffer_size && "Stream reached eof");
     if (m_position >= buffer_size) {
         LOG_ERROR_AND_THROW_GENERAL("Stream reached eof");
     }


### PR DESCRIPTION
## Summary

Two mechanical passes over the assertions, both addressing the same problem: an assertion on file-derived data aborts a debug build on input a caller legitimately handed us, and is compiled out of a release build exactly where it was load bearing.

Assertions go from 337 to 242.

## Evidence

Parsing the content stream `1 2 3 Tf` used to abort:

```
Assertion failed: operands.size() == 2, content_stream_operations.cpp, line 101
exit code 3
```

The operands come straight from `ContentStreamParser::ReadOperator`, and `fuzz_content_stream` feeds arbitrary bytes down that path. The `ParseException` on the following line never ran. After this change the same input reports an error in both Debug and Release, exit code 0.

## Collapse the Contains/Remove/assert pattern, 44 sites

Every one was

```cpp
if (obj->Contains(key)) {
    bool removed = obj->Remove(key);
    assert(removed && "Unable to remove existing item"); UNUSED(removed);
}
```

which is just `obj->Remove(key)`. `Remove` already returns false when the key is absent and only touches the dictionary when it is present, so the guard bought nothing. It also made the pair non-atomic, which turned the assertion into a latent TOCTOU under the concurrency the library documents.

## Remove 51 assertions that duplicate an adjacent throw

The throw already handles the condition and now logs it too, so the assertion only turned a handled parse error into a debug abort. `content_stream_operations.cpp` accounts for 26 of them.

## 20 assertions kept on purpose

The ones that can only fail if we have a bug, never because of the file, so the debugger break still earns its place:

| Site | Invariant |
| --- | --- |
| `file_writer.cpp` 346, 356, 404, 414 | xref cloning consistency |
| `xref.cpp` 200, 218, 365, 421 | our own width arithmetic, entries we construct, state we set |
| `object.cpp` 290 | null clone parameter |
| `document.cpp` 624 | clone invariant |
| `zlib_wrapper.cpp` 68, 150 | `Z_STREAM_ERROR` means we misused zlib, not that the data is bad |
| `numeric_object.cpp` ×7 | `m_type` is our own field |
| `destinations.cpp` 395 | we built the object |

## Something the tests turned up

The first draft of the regression test used `1 2 3 cm` and passed when it should have failed. Only eight operators get a dedicated operation class from the parser: `BT`, `ET`, `Tf`, `Tj`, `TJ`, `BI`, `ID`, `EI`. Everything else, `cm`, `q`, `Q`, `RG`, `rg` and `Td` included, becomes an `OperationGeneric`, which does not check its operands at all.

So `OperationTransformationMatrix` and the RGB colour space classes validate operands that parsing never sends them; only an API-constructed instance reaches that code. Removing their assertions is still right, since aborting on bad arguments across a C ABI is wrong either way, but whether that routing is intended is worth a look. The test covers the parser-reachable operators only, and says so.

## Test plan

- 7 new `MalformedContentStreamTest` cases, passing in Debug and Release with exit code 0. Before the change the `Tf` case aborted the runner.
- Full Release suite passes, 821/821 (`MPK_SLOVLEX.pdf` is disabled in the manifest).
- Both configurations build with no new warnings. Removing an assertion cannot orphan its variable, because the condition is re-tested by the `if` that follows.

## Relationship to #544

#544 has merged, so this now applies directly to `main` as a single commit. The two are related: the assertions removed here sat directly above the throws that #544 rewrote, which is why this was written on top of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
