### PR TITLE
ci: Drop the Intel entry from the Homebrew integration job

### DIFF
--- a/.github/workflows/examples-integration.yml
+++ b/.github/workflows/examples-integration.yml
@@ -365,8 +365,19 @@ jobs:
         include:
           - runner: macos-26
             preset: macos-arm64-release
-          - runner: macos-26-intel
-            preset: macos-x64-release
+
+          # Intel is deliberately absent. Homebrew moved macOS x86_64 to tier 3
+          # in September 2026 - CI support stopped and no further bottles are
+          # built - and stops running on Intel altogether in September 2027.
+          # macOS 27 requires Apple Silicon, so homebrew-core will not bottle
+          # vanillapdf for Intel either, and this job would be validating a
+          # formula no Homebrew user can install.
+          # https://docs.brew.sh/Support-Tiers
+          # https://www.macrumors.com/2026/04/18/macos-27-compatibility-change/
+          #
+          # Only Homebrew coverage is dropped. Intel is still built and tested
+          # through vcpkg and CMake in sanity-check, nightly-check and
+          # build-nuget, none of which depend on bottles.
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary

`Homebrew - macOS macos-x64-release` has failed on every run of this workflow since 31 August, which is what is currently blocking #545.

The zlib caveat at the end of the log is a red herring — zlib poured fine (`🍺 /usr/local/Cellar/zlib/1.3.2`), its keg-only notice is just the last thing printed before the step exits. The failure is four lines earlier:

```
==> Upgrading openssl@3   3.6.3 -> 3.6.4
==> perl ./Configure … / make / make install / make test        ← 14 minutes
##[warning]The post-install step did not complete successfully
```

In the fetch summary `openssl@3` arrived as `✔︎ API Source` while zlib and openjpeg arrived as `✔︎ Bottle` — no Intel bottle existed, so Homebrew compiled OpenSSL from source and its post-install step then failed the run.

The two jobs in the same run isolate the cause. Same step, same formulae, only the runner differs:

| Runner | Result | Duration |
| --- | --- | --- |
| `macos-26` (arm64) | success | 158s — bottles poured |
| `macos-26-intel` | failure | 946s — 14 minutes compiling OpenSSL |

## Why the entry is removed rather than repaired

Homebrew moved macOS x86_64 to tier 3 in September 2026: CI support stopped and no further bottles are built. It stops running on Intel altogether in September 2027. macOS 27 requires Apple Silicon.

So homebrew-core will not bottle vanillapdf for Intel either. This job was validating a formula no Homebrew user can install, and paying a from-source build of every dependency to do it. Repairing the install step would only delay the next failure, since every formula now compiles from source on that platform.

## Why vcpkg cannot substitute here

The formula declares its own dependencies:

```ruby
depends_on "cmake" => :build
depends_on "fmt"
depends_on "jpeg-turbo"
depends_on "openjpeg"
depends_on "openssl@3"
depends_on "spdlog"
```

`brew install --build-from-source --HEAD vanillapdf/test/vanillapdf` resolves those through Homebrew whatever the workflow installed beforehand, so the explicit install step is only pre-warming and removing it changes nothing. Substituting vcpkg would mean no longer testing the formula, which is the entire purpose of the job.

## What is not affected

Only Homebrew coverage is dropped. Intel is still built and tested with vcpkg and CMake, none of which depend on bottles:

| Workflow | Intel job | Status |
| --- | --- | --- |
| `sanity-check.yml` | `osx.26-x64` Debug and Release | green, 561s and 371s |
| `nightly-check.yml` | `osx.15-x64`, `osx.26-x64` | in matrix |
| `build-nuget.yml` | `macos-15-intel` | in matrix |

The README's `macOS | x64, ARM64` claim therefore still holds — Intel users building from source or consuming the NuGet package are unaffected.

## Worth knowing for later

GitHub's own announcement names `macos-15-intel` as the last x86_64 image, available until **August 2027**, after which x86_64 is unsupported on Actions entirely. That is the hard deadline for the remaining Intel jobs. The earlier warning sign will be the `brew install --quiet autoconf automake autoconf-archive` steps in sanity-check and nightly-check starting to compile from source as Intel bottles age out.

Note that the announcement does not mention `macos-26-intel`, which those workflows use and which still runs today, so its lifetime should not be assumed to match.

## Test plan

The workflow parses as YAML and the `homebrew-macos` matrix resolves to a single entry. The check is the run on this PR: the Intel job should no longer appear, and `Homebrew - macOS macos-arm64-release` should stay green.

Sources: <https://docs.brew.sh/Support-Tiers>, <https://www.macrumors.com/2026/04/18/macos-27-compatibility-change/>, <https://github.com/actions/runner-images/issues/13045>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
