### PR TITLE
fix: Stop counting gcov branch edges no test can take

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -5,6 +5,11 @@
 # - Sets pass/fail status checks for project and patch coverage
 # - Helps enforce or improve test coverage over time
 #
+# The reported numbers exclude gcov's throw and unreachable branch edges (see
+# the gcovr call in .github/workflows/coverage.yml), so they reflect branches a
+# test could actually take. Expect them to sit above the figure quoted below;
+# the targets are worth revisiting once the first report on that basis lands.
+#
 # Current coverage is around 58%, so the thresholds are tightened modestly:
 # - Holds overall project coverage near its current level (with a small buffer)
 # - Enforces testing of new code with only a small tolerance for gaps

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -79,8 +79,15 @@ jobs:
       - name: Test ${{ matrix.config.name }}
         run: ctest --preset linux-x64-gcc
 
+      # gcov emits a branch edge for every call that may unwind, and for
+      # compiler-generated code that cannot be reached. No test can ever take
+      # those edges, so a line is reported as a partially covered branch simply
+      # for calling something. That falls hardest on error handling: a
+      # validation branch that throws scores as half covered however it is
+      # tested. Both flags are gcovr's documented answer for C++.
+      # https://gcovr.com/en/stable/faq.html#why-does-c-code-have-so-many-uncovered-branches
       - name: Generate coverage report
-        run: gcovr -r . --xml-pretty -o coverage.xml
+        run: gcovr -r . --exclude-throw-branches --exclude-unreachable-branches --print-summary --xml-pretty -o coverage.xml
 
       - name: Upload to Codecov
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f  # v7.0.0


### PR DESCRIPTION
## Summary

gcov emits a branch edge for every call that may unwind, and for compiler-generated code that cannot be reached. Nothing a test does can take those edges, so a line is reported as a partially covered branch simply for calling something, and Codecov scores a partial as a miss.

The cost falls on error handling. A line that throws builds its message first, and that call may unwind, so the line carries edges no test will ever take. The code most worth testing is the code the metric punishes.

#546 is what surfaced it: eight changed lines, four hits and four partials, 50% patch coverage, while all three of its validation branches were exercised in both directions by ten existing reconstruction cases and seven new geometry cases. There was no missing test to write.

## Measured, not assumed

A minimal reproduction under `ubuntu:24.04` with the same apt `gcovr` the workflow installs, on a validating branch that throws:

| Line | Without the flags | With the flags |
| --- | --- | --- |
| `if (columns < 1)` | full, 100% (2/2) | full, 100% (2/2) |
| `throw ...` building its message | **partial, 50% (2/4)** | full, 100% (2/2) |

So the condition was never the problem and the throw line was. Applied to #546 this turns three of its four partials into hits, leaving only the hoisted `assert`, whose false branch is genuinely unreachable. That patch would have scored around 87% rather than 50%.

## What changed

`--exclude-throw-branches` and `--exclude-unreachable-branches` are gcovr's documented answer for C++.

`--print-summary` puts the totals in the job log, so the next question about a coverage number can be answered from the run instead of the Codecov API. Answering it this time required querying the API by hand.

## Thresholds

Left alone. The reported numbers will rise, since the excluded edges were counted as uncovered, and it is better to re-baseline from a real report than from a guess. `.codecov.yml` carries a note to that effect so the `around 58%` comment is not read as current.

## Considered and left out

Scoping flags, and a `.codecov.yml` ignore for the test, benchmark and fuzzer directories. The Codecov file list shows the report already covers only the library, so all of them would be inert. The fuzzer and benchmark targets are not even built by the coverage job, which configures with the `linux-x64-gcc` preset and never sets `VANILLAPDF_ENABLE_BENCHMARK` or `VANILLAPDF_ENABLE_FUZZING`.

## Test plan

Both files parse as YAML. The change is confined to the coverage job, so the first run on this PR is the check: the summary line appears in the job log, and patch coverage should be visibly higher than it would have been.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
